### PR TITLE
Refactor wishlist to use per-volume tracking in collection

### DIFF
--- a/back/migrations/Version20260414000001.php
+++ b/back/migrations/Version20260414000001.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260414000001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_wishlisted column to volume_entries for per-volume wishlist tracking';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE volume_entries ADD COLUMN is_wishlisted BOOLEAN NOT NULL DEFAULT FALSE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE volume_entries DROP COLUMN is_wishlisted');
+    }
+}

--- a/back/src/Collection/Application/ToggleVolume/ToggleVolumeHandler.php
+++ b/back/src/Collection/Application/ToggleVolume/ToggleVolumeHandler.php
@@ -34,8 +34,14 @@ final readonly class ToggleVolumeHandler
 
         if ($command->field === 'isOwned') {
             $volumeEntry->isOwned = !$volumeEntry->isOwned;
+            // When marking as owned, clear wishlist flag
+            if ($volumeEntry->isOwned) {
+                $volumeEntry->isWishlisted = false;
+            }
         } elseif ($command->field === 'isRead') {
             $volumeEntry->isRead = !$volumeEntry->isRead;
+        } elseif ($command->field === 'isWishlisted') {
+            $volumeEntry->isWishlisted = !$volumeEntry->isWishlisted;
         }
 
         $this->repository->save($entry);

--- a/back/src/Collection/Application/WishlistRemaining/WishlistRemainingCommand.php
+++ b/back/src/Collection/Application/WishlistRemaining/WishlistRemainingCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Collection\Application\WishlistRemaining;
+
+final readonly class WishlistRemainingCommand
+{
+    public function __construct(public string $collectionEntryId)
+    {
+    }
+}

--- a/back/src/Collection/Application/WishlistRemaining/WishlistRemainingHandler.php
+++ b/back/src/Collection/Application/WishlistRemaining/WishlistRemainingHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Collection\Application\WishlistRemaining;
+
+use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Collection\Domain\VolumeEntry;
+use App\Shared\Domain\Exception\NotFoundException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'command.bus')]
+final readonly class WishlistRemainingHandler
+{
+    public function __construct(private CollectionRepositoryInterface $repository)
+    {
+    }
+
+    public function __invoke(WishlistRemainingCommand $command): void
+    {
+        $entry = $this->repository->findById($command->collectionEntryId);
+
+        if ($entry === null) {
+            throw new NotFoundException('CollectionEntry', $command->collectionEntryId);
+        }
+
+        foreach ($entry->volumeEntries as $ve) {
+            /** @var VolumeEntry $ve */
+            if (!$ve->isOwned) {
+                $ve->isWishlisted = true;
+            }
+        }
+
+        $this->repository->save($entry);
+    }
+}

--- a/back/src/Collection/Domain/CollectionEntry.php
+++ b/back/src/Collection/Domain/CollectionEntry.php
@@ -48,6 +48,7 @@ class CollectionEntry
             'rating' => $this->rating,
             'ownedCount' => $this->volumeEntries->filter(fn (VolumeEntry $ve) => $ve->isOwned)->count(),
             'readCount' => $this->volumeEntries->filter(fn (VolumeEntry $ve) => $ve->isRead)->count(),
+            'wishlistCount' => $this->volumeEntries->filter(fn (VolumeEntry $ve) => $ve->isWishlisted && !$ve->isOwned)->count(),
             'totalVolumes' => $this->manga->volumes->count(),
             'addedAt' => $this->addedAt->format(\DateTimeInterface::ATOM),
         ];

--- a/back/src/Collection/Domain/CollectionRepositoryInterface.php
+++ b/back/src/Collection/Domain/CollectionRepositoryInterface.php
@@ -13,6 +13,9 @@ interface CollectionRepositoryInterface
     /** @return CollectionEntry[] */
     public function findAll(): array;
 
+    /** @return CollectionEntry[] entries that have at least one wishlisted (non-owned) volume */
+    public function findWithWishlistVolumes(): array;
+
     public function save(CollectionEntry $entry): void;
 
     public function delete(CollectionEntry $entry): void;

--- a/back/src/Collection/Domain/VolumeEntry.php
+++ b/back/src/Collection/Domain/VolumeEntry.php
@@ -26,6 +26,8 @@ class VolumeEntry
         public bool $isOwned = false,
         #[ORM\Column]
         public bool $isRead = false,
+        #[ORM\Column]
+        public bool $isWishlisted = false,
         #[ORM\Column(type: 'text', nullable: true)]
         public ?string $review = null,
         #[ORM\Column(nullable: true)]
@@ -43,6 +45,7 @@ class VolumeEntry
             'priceCode' => $this->volume->priceCode?->toArray(),
             'isOwned' => $this->isOwned,
             'isRead' => $this->isRead,
+            'isWishlisted' => $this->isWishlisted,
             'review' => $this->review,
             'rating' => $this->rating,
         ];

--- a/back/src/Collection/Infrastructure/Doctrine/DoctrineCollectionRepository.php
+++ b/back/src/Collection/Infrastructure/Doctrine/DoctrineCollectionRepository.php
@@ -6,6 +6,7 @@ namespace App\Collection\Infrastructure\Doctrine;
 
 use App\Collection\Domain\CollectionEntry;
 use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Collection\Domain\VolumeEntry;
 use Doctrine\ORM\EntityManagerInterface;
 
 final readonly class DoctrineCollectionRepository implements CollectionRepositoryInterface
@@ -29,6 +30,21 @@ final readonly class DoctrineCollectionRepository implements CollectionRepositor
     {
         return $this->em->getRepository(CollectionEntry::class)
             ->findBy([], ['addedAt' => 'DESC']);
+    }
+
+    public function findWithWishlistVolumes(): array
+    {
+        return $this->em->createQueryBuilder()
+            ->select('DISTINCT ce')
+            ->from(CollectionEntry::class, 'ce')
+            ->join('ce.volumeEntries', 've')
+            ->where('ve.isWishlisted = :wishlisted')
+            ->andWhere('ve.isOwned = :owned')
+            ->setParameter('wishlisted', true)
+            ->setParameter('owned', false)
+            ->orderBy('ce.addedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
     }
 
     public function save(CollectionEntry $entry): void

--- a/back/src/Collection/Infrastructure/Http/CollectionController.php
+++ b/back/src/Collection/Infrastructure/Http/CollectionController.php
@@ -10,6 +10,7 @@ use App\Collection\Application\GetDetail\GetCollectionDetailQuery;
 use App\Collection\Application\Remove\RemoveFromCollectionCommand;
 use App\Collection\Application\ToggleVolume\ToggleVolumeCommand;
 use App\Collection\Application\UpdateStatus\UpdateReadingStatusCommand;
+use App\Collection\Application\WishlistRemaining\WishlistRemainingCommand;
 use App\Shared\Application\Bus\CommandBusInterface;
 use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -69,6 +70,14 @@ final readonly class CollectionController
         #[MapRequestPayload] ToggleVolumeRequest $request,
     ): JsonResponse {
         $this->commandBus->dispatch(new ToggleVolumeCommand($id, $volumeEntryId, $request->field));
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/{id}/wishlist-remaining', methods: ['POST'])]
+    public function wishlistRemaining(string $id): JsonResponse
+    {
+        $this->commandBus->dispatch(new WishlistRemainingCommand($id));
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/back/src/Stats/Application/GetStats/GetStatsHandler.php
+++ b/back/src/Stats/Application/GetStats/GetStatsHandler.php
@@ -6,9 +6,6 @@ namespace App\Stats\Application\GetStats;
 
 use App\Collection\Domain\CollectionEntry;
 use App\Collection\Domain\VolumeEntry;
-use App\Manga\Domain\Manga;
-use App\Manga\Domain\Volume;
-use App\Wishlist\Domain\WishlistItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -41,10 +38,12 @@ final readonly class GetStatsHandler
             ->getQuery()
             ->getSingleScalarResult();
 
+        // Count wishlisted volumes that are not yet owned
         $totalWishlist = (int) $this->em->createQueryBuilder()
-            ->select('COUNT(w.id)')
-            ->from(WishlistItem::class, 'w')
-            ->where('w.isPurchased = false')
+            ->select('COUNT(ve.id)')
+            ->from(VolumeEntry::class, 've')
+            ->where('ve.isWishlisted = true')
+            ->andWhere('ve.isOwned = false')
             ->getQuery()
             ->getSingleScalarResult();
 

--- a/back/src/Wishlist/Application/Add/AddWishlistItemHandler.php
+++ b/back/src/Wishlist/Application/Add/AddWishlistItemHandler.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Wishlist\Application\Add;
 
+use App\Collection\Domain\CollectionEntry;
+use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Collection\Domain\VolumeEntry;
 use App\Manga\Domain\MangaRepositoryInterface;
 use App\Shared\Domain\Exception\NotFoundException;
-use App\Wishlist\Domain\WishlistItem;
-use App\Wishlist\Domain\WishlistRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Uid\Uuid;
 
@@ -15,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 final readonly class AddWishlistItemHandler
 {
     public function __construct(
-        private WishlistRepositoryInterface $repository,
+        private CollectionRepositoryInterface $collectionRepository,
         private MangaRepositoryInterface $mangaRepository,
     ) {
     }
@@ -28,9 +29,34 @@ final readonly class AddWishlistItemHandler
             throw new NotFoundException('Manga', $command->mangaId);
         }
 
-        $item = new WishlistItem(id: Uuid::v4()->toRfc4122(), manga: $manga);
-        $this->repository->save($item);
+        // Find or create a CollectionEntry for this manga
+        $entry = $this->collectionRepository->findByMangaId($command->mangaId);
 
-        return $item->id;
+        if ($entry === null) {
+            $entry = new CollectionEntry(
+                id: Uuid::v4()->toRfc4122(),
+                manga: $manga,
+            );
+
+            foreach ($manga->volumes as $volume) {
+                $entry->volumeEntries->add(new VolumeEntry(
+                    id: Uuid::v4()->toRfc4122(),
+                    collectionEntry: $entry,
+                    volume: $volume,
+                ));
+            }
+        }
+
+        // Mark all unowned volumes as wishlisted
+        foreach ($entry->volumeEntries as $ve) {
+            /** @var VolumeEntry $ve */
+            if (!$ve->isOwned) {
+                $ve->isWishlisted = true;
+            }
+        }
+
+        $this->collectionRepository->save($entry);
+
+        return $entry->id;
     }
 }

--- a/back/src/Wishlist/Application/Get/GetWishlistHandler.php
+++ b/back/src/Wishlist/Application/Get/GetWishlistHandler.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace App\Wishlist\Application\Get;
 
-use App\Wishlist\Domain\WishlistRepositoryInterface;
+use App\Collection\Domain\CollectionRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'query.bus')]
 final readonly class GetWishlistHandler
 {
-    public function __construct(private WishlistRepositoryInterface $repository)
+    public function __construct(private CollectionRepositoryInterface $collectionRepository)
     {
     }
 
     public function __invoke(GetWishlistQuery $query): array
     {
         return array_map(
-            static fn ($item) => $item->toArray(),
-            $this->repository->findAll(),
+            static fn ($entry) => $entry->toArray(),
+            $this->collectionRepository->findWithWishlistVolumes(),
         );
     }
 }

--- a/back/src/Wishlist/Application/Purchase/PurchaseWishlistItemHandler.php
+++ b/back/src/Wishlist/Application/Purchase/PurchaseWishlistItemHandler.php
@@ -4,32 +4,34 @@ declare(strict_types=1);
 
 namespace App\Wishlist\Application\Purchase;
 
-use App\Collection\Application\Add\AddToCollectionCommand;
-use App\Shared\Application\Bus\CommandBusInterface;
+use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Collection\Domain\VolumeEntry;
 use App\Shared\Domain\Exception\NotFoundException;
-use App\Wishlist\Domain\WishlistRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class PurchaseWishlistItemHandler
 {
-    public function __construct(
-        private WishlistRepositoryInterface $repository,
-        private CommandBusInterface $commandBus,
-    ) {
+    public function __construct(private CollectionRepositoryInterface $collectionRepository)
+    {
     }
 
     public function __invoke(PurchaseWishlistItemCommand $command): void
     {
-        $item = $this->repository->findById($command->id);
+        $entry = $this->collectionRepository->findById($command->id);
 
-        if ($item === null) {
-            throw new NotFoundException('WishlistItem', $command->id);
+        if ($entry === null) {
+            throw new NotFoundException('CollectionEntry', $command->id);
         }
 
-        $item->isPurchased = true;
-        $this->repository->save($item);
+        foreach ($entry->volumeEntries as $ve) {
+            /** @var VolumeEntry $ve */
+            if ($ve->isWishlisted && !$ve->isOwned) {
+                $ve->isOwned = true;
+                $ve->isWishlisted = false;
+            }
+        }
 
-        $this->commandBus->dispatch(new AddToCollectionCommand($item->manga->id));
+        $this->collectionRepository->save($entry);
     }
 }

--- a/back/src/Wishlist/Application/Remove/RemoveWishlistItemHandler.php
+++ b/back/src/Wishlist/Application/Remove/RemoveWishlistItemHandler.php
@@ -4,25 +4,38 @@ declare(strict_types=1);
 
 namespace App\Wishlist\Application\Remove;
 
+use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Collection\Domain\VolumeEntry;
 use App\Shared\Domain\Exception\NotFoundException;
-use App\Wishlist\Domain\WishlistRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class RemoveWishlistItemHandler
 {
-    public function __construct(private WishlistRepositoryInterface $repository)
+    public function __construct(private CollectionRepositoryInterface $collectionRepository)
     {
     }
 
     public function __invoke(RemoveWishlistItemCommand $command): void
     {
-        $item = $this->repository->findById($command->id);
+        $entry = $this->collectionRepository->findById($command->id);
 
-        if ($item === null) {
-            throw new NotFoundException('WishlistItem', $command->id);
+        if ($entry === null) {
+            throw new NotFoundException('CollectionEntry', $command->id);
         }
 
-        $this->repository->delete($item);
+        $ownedCount = $entry->volumeEntries->filter(fn (VolumeEntry $ve) => $ve->isOwned)->count();
+
+        if ($ownedCount === 0) {
+            // No owned volumes — remove the entire entry from the system
+            $this->collectionRepository->delete($entry);
+        } else {
+            // Keep the collection entry but clear all wishlist flags
+            foreach ($entry->volumeEntries as $ve) {
+                /** @var VolumeEntry $ve */
+                $ve->isWishlisted = false;
+            }
+            $this->collectionRepository->save($entry);
+        }
     }
 }

--- a/front/src/api/collection.ts
+++ b/front/src/api/collection.ts
@@ -27,7 +27,11 @@ export async function updateReadingStatus(id: string, status: ReadingStatus): Pr
 export async function toggleVolume(
   collectionId: string,
   volumeEntryId: string,
-  field: 'isOwned' | 'isRead',
+  field: 'isOwned' | 'isRead' | 'isWishlisted',
 ): Promise<void> {
   await client.patch(`/collection/${collectionId}/volumes/${volumeEntryId}/toggle`, { field })
+}
+
+export async function wishlistRemaining(collectionId: string): Promise<void> {
+  await client.post(`/collection/${collectionId}/wishlist-remaining`)
 }

--- a/front/src/api/wishlist.ts
+++ b/front/src/api/wishlist.ts
@@ -1,7 +1,8 @@
 import client from './client'
-import type { WishlistItem } from '@/types'
+import type { CollectionEntry } from '@/types'
 
-export async function getWishlist(): Promise<WishlistItem[]> {
+// GET /api/wishlist now returns CollectionEntry[] (entries with at least one wishlisted volume)
+export async function getWishlist(): Promise<CollectionEntry[]> {
   const res = await client.get('/wishlist')
   return res.data
 }
@@ -11,10 +12,12 @@ export async function addToWishlist(mangaId: string): Promise<{ id: string }> {
   return res.data
 }
 
+// id is now a CollectionEntry.id
 export async function removeFromWishlist(id: string): Promise<void> {
   await client.delete(`/wishlist/${id}`)
 }
 
+// id is now a CollectionEntry.id — marks all wishlisted volumes as owned
 export async function purchaseWishlistItem(id: string): Promise<void> {
   await client.post(`/wishlist/${id}/purchase`)
 }

--- a/front/src/components/organisms/MangaCard.vue
+++ b/front/src/components/organisms/MangaCard.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import type { CollectionEntry } from '@/types'
 
-const props = defineProps<{ entry: CollectionEntry }>()
+const props = defineProps<{
+  entry: CollectionEntry
+  mode?: 'collection' | 'wishlist'
+}>()
+
 const router = useRouter()
 
 const ownedRatio = computed(() =>
@@ -11,7 +16,24 @@ const ownedRatio = computed(() =>
     : 0,
 )
 
-import { computed } from 'vue'
+const wishlistRatio = computed(() =>
+  props.entry.totalVolumes > 0
+    ? Math.round((props.entry.wishlistCount / props.entry.totalVolumes) * 100)
+    : 0,
+)
+
+// Volume mini-dots: compact visual (max 25 shown)
+const volumeDots = computed(() => {
+  const total = props.entry.totalVolumes
+  if (total === 0) return []
+  const shown = Math.min(total, 25)
+  // We only have ownedCount + wishlistCount from summary; fill dots left to right
+  return Array.from({ length: shown }, (_, i) => {
+    if (i < props.entry.ownedCount) return 'owned'
+    if (i < props.entry.ownedCount + props.entry.wishlistCount) return 'wishlist'
+    return 'none'
+  })
+})
 
 function open() {
   router.push({ name: 'collection-detail', params: { id: props.entry.id } })
@@ -20,34 +42,110 @@ function open() {
 
 <template>
   <div
-    class="manga-card card bg-base-100 shadow cursor-pointer"
+    class="manga-card group relative cursor-pointer select-none"
     @click="open"
   >
-    <!-- Cover -->
-    <figure class="aspect-[2/3] overflow-hidden bg-base-200">
-      <img
-        v-if="entry.manga.coverUrl"
-        :src="entry.manga.coverUrl"
-        :alt="entry.manga.title"
-        class="w-full h-full object-cover"
-      />
-      <div v-else class="w-full h-full flex items-center justify-center text-base-content/30 text-3xl">
-        📚
-      </div>
-    </figure>
+    <!-- Card container with glass morphism + hover lift -->
+    <div class="relative overflow-hidden rounded-2xl bg-base-100 shadow-md
+                transition-all duration-300 ease-out
+                hover:shadow-xl hover:-translate-y-1 hover:scale-[1.02]
+                border border-base-200 hover:border-primary/30">
 
-    <div class="card-body p-3 gap-1">
-      <p class="font-semibold text-sm line-clamp-2 leading-tight">{{ entry.manga.title }}</p>
-      <p class="text-xs text-base-content/60">{{ entry.manga.edition }}</p>
-      <p class="text-xs text-base-content/40 uppercase tracking-wide">{{ entry.manga.language }}</p>
-
-      <!-- Progress -->
-      <div class="mt-2 space-y-0.5">
-        <div class="flex justify-between text-xs text-base-content/60">
-          <span>{{ entry.ownedCount }}/{{ entry.totalVolumes }}</span>
-          <span>{{ ownedRatio }}%</span>
+      <!-- Cover image -->
+      <div class="relative aspect-[2/3] overflow-hidden bg-base-200">
+        <img
+          v-if="entry.manga.coverUrl"
+          :src="entry.manga.coverUrl"
+          :alt="entry.manga.title"
+          class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          loading="lazy"
+        />
+        <div
+          v-else
+          class="w-full h-full flex items-center justify-center text-4xl text-base-content/20"
+        >
+          📚
         </div>
-        <progress class="progress progress-primary w-full h-1" :value="entry.ownedCount" :max="entry.totalVolumes" />
+
+        <!-- Gradient overlay at bottom -->
+        <div class="absolute inset-x-0 bottom-0 h-2/3
+                    bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+
+        <!-- Wishlist badge -->
+        <div
+          v-if="mode === 'wishlist' || entry.wishlistCount > 0"
+          class="absolute top-2 right-2"
+        >
+          <div class="badge badge-warning badge-sm gap-1 shadow font-semibold">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+            </svg>
+            {{ entry.wishlistCount }}
+          </div>
+        </div>
+
+        <!-- Title overlay on cover -->
+        <div class="absolute inset-x-0 bottom-0 p-3">
+          <p class="font-bold text-sm leading-tight text-white line-clamp-2 drop-shadow">
+            {{ entry.manga.title }}
+          </p>
+          <p class="text-xs text-white/70 mt-0.5 truncate drop-shadow">{{ entry.manga.edition }}</p>
+        </div>
+      </div>
+
+      <!-- Card body -->
+      <div class="p-3 space-y-2">
+        <!-- Genre badge -->
+        <div class="flex items-center gap-1.5 flex-wrap">
+          <span v-if="entry.manga.genre" class="badge badge-outline badge-xs capitalize opacity-70">
+            {{ entry.manga.genre?.replace('_', ' ') }}
+          </span>
+          <span class="badge badge-outline badge-xs opacity-50 uppercase">
+            {{ entry.manga.language }}
+          </span>
+        </div>
+
+        <!-- Volume mini dots -->
+        <div v-if="entry.totalVolumes > 0" class="flex flex-wrap gap-0.5">
+          <div
+            v-for="(dot, i) in volumeDots"
+            :key="i"
+            class="w-2 h-2 rounded-full transition-colors"
+            :class="{
+              'bg-success': dot === 'owned',
+              'bg-warning': dot === 'wishlist',
+              'bg-base-300': dot === 'none',
+            }"
+          />
+          <span v-if="entry.totalVolumes > 25" class="text-xs text-base-content/30 self-center ml-0.5">
+            +{{ entry.totalVolumes - 25 }}
+          </span>
+        </div>
+
+        <!-- Progress bar + count -->
+        <div class="space-y-1">
+          <!-- Stacked bar: owned (green) + wishlist (orange) + missing (gray) -->
+          <div class="w-full h-1.5 rounded-full bg-base-300 overflow-hidden flex">
+            <div
+              class="bg-success h-full rounded-l-full transition-all duration-500"
+              :style="{ width: `${ownedRatio}%` }"
+            />
+            <div
+              class="bg-warning h-full transition-all duration-500"
+              :style="{ width: `${wishlistRatio}%` }"
+            />
+          </div>
+          <div class="flex justify-between text-xs text-base-content/50">
+            <span>
+              <span class="text-success font-semibold">{{ entry.ownedCount }}</span>
+              <span v-if="entry.wishlistCount > 0">
+                + <span class="text-warning font-semibold">{{ entry.wishlistCount }}</span>
+              </span>
+              <span class="opacity-60"> / {{ entry.totalVolumes }}</span>
+            </span>
+            <span>{{ ownedRatio }}%</span>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -12,7 +12,7 @@
     "title": "Dashboard",
     "ownedVolumes": "Owned Volumes",
     "readVolumes": "Read Volumes",
-    "wishlist": "Wishlist",
+    "wishlist": "Wishlisted Volumes",
     "collectionValue": "Total Value",
     "genreBreakdown": "Genre Breakdown",
     "recentAdditions": "Recent Additions"
@@ -25,15 +25,29 @@
     "removed": "Removed from collection",
     "empty": "Your collection is empty",
     "volumes": "Volumes",
-    "owned": "owned"
+    "owned": "owned",
+    "read": "read",
+    "missing": "missing",
+    "noVolumes": "No volumes registered for this manga.",
+    "oeuvres": "works",
+    "totalVolumes": "volumes total",
+    "wishlisted": "wishlisted"
   },
   "wishlist": {
     "title": "Wishlist",
     "addToWishlist": "Add to Wishlist",
     "added": "Added to wishlist",
-    "purchased": "Manga purchased and added to collection",
-    "purchase": "Purchased",
-    "empty": "Your wishlist is empty"
+    "purchased": "Volumes purchased and added to collection",
+    "purchase": "All Purchased",
+    "empty": "Your wishlist is empty",
+    "removeFromWishlist": "Remove from wishlist",
+    "removed": "Removed from wishlist",
+    "inWishlist": "in wishlist",
+    "toGet": "to buy",
+    "oeuvres": "series",
+    "volumesToBuy": "volumes to buy",
+    "addRemaining": "Wishlist remaining volumes",
+    "remainingAdded": "Missing volumes added to wishlist"
   },
   "add": {
     "title": "Add a Manga",

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -12,7 +12,7 @@
     "title": "Tableau de bord",
     "ownedVolumes": "Tomes possédés",
     "readVolumes": "Tomes lus",
-    "wishlist": "Souhaits",
+    "wishlist": "Tomes souhaités",
     "collectionValue": "Valeur totale",
     "genreBreakdown": "Répartition par genre",
     "recentAdditions": "Ajouts récents"
@@ -25,15 +25,29 @@
     "removed": "Retiré de la collection",
     "empty": "Votre collection est vide",
     "volumes": "Tomes",
-    "owned": "possédés"
+    "owned": "possédés",
+    "read": "lus",
+    "missing": "manquants",
+    "noVolumes": "Aucun tome enregistré pour ce manga.",
+    "oeuvres": "œuvres",
+    "totalVolumes": "tomes au total",
+    "wishlisted": "en liste de souhaits"
   },
   "wishlist": {
     "title": "Liste de souhaits",
-    "addToWishlist": "Ajouter à la liste de souhaits",
+    "addToWishlist": "Ajouter à la liste",
     "added": "Ajouté à la liste de souhaits",
-    "purchased": "Manga acheté et ajouté à la collection",
-    "purchase": "Acheté",
-    "empty": "Votre liste de souhaits est vide"
+    "purchased": "Tomes achetés et ajoutés à la collection",
+    "purchase": "Tous achetés",
+    "empty": "Votre liste de souhaits est vide",
+    "removeFromWishlist": "Retirer de la liste",
+    "removed": "Retiré de la liste de souhaits",
+    "inWishlist": "en liste de souhaits",
+    "toGet": "à acheter",
+    "oeuvres": "séries",
+    "volumesToBuy": "tomes à acheter",
+    "addRemaining": "Mettre les manquants en souhait",
+    "remainingAdded": "Tomes manquants ajoutés à la liste de souhaits"
   },
   "add": {
     "title": "Ajouter un manga",

--- a/front/src/pages/CollectionPage.vue
+++ b/front/src/pages/CollectionPage.vue
@@ -10,7 +10,7 @@ const { data: collection, isPending } = useQuery({ queryKey: ['collection'], que
 
 const search = ref('')
 const page = ref(1)
-const perPage = 12
+const perPage = 18
 
 const filtered = computed(() => {
   if (!collection.value) return []
@@ -27,42 +27,91 @@ const paginated = computed(() => {
 })
 
 const totalPages = computed(() => Math.ceil(filtered.value.length / perPage))
+const totalOwned = computed(() => collection.value?.reduce((s, e) => s + e.ownedCount, 0) ?? 0)
+const totalVolumes = computed(() => collection.value?.reduce((s, e) => s + e.totalVolumes, 0) ?? 0)
+const totalWishlist = computed(() => collection.value?.reduce((s, e) => s + e.wishlistCount, 0) ?? 0)
 </script>
 
 <template>
-  <div class="p-6 space-y-6">
-    <div class="flex items-center justify-between gap-4">
-      <h1 class="text-2xl font-bold">{{ t('collection.title') }}</h1>
-      <RouterLink to="/add" class="btn btn-primary btn-sm">
-        + {{ t('collection.add') }}
+  <div class="p-4 md:p-6 space-y-6 max-w-screen-2xl mx-auto">
+    <!-- Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight">{{ t('collection.title') }}</h1>
+        <p v-if="!isPending && collection?.length" class="text-sm text-base-content/50 mt-1">
+          {{ collection.length }} {{ t('collection.oeuvres') }} &bull;
+          <span class="text-success font-medium">{{ totalOwned }}</span> {{ t('collection.owned') }}
+          <template v-if="totalWishlist > 0">
+            &bull; <span class="text-warning font-medium">{{ totalWishlist }}</span> {{ t('collection.wishlisted') }}
+          </template>
+          <template v-if="totalVolumes > 0">
+            / {{ totalVolumes }} {{ t('collection.totalVolumes') }}
+          </template>
+        </p>
+      </div>
+      <RouterLink to="/add" class="btn btn-primary gap-2 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        {{ t('collection.add') }}
       </RouterLink>
     </div>
 
-    <input
-      v-model="search"
-      type="search"
-      :placeholder="t('common.search')"
-      class="input input-bordered w-full max-w-sm"
-      @input="page = 1"
-    />
+    <!-- Search bar -->
+    <label class="input input-bordered flex items-center gap-2 w-full max-w-sm">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 opacity-40 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <input
+        v-model="search"
+        type="search"
+        :placeholder="t('common.search')"
+        class="grow bg-transparent outline-none"
+        @input="page = 1"
+      />
+    </label>
 
-    <div v-if="isPending" class="flex justify-center py-16">
-      <span class="loading loading-spinner loading-lg" />
+    <!-- Loading -->
+    <div v-if="isPending" class="flex justify-center py-20">
+      <span class="loading loading-spinner loading-lg text-primary" />
     </div>
 
-    <div v-else-if="paginated.length === 0" class="text-center py-16 text-base-content/50">
-      {{ t('collection.empty') }}
+    <!-- Empty state -->
+    <div
+      v-else-if="paginated.length === 0"
+      class="flex flex-col items-center justify-center py-24 gap-4 text-base-content/40"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-16 h-16 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+      </svg>
+      <p class="text-lg font-medium">{{ t('collection.empty') }}</p>
+      <RouterLink to="/add" class="btn btn-primary btn-sm">
+        {{ t('collection.add') }}
+      </RouterLink>
     </div>
 
-    <div v-else class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+    <!-- Grid of cards -->
+    <div
+      v-else
+      class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4"
+    >
       <MangaCard
         v-for="entry in paginated"
         :key="entry.id"
         :entry="entry"
+        mode="collection"
       />
     </div>
 
-    <div v-if="totalPages > 1" class="flex justify-center gap-2">
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex justify-center gap-2 flex-wrap">
+      <button
+        class="btn btn-sm btn-ghost"
+        :disabled="page === 1"
+        @click="page--"
+      >
+        ←
+      </button>
       <button
         v-for="p in totalPages"
         :key="p"
@@ -71,6 +120,13 @@ const totalPages = computed(() => Math.ceil(filtered.value.length / perPage))
         @click="page = p"
       >
         {{ p }}
+      </button>
+      <button
+        class="btn btn-sm btn-ghost"
+        :disabled="page === totalPages"
+        @click="page++"
+      >
+        →
       </button>
     </div>
   </div>

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
-import { getCollectionEntry, removeFromCollection, updateReadingStatus, toggleVolume } from '@/api/collection'
+import { getCollectionEntry, removeFromCollection, updateReadingStatus, toggleVolume, wishlistRemaining } from '@/api/collection'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
 import type { ReadingStatus, VolumeEntry } from '@/types'
@@ -24,6 +24,10 @@ const sortedVolumes = computed<VolumeEntry[]>(() =>
   [...(entry.value?.volumes ?? [])].sort((a, b) => a.number - b.number),
 )
 
+const wishlistCount = computed(() =>
+  sortedVolumes.value.filter((ve) => ve.isWishlisted && !ve.isOwned).length,
+)
+
 const removeMutation = useMutation({
   mutationFn: () => removeFromCollection(id),
   onSuccess: () => {
@@ -39,13 +43,38 @@ const statusMutation = useMutation({
 })
 
 const toggleMutation = useMutation({
-  mutationFn: ({ veId, field }: { veId: string; field: 'isOwned' | 'isRead' }) =>
+  mutationFn: ({ veId, field }: { veId: string; field: 'isOwned' | 'isRead' | 'isWishlisted' }) =>
     toggleVolume(id, veId, field),
   onSuccess: () => {
     qc.invalidateQueries({ queryKey: ['collection', id] })
+    qc.invalidateQueries({ queryKey: ['collection'] })
+    qc.invalidateQueries({ queryKey: ['wishlist'] })
     qc.invalidateQueries({ queryKey: ['stats'] })
   },
 })
+
+const wishlistRemainingMutation = useMutation({
+  mutationFn: () => wishlistRemaining(id),
+  onSuccess: () => {
+    qc.invalidateQueries({ queryKey: ['collection', id] })
+    qc.invalidateQueries({ queryKey: ['collection'] })
+    qc.invalidateQueries({ queryKey: ['wishlist'] })
+    qc.invalidateQueries({ queryKey: ['stats'] })
+    ui.addToast(t('wishlist.remainingAdded'), 'success')
+  },
+})
+
+function volumeRingClass(ve: VolumeEntry) {
+  if (ve.isOwned) return 'ring-success/70 opacity-100'
+  if (ve.isWishlisted) return 'ring-warning/70 opacity-80'
+  return 'ring-base-300 opacity-30 grayscale'
+}
+
+function volumeBgClass(ve: VolumeEntry) {
+  if (ve.isOwned) return 'bg-base-200 text-base-content'
+  if (ve.isWishlisted) return 'bg-warning/20 text-warning'
+  return 'bg-base-300 text-base-content/30'
+}
 </script>
 
 <template>
@@ -58,14 +87,16 @@ const toggleMutation = useMutation({
       <!-- Header -->
       <div class="flex gap-5 mb-8">
         <div class="shrink-0">
-          <img
-            v-if="entry.manga.coverUrl"
-            :src="entry.manga.coverUrl"
-            :alt="entry.manga.title"
-            class="w-28 md:w-36 rounded-xl shadow-lg object-cover"
-          />
-          <div v-else class="w-28 md:w-36 aspect-[2/3] rounded-xl bg-base-300 flex items-center justify-center text-4xl">
-            📚
+          <div class="relative">
+            <img
+              v-if="entry.manga.coverUrl"
+              :src="entry.manga.coverUrl"
+              :alt="entry.manga.title"
+              class="w-28 md:w-36 rounded-2xl shadow-xl object-cover"
+            />
+            <div v-else class="w-28 md:w-36 aspect-[2/3] rounded-2xl bg-base-300 flex items-center justify-center text-4xl shadow-xl">
+              📚
+            </div>
           </div>
         </div>
 
@@ -75,7 +106,9 @@ const toggleMutation = useMutation({
           <div class="flex flex-wrap gap-1.5">
             <span class="badge badge-primary">{{ entry.manga.edition }}</span>
             <span class="badge badge-outline">{{ entry.manga.language.toUpperCase() }}</span>
-            <span v-if="entry.manga.genre" class="badge badge-outline capitalize">{{ entry.manga.genre }}</span>
+            <span v-if="entry.manga.genre" class="badge badge-outline capitalize">
+              {{ entry.manga.genre.replace('_', ' ') }}
+            </span>
           </div>
 
           <p v-if="entry.manga.author" class="text-sm text-base-content/70 font-medium">
@@ -87,14 +120,21 @@ const toggleMutation = useMutation({
           </p>
 
           <!-- Stats row -->
-          <div class="flex gap-4 text-sm pt-1">
-            <span class="flex items-center gap-1">
+          <div class="flex flex-wrap gap-4 text-sm pt-1">
+            <span class="flex items-center gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-success inline-block" />
               <span class="text-success font-bold">{{ entry.ownedCount }}</span>
-              <span class="text-base-content/50">/ {{ entry.totalVolumes }} possédés</span>
+              <span class="text-base-content/50">/ {{ entry.totalVolumes }} {{ t('collection.owned') }}</span>
             </span>
-            <span class="flex items-center gap-1">
+            <span v-if="wishlistCount > 0" class="flex items-center gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-warning inline-block" />
+              <span class="text-warning font-bold">{{ wishlistCount }}</span>
+              <span class="text-base-content/50">{{ t('wishlist.inWishlist') }}</span>
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="w-2.5 h-2.5 rounded-full bg-info inline-block" />
               <span class="text-info font-bold">{{ entry.readCount }}</span>
-              <span class="text-base-content/50">lus</span>
+              <span class="text-base-content/50">{{ t('collection.read') }}</span>
             </span>
           </div>
 
@@ -112,6 +152,20 @@ const toggleMutation = useMutation({
               <option value="dropped">{{ t('status.dropped') }}</option>
             </select>
 
+            <!-- Wishlist remaining button -->
+            <button
+              v-if="entry.ownedCount < entry.totalVolumes && wishlistCount < (entry.totalVolumes - entry.ownedCount)"
+              class="btn btn-warning btn-sm gap-1.5"
+              :class="{ loading: wishlistRemainingMutation.isPending.value }"
+              :disabled="wishlistRemainingMutation.isPending.value"
+              @click="wishlistRemainingMutation.mutate()"
+            >
+              <svg v-if="!wishlistRemainingMutation.isPending.value" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+              </svg>
+              {{ t('wishlist.addRemaining') }}
+            </button>
+
             <button
               class="btn btn-error btn-sm btn-outline"
               :class="{ loading: removeMutation.isPending.value }"
@@ -123,10 +177,10 @@ const toggleMutation = useMutation({
         </div>
       </div>
 
-      <!-- Volumes -->
+      <!-- Volumes section -->
       <div>
-        <h2 class="text-base font-semibold mb-3 text-base-content/70 uppercase tracking-wide text-xs">
-          {{ t('collection.volumes') }} — {{ entry.ownedCount }}/{{ entry.totalVolumes }} {{ t('collection.owned') }}
+        <h2 class="text-xs font-semibold mb-3 text-base-content/50 uppercase tracking-widest">
+          {{ t('collection.volumes') }} — {{ entry.ownedCount }}/{{ entry.totalVolumes }}
         </h2>
 
         <div v-if="sortedVolumes.length" class="grid grid-cols-6 sm:grid-cols-8 md:grid-cols-10 lg:grid-cols-12 gap-2">
@@ -134,15 +188,13 @@ const toggleMutation = useMutation({
             v-for="ve in sortedVolumes"
             :key="ve.id"
             class="group relative cursor-pointer select-none"
-            :title="`Tome ${ve.number}${ve.priceCode ? ` — ${ve.priceCode.value.toFixed(2)}€` : ''}`"
+            :title="`Tome ${ve.number}${ve.isWishlisted ? ' ⭐ wishlist' : ''}${ve.priceCode ? ` — ${ve.priceCode.value.toFixed(2)}€` : ''}`"
             @click="toggleMutation.mutate({ veId: ve.id, field: 'isOwned' })"
           >
             <!-- Cover -->
             <div
-              class="aspect-[2/3] rounded-lg overflow-hidden ring-2 transition-all duration-150"
-              :class="ve.isOwned
-                ? 'ring-success/60 opacity-100'
-                : 'ring-base-300 opacity-35 grayscale'"
+              class="aspect-[2/3] rounded-lg overflow-hidden ring-2 transition-all duration-200"
+              :class="volumeRingClass(ve)"
             >
               <img
                 v-if="ve.coverUrl"
@@ -153,16 +205,17 @@ const toggleMutation = useMutation({
               <div
                 v-else
                 class="w-full h-full flex items-center justify-center font-bold text-sm"
-                :class="ve.isOwned ? 'bg-base-200 text-base-content' : 'bg-base-300 text-base-content/30'"
+                :class="volumeBgClass(ve)"
               >
                 {{ ve.number }}
               </div>
             </div>
 
+            <!-- Status indicators (top-left corner) -->
             <!-- Read indicator -->
             <div
               v-if="ve.isRead"
-              class="absolute top-1 left-1 w-4 h-4 rounded-full bg-info flex items-center justify-center"
+              class="absolute top-1 left-1 w-4 h-4 rounded-full bg-info flex items-center justify-center shadow"
               @click.stop="toggleMutation.mutate({ veId: ve.id, field: 'isRead' })"
             >
               <svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-info-content" viewBox="0 0 20 20" fill="currentColor">
@@ -170,10 +223,10 @@ const toggleMutation = useMutation({
               </svg>
             </div>
 
-            <!-- Hover: toggle read button -->
+            <!-- Hover: toggle read (only if owned) -->
             <button
               v-if="ve.isOwned && !ve.isRead"
-              class="absolute top-1 left-1 w-4 h-4 rounded-full bg-base-300/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+              class="absolute top-1 left-1 w-4 h-4 rounded-full bg-base-300/80 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow"
               title="Marquer comme lu"
               @click.stop="toggleMutation.mutate({ veId: ve.id, field: 'isRead' })"
             >
@@ -182,30 +235,61 @@ const toggleMutation = useMutation({
               </svg>
             </button>
 
+            <!-- Wishlist star indicator (top-right) -->
+            <div
+              v-if="ve.isWishlisted && !ve.isOwned"
+              class="absolute top-1 right-1 w-4 h-4 rounded-full bg-warning flex items-center justify-center shadow"
+              :title="t('wishlist.inWishlist')"
+              @click.stop="toggleMutation.mutate({ veId: ve.id, field: 'isWishlisted' })"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-warning-content" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            </div>
+
+            <!-- Hover: toggle wishlist (only if not owned and not wishlisted) -->
+            <button
+              v-if="!ve.isOwned && !ve.isWishlisted"
+              class="absolute top-1 right-1 w-4 h-4 rounded-full bg-base-300/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center shadow"
+              :title="t('wishlist.addToWishlist')"
+              @click.stop="toggleMutation.mutate({ veId: ve.id, field: 'isWishlisted' })"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 text-base-content/50" fill="none" viewBox="0 0 20 20" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            </button>
+
             <!-- Number label -->
-            <div class="text-center text-xs mt-0.5 tabular-nums" :class="ve.isOwned ? 'text-base-content/70' : 'text-base-content/25'">
+            <div
+              class="text-center text-xs mt-0.5 tabular-nums"
+              :class="ve.isOwned ? 'text-base-content/70' : ve.isWishlisted ? 'text-warning/70' : 'text-base-content/25'"
+            >
               {{ ve.number }}
             </div>
           </div>
         </div>
 
         <div v-else class="text-sm text-base-content/40 italic">
-          Aucun tome enregistré pour ce manga.
+          {{ t('collection.noVolumes') }}
         </div>
 
         <!-- Legend -->
-        <div class="flex gap-4 mt-4 text-xs text-base-content/50">
+        <div class="flex flex-wrap gap-4 mt-4 text-xs text-base-content/50">
           <span class="flex items-center gap-1.5">
             <span class="w-3 h-3 rounded-sm bg-success/40 ring-1 ring-success/60 inline-block" />
-            Possédé
+            {{ t('collection.owned') }}
           </span>
           <span class="flex items-center gap-1.5">
             <span class="w-3 h-3 rounded-sm bg-info inline-block" />
-            Lu
+            {{ t('collection.read') }}
+          </span>
+          <span class="flex items-center gap-1.5">
+            <span class="w-3 h-3 rounded-sm bg-warning/40 ring-1 ring-warning/60 inline-block" />
+            {{ t('wishlist.inWishlist') }}
           </span>
           <span class="flex items-center gap-1.5">
             <span class="w-3 h-3 rounded-sm bg-base-300 opacity-40 inline-block" />
-            Manquant
+            {{ t('collection.missing') }}
           </span>
         </div>
       </div>

--- a/front/src/pages/WishlistPage.vue
+++ b/front/src/pages/WishlistPage.vue
@@ -1,20 +1,30 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import { getWishlist, removeFromWishlist, purchaseWishlistItem } from '@/api/wishlist'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
+import type { CollectionEntry } from '@/types'
 
 const qc = useQueryClient()
 const ui = useUiStore()
 const { t } = useI18n()
+const router = useRouter()
 
 const { data: items, isPending } = useQuery({ queryKey: ['wishlist'], queryFn: getWishlist })
+
+const totalWishlistVolumes = computed(() =>
+  items.value?.reduce((s, e) => s + e.wishlistCount, 0) ?? 0,
+)
 
 const removeMutation = useMutation({
   mutationFn: (id: string) => removeFromWishlist(id),
   onSuccess: () => {
     qc.invalidateQueries({ queryKey: ['wishlist'] })
+    qc.invalidateQueries({ queryKey: ['collection'] })
     qc.invalidateQueries({ queryKey: ['stats'] })
+    ui.addToast(t('wishlist.removed'), 'success')
   },
 })
 
@@ -27,51 +37,159 @@ const purchaseMutation = useMutation({
     ui.addToast(t('wishlist.purchased'), 'success')
   },
 })
+
+// Compute the visual volume dots for each entry
+function getVolumeDots(entry: CollectionEntry) {
+  const total = entry.totalVolumes
+  if (total === 0) return []
+  const shown = Math.min(total, 30)
+  return Array.from({ length: shown }, (_, i) => {
+    if (i < entry.ownedCount) return 'owned'
+    if (i < entry.ownedCount + entry.wishlistCount) return 'wishlist'
+    return 'none'
+  })
+}
+
+function openDetail(id: string) {
+  router.push({ name: 'collection-detail', params: { id } })
+}
 </script>
 
 <template>
-  <div class="p-6 space-y-6">
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold">{{ t('wishlist.title') }}</h1>
+  <div class="p-4 md:p-6 space-y-6 max-w-screen-xl mx-auto">
+    <!-- Header -->
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+      <div>
+        <h1 class="text-3xl font-bold tracking-tight">{{ t('wishlist.title') }}</h1>
+        <p v-if="!isPending && items?.length" class="text-sm text-base-content/50 mt-1">
+          {{ items.length }} {{ t('wishlist.oeuvres') }} &bull;
+          <span class="text-warning font-medium">{{ totalWishlistVolumes }}</span>
+          {{ t('wishlist.volumesToBuy') }}
+        </p>
+      </div>
+      <RouterLink to="/add" class="btn btn-outline btn-warning gap-2 shrink-0">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        {{ t('wishlist.addToWishlist') }}
+      </RouterLink>
     </div>
 
-    <div v-if="isPending" class="flex justify-center py-16">
-      <span class="loading loading-spinner loading-lg" />
+    <!-- Loading -->
+    <div v-if="isPending" class="flex justify-center py-20">
+      <span class="loading loading-spinner loading-lg text-warning" />
     </div>
 
-    <div v-else-if="!items?.length" class="text-center py-16 text-base-content/50">
-      {{ t('wishlist.empty') }}
+    <!-- Empty state -->
+    <div
+      v-else-if="!items?.length"
+      class="flex flex-col items-center justify-center py-24 gap-4 text-base-content/40"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-16 h-16 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      </svg>
+      <p class="text-lg font-medium">{{ t('wishlist.empty') }}</p>
+      <RouterLink to="/add" class="btn btn-warning btn-sm">
+        {{ t('wishlist.addToWishlist') }}
+      </RouterLink>
     </div>
 
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <!-- Wishlist cards grid -->
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       <div
-        v-for="item in items.filter(i => !i.isPurchased)"
-        :key="item.id"
-        class="card bg-base-100 shadow hover:shadow-lg transition-shadow"
+        v-for="entry in items"
+        :key="entry.id"
+        class="group relative overflow-hidden rounded-2xl bg-base-100 border border-warning/20
+               shadow-md transition-all duration-300 hover:shadow-xl hover:-translate-y-0.5
+               hover:border-warning/40"
       >
-        <div class="card-body flex-row gap-4 p-4">
-          <img
-            v-if="item.manga.coverUrl"
-            :src="item.manga.coverUrl"
-            :alt="item.manga.title"
-            class="w-16 h-22 object-cover rounded"
-          />
-          <div class="flex-1 min-w-0 space-y-1">
-            <p class="font-semibold truncate">{{ item.manga.title }}</p>
-            <p class="text-sm text-base-content/60">{{ item.manga.edition }}</p>
-            <div class="flex gap-2 pt-2">
+        <!-- Accent line at top -->
+        <div class="absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-warning/60 via-warning to-warning/60" />
+
+        <div class="flex gap-4 p-4">
+          <!-- Cover -->
+          <div
+            class="shrink-0 w-20 rounded-xl overflow-hidden bg-base-200 shadow cursor-pointer
+                   transition-transform duration-300 group-hover:scale-105"
+            @click="openDetail(entry.id)"
+          >
+            <div class="aspect-[2/3]">
+              <img
+                v-if="entry.manga.coverUrl"
+                :src="entry.manga.coverUrl"
+                :alt="entry.manga.title"
+                class="w-full h-full object-cover"
+                loading="lazy"
+              />
+              <div v-else class="w-full h-full flex items-center justify-center text-2xl text-base-content/20">
+                📚
+              </div>
+            </div>
+          </div>
+
+          <!-- Info -->
+          <div class="flex-1 min-w-0 space-y-2">
+            <div>
               <button
-                class="btn btn-success btn-xs"
-                :class="{ loading: purchaseMutation.isPending.value }"
-                @click="purchaseMutation.mutate(item.id)"
+                class="font-bold leading-tight line-clamp-2 text-left hover:text-primary transition-colors"
+                @click="openDetail(entry.id)"
               >
+                {{ entry.manga.title }}
+              </button>
+              <p class="text-sm text-base-content/60 mt-0.5">{{ entry.manga.edition }}</p>
+            </div>
+
+            <!-- Volume dots -->
+            <div class="flex flex-wrap gap-0.5" :title="`${entry.ownedCount} possédés, ${entry.wishlistCount} souhaités`">
+              <div
+                v-for="(dot, i) in getVolumeDots(entry)"
+                :key="i"
+                class="w-2.5 h-2.5 rounded-full transition-colors"
+                :class="{
+                  'bg-success': dot === 'owned',
+                  'bg-warning': dot === 'wishlist',
+                  'bg-base-300': dot === 'none',
+                }"
+              />
+              <span v-if="entry.totalVolumes > 30" class="text-xs text-base-content/30 self-center ml-1">
+                +{{ entry.totalVolumes - 30 }}
+              </span>
+            </div>
+
+            <!-- Volume counts -->
+            <div class="flex gap-3 text-xs">
+              <span v-if="entry.ownedCount > 0" class="flex items-center gap-1">
+                <span class="w-2 h-2 rounded-full bg-success inline-block" />
+                <span class="text-base-content/60">{{ entry.ownedCount }} {{ t('collection.owned') }}</span>
+              </span>
+              <span class="flex items-center gap-1">
+                <span class="w-2 h-2 rounded-full bg-warning inline-block" />
+                <span class="text-warning font-semibold">{{ entry.wishlistCount }}</span>
+                <span class="text-base-content/60">{{ t('wishlist.toGet') }}</span>
+              </span>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex gap-2 pt-1">
+              <button
+                class="btn btn-warning btn-sm flex-1 gap-1.5 font-semibold"
+                :class="{ loading: purchaseMutation.isPending.value }"
+                :disabled="purchaseMutation.isPending.value"
+                @click="purchaseMutation.mutate(entry.id)"
+              >
+                <svg v-if="!purchaseMutation.isPending.value" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" />
+                </svg>
                 {{ t('wishlist.purchase') }}
               </button>
               <button
-                class="btn btn-ghost btn-xs"
-                @click="removeMutation.mutate(item.id)"
+                class="btn btn-ghost btn-sm btn-square text-base-content/40 hover:text-error hover:bg-error/10"
+                :title="t('wishlist.removeFromWishlist')"
+                @click="removeMutation.mutate(entry.id)"
               >
-                {{ t('common.remove') }}
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
               </button>
             </div>
           </div>

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -41,6 +41,7 @@ export interface VolumeEntry {
   priceCode: PriceCode | null
   isOwned: boolean
   isRead: boolean
+  isWishlisted: boolean
   review: string | null
   rating: number | null
 }
@@ -53,6 +54,7 @@ export interface CollectionEntry {
   rating: number | null
   ownedCount: number
   readCount: number
+  wishlistCount: number
   totalVolumes: number
   addedAt: string
 }


### PR DESCRIPTION
## Summary
This PR refactors the wishlist system from a separate entity model to per-volume wishlist tracking within the collection domain. Instead of maintaining a separate `WishlistItem` table, volumes can now be marked as wishlisted individually, allowing users to track which specific volumes they want to purchase.

## Key Changes

### Backend
- **Domain Model**: Added `isWishlisted` boolean field to `VolumeEntry` entity to track wishlist status per volume
- **Wishlist Operations**: Refactored wishlist handlers to operate on `CollectionEntry` instead of separate `WishlistItem`:
  - `AddWishlistItemHandler`: Creates/updates collection entry and marks all unowned volumes as wishlisted
  - `RemoveWishlistItemHandler`: Clears wishlist flags; deletes entry if no owned volumes remain
  - `PurchaseWishlistItemHandler`: Marks wishlisted volumes as owned
  - New `WishlistRemainingHandler`: Bulk-wishlist all remaining unowned volumes for a series
- **Repository**: Added `findWithWishlistVolumes()` method to `CollectionRepositoryInterface` for efficient wishlist queries
- **Stats**: Updated to count wishlisted volumes from collection entries instead of separate wishlist table
- **Migration**: Added database migration to add `is_wishlisted` column to `volume_entries` table

### Frontend
- **API Layer**: Updated `getWishlist()` to return `CollectionEntry[]` instead of `WishlistItem[]`
- **Type System**: Added `isWishlisted` field to `VolumeEntry` type
- **WishlistPage**: Complete redesign with:
  - Visual volume dots showing owned (green), wishlisted (orange), and missing (gray) volumes
  - Per-series wishlist count display
  - Enhanced card layout with cover images and action buttons
  - Empty state with icon and call-to-action
- **MangaDetailPage**: 
  - Added wishlist count display in stats
  - New "Wishlist remaining volumes" button to bulk-add unowned volumes
  - Volume grid now shows wishlist status with visual indicators
  - Toggle functionality for individual volume wishlist status
- **MangaCard**: Enhanced with:
  - Wishlist badge showing count
  - Mini volume dots visualization (max 25 shown)
  - Stacked progress bar showing owned + wishlisted + missing breakdown
  - Improved hover effects and visual hierarchy
- **CollectionPage**: 
  - Added wishlist statistics to header
  - Increased grid columns for better use of space
  - Enhanced search and pagination UI
- **i18n**: Updated French and English translations with new wishlist-related strings

## Implementation Details
- Wishlist is now a derived view of collection entries with wishlisted volumes, eliminating data duplication
- Volume-level wishlist tracking enables granular control (e.g., wishlist only volumes 5-10 of a series)
- Visual indicators (dots, badges, progress bars) provide quick status overview across the UI
- Bulk operations (add remaining, purchase all) reduce friction for common workflows

https://claude.ai/code/session_01MgydU9ngX9wz1tWMr2ifsF