### PR TITLE
fix: add dedicated worker build stage to fix Railway worker not starting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,12 @@ EXPOSE ${PORT:-80}
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+
+# ── Stage 4: Worker ───────────────────────────────────────────────────────────
+FROM prod AS worker
+
+COPY back/worker-entrypoint.sh /usr/local/bin/worker-entrypoint.sh
+RUN chmod +x /usr/local/bin/worker-entrypoint.sh
+
+ENTRYPOINT ["worker-entrypoint.sh"]
+CMD ["php", "bin/console", "messenger:consume", "async", "scheduler_default", "--time-limit=3600", "-vv"]

--- a/back/worker-entrypoint.sh
+++ b/back/worker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "[worker] Warming up Symfony cache..."
+php bin/console cache:warmup --env=prod
+
+echo "[worker] Running database migrations..."
+php bin/console doctrine:migrations:migrate --no-interaction --env=prod
+
+echo "[worker] Starting Messenger consumer..."
+exec "$@"

--- a/worker/railway.json
+++ b/worker/railway.json
@@ -3,13 +3,9 @@
   "build": {
     "builder": "DOCKERFILE",
     "dockerfilePath": "../Dockerfile",
-    "dockerBuildTarget": "prod",
-    "buildArgs": {
-      "JWT_PASSPHRASE": "${{JWT_PASSPHRASE}}"
-    }
+    "dockerBuildTarget": "worker"
   },
   "deploy": {
-    "startCommand": "php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv",
     "restartPolicyType": "ALWAYS",
     "restartPolicyMaxRetries": 5
   }


### PR DESCRIPTION
- Add `worker` stage in Dockerfile (inherits from `prod`, overrides
  ENTRYPOINT and CMD) so the build target is explicit and isolated
- Add `back/worker-entrypoint.sh` that only does cache warmup + migrations,
  without JWT keypair generation or FrankenPHP-specific setup
- Update `worker/railway.json` to target `dockerBuildTarget: "worker"`,
  removing `startCommand` (CMD in Dockerfile is authoritative) and the
  unused `JWT_PASSPHRASE` build arg

The previous config used `dockerBuildTarget: "prod"` + `startCommand`.
The `prod` ENTRYPOINT (docker-entrypoint.sh) generated JWT keys requiring
JWT_PASSPHRASE at runtime and logged "Starting FrankenPHP", making the
consumer fragile. The new `worker` stage has its own minimal entrypoint.

https://claude.ai/code/session_019AHtjkPWvZsm2NFyGTjpC2