### PR TITLE
fix: shell injection in deploy workflow via commit message backticks

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -263,11 +263,15 @@ jobs:
       - name: Deploy backend service
         # Run from repo root so Railway finds railway.json → uses root Dockerfile.
         # back/ has no Dockerfile, so railway up from back/ triggers Nixpacks (wrong).
+        # COMMIT_MSG is set as env var (not inline) to prevent backticks in the message
+        # from being interpreted as shell command substitution.
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           railway up \
             --service ziggytheque-back \
             --ci \
-            -m "Deploy ${{ github.sha }} — ${{ github.event.head_commit.message }}"
+            -m "Deploy ${{ github.sha }} — $COMMIT_MSG"
 
   deploy-worker:
     name: "Production: Deploy Worker"
@@ -279,11 +283,13 @@ jobs:
         run: npm install -g @railway/cli
       - name: Deploy worker service
         # Same as back: run from root to pick up railway.json + root Dockerfile.
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           railway up \
             --service ziggytheque-worker \
             --ci \
-            -m "Deploy ${{ github.sha }} — ${{ github.event.head_commit.message }}"
+            -m "Deploy ${{ github.sha }} — $COMMIT_MSG"
 
   deploy-front:
     name: "Production: Deploy Frontend"
@@ -295,11 +301,13 @@ jobs:
         run: npm install -g @railway/cli
       - name: Deploy frontend service
         working-directory: front
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           railway up \
             --service ziggytheque-front \
             --ci \
-            -m "Deploy ${{ github.sha }} — ${{ github.event.head_commit.message }}"
+            -m "Deploy ${{ github.sha }} — $COMMIT_MSG"
 
   # ---------------------------------------------------------------------------
   # Release gate — fires only after back + worker + front all deploy successfully


### PR DESCRIPTION
## Problème

Les trois steps de déploiement Railway interpolaient le message de commit directement dans le shell :

```yaml
-m "Deploy ${{ github.sha }} — ${{ github.event.head_commit.message }}"
```

GitHub Actions substitue `${{ }}` en premier, puis le shell exécute la chaîne résultante. Les backticks dans un message de commit (ex. `` `worker` ``, `` `prod` ``, `` `startCommand` ``) sont interprétés comme des substitutions de commandes shell, provoquant des erreurs du type `worker: command not found`.

## Fix

Assigner le message à une variable d'environnement avant utilisation :

```yaml
env:
  COMMIT_MSG: ${{ github.event.head_commit.message }}
run: |
  railway up ... -m "Deploy ${{ github.sha }} — $COMMIT_MSG"
```

Quand bash étend `$COMMIT_MSG`, le contenu n'est jamais re-parsé — les backticks sont inertes. Fix appliqué aux trois steps : `deploy-back`, `deploy-worker`, `deploy-front`.

## Test plan

- [ ] Merger et vérifier que le prochain déploiement ne produit plus d'erreurs `command not found` dans les logs CI
- [ ] Vérifier que le message de commit apparaît correctement dans l'historique Railway

https://claude.ai/code/session_019AHtjkPWvZsm2NFyGTjpC2

---
_Generated by [Claude Code](https://claude.ai/code/session_019AHtjkPWvZsm2NFyGTjpC2)_