### PR TITLE
feat(back,front): update edition on collection and handle logo

### DIFF
--- a/back/migrations/Version20260427000000.php
+++ b/back/migrations/Version20260427000000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260427000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make manga edition nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE mangas ALTER COLUMN edition DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("UPDATE mangas SET edition = '' WHERE edition IS NULL");
+        $this->addSql('ALTER TABLE mangas ALTER COLUMN edition SET NOT NULL');
+    }
+}

--- a/back/src/Manga/Application/Import/ImportMangaCommand.php
+++ b/back/src/Manga/Application/Import/ImportMangaCommand.php
@@ -8,8 +8,8 @@ final readonly class ImportMangaCommand
 {
     public function __construct(
         public string $title,
-        public string $edition,
         public string $language,
+        public ?string $edition = null,
         public ?string $author = null,
         public ?string $summary = null,
         public ?string $coverUrl = null,

--- a/back/src/Manga/Application/Update/UpdateMangaHandler.php
+++ b/back/src/Manga/Application/Update/UpdateMangaHandler.php
@@ -34,7 +34,7 @@ final readonly class UpdateMangaHandler
             }
 
             if ($command->edition !== null) {
-                $manga->edition = $command->edition;
+                $manga->edition = $command->edition === '' ? null : $command->edition;
             }
 
             if ($command->coverUrl !== null) {

--- a/back/src/Manga/Domain/Manga.php
+++ b/back/src/Manga/Domain/Manga.php
@@ -33,8 +33,8 @@ class Manga
         public readonly string $id,
         #[ORM\Column(length: 255)]
         public string $title,
-        #[ORM\Column(length: 100)]
-        public string $edition,
+        #[ORM\Column(length: 100, nullable: true)]
+        public ?string $edition,
         #[ORM\Column(length: 10)]
         public string $language,
         #[ORM\Column(nullable: true)]

--- a/back/src/Manga/Infrastructure/Http/ImportMangaRequest.php
+++ b/back/src/Manga/Infrastructure/Http/ImportMangaRequest.php
@@ -13,11 +13,10 @@ final readonly class ImportMangaRequest
         #[Assert\Length(max: 255)]
         public string $title,
         #[Assert\NotBlank]
-        #[Assert\Length(max: 100)]
-        public string $edition,
-        #[Assert\NotBlank]
         #[Assert\Length(max: 10)]
         public string $language,
+        #[Assert\Length(max: 100)]
+        public ?string $edition = null,
         public ?string $author = null,
         public ?string $summary = null,
         public ?string $coverUrl = null,

--- a/front/src/api/manga.ts
+++ b/front/src/api/manga.ts
@@ -13,8 +13,8 @@ export async function getManga(id: string): Promise<MangaDetail> {
 
 export async function importManga(payload: {
   title: string
-  edition: string
   language: string
+  edition?: string
   author?: string
   summary?: string
   coverUrl?: string

--- a/front/src/components/atoms/BaseEditionSelector.vue
+++ b/front/src/components/atoms/BaseEditionSelector.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { FRENCH_EDITIONS } from '@/data/editions'
+
+const props = defineProps<{
+  modelValue: string | null
+  inputClass?: string
+  placeholder?: string
+  autofocus?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+  'confirm': []
+  'cancel': []
+}>()
+
+const inputValue = ref(props.modelValue ?? '')
+const showDropdown = ref(false)
+
+watch(() => props.modelValue, (v) => {
+  if ((v ?? '') !== inputValue.value) inputValue.value = v ?? ''
+})
+
+const filtered = computed(() => {
+  const q = inputValue.value.toLowerCase().trim()
+  if (!q) return FRENCH_EDITIONS
+  return FRENCH_EDITIONS.filter((e) => e.name.toLowerCase().includes(q))
+})
+
+function select(name: string | null) {
+  inputValue.value = name ?? ''
+  emit('update:modelValue', name)
+  showDropdown.value = false
+  emit('confirm')
+}
+
+function onInput() {
+  emit('update:modelValue', inputValue.value || null)
+  showDropdown.value = true
+}
+
+function onBlur() {
+  setTimeout(() => { showDropdown.value = false }, 150)
+}
+</script>
+
+<template>
+  <div class="relative">
+    <input
+      v-model="inputValue"
+      type="text"
+      :class="inputClass ?? 'input input-bordered w-full'"
+      :placeholder="placeholder ?? 'Pika, Glénat, Kana…'"
+      autocomplete="off"
+      :autofocus="autofocus"
+      @input="onInput"
+      @focus="showDropdown = true"
+      @blur="onBlur"
+      @keydown.enter.prevent="emit('confirm')"
+      @keydown.escape="emit('cancel')"
+    />
+    <ul
+      v-if="showDropdown && filtered.length"
+      class="absolute top-full left-0 right-0 z-30 mt-0.5 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-52 overflow-y-auto text-sm min-w-52"
+    >
+      <li
+        v-if="modelValue"
+        class="px-3 py-2 cursor-pointer hover:bg-error/10 hover:text-error transition-colors text-xs text-base-content/50 border-b border-base-200"
+        @mousedown.prevent="select(null)"
+      >
+        × Effacer l'édition
+      </li>
+      <li
+        v-for="ed in filtered"
+        :key="ed.name"
+        class="px-3 py-2.5 cursor-pointer hover:bg-primary hover:text-primary-content transition-colors flex items-center gap-2.5"
+        @mousedown.prevent="select(ed.name)"
+      >
+        <img
+          :src="ed.logo"
+          :alt="ed.name"
+          class="w-5 h-5 rounded object-contain flex-shrink-0"
+        />
+        {{ ed.name }}
+      </li>
+    </ul>
+  </div>
+</template>

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
   collectionEntryId: string
   mangaId: string
   mangaTitle: string
-  mangaEdition: string
+  mangaEdition: string | null
   volume: VolumeEntry | null
 }>()
 
@@ -53,7 +53,7 @@ watch(() => [props.open, props.volume] as const, ([open, vol], prev) => {
 
   if (justOpened && vol) {
     skipNextSearch = true
-    searchQuery.value = `${props.mangaTitle} tome ${vol.number} ${props.mangaEdition}`.trim()
+    searchQuery.value = `${props.mangaTitle} tome ${vol.number} ${props.mangaEdition ?? ''}`.trim()
     if (!vol.coverUrl) {
       runSearch(searchQuery.value)
     }

--- a/front/src/data/editions.ts
+++ b/front/src/data/editions.ts
@@ -1,0 +1,29 @@
+export interface EditionInfo {
+  name: string
+  logo: string
+}
+
+function favicon(domain: string): string {
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`
+}
+
+export const FRENCH_EDITIONS: EditionInfo[] = [
+  { name: 'Pika Édition',      logo: favicon('pika-editions.fr') },
+  { name: 'Glénat',            logo: favicon('glenat.com') },
+  { name: 'Kana',              logo: favicon('kana.fr') },
+  { name: 'Ki-oon',            logo: favicon('ki-oon.com') },
+  { name: 'Kazé Manga',        logo: favicon('kaze-manga.fr') },
+  { name: 'Kurokawa',          logo: favicon('kurokawa.fr') },
+  { name: 'Delcourt / Tonkam', logo: favicon('delcourt.fr') },
+  { name: 'Akata',             logo: favicon('akata.fr') },
+  { name: 'Nobi Nobi!',        logo: favicon('nobi-nobi.fr') },
+  { name: 'Doki-Doki',         logo: favicon('doki-doki.net') },
+  { name: 'Soleil Manga',      logo: favicon('soleilprod.com') },
+  { name: 'Michel Lafon',      logo: favicon('michel-lafon.fr') },
+  { name: "J'ai Lu",           logo: favicon('jailu.com') },
+  { name: 'Panini Manga',      logo: favicon('panini.fr') },
+  { name: 'Bamboo Édition',    logo: favicon('bamboo.fr') },
+  { name: 'Kami',              logo: favicon('kamilivres.fr') },
+  { name: 'Vega-Dupuis',       logo: favicon('vega-dupuis.com') },
+  { name: 'Crunchyroll',       logo: favicon('crunchyroll.com') },
+]

--- a/front/src/pages/AddMangaPage.vue
+++ b/front/src/pages/AddMangaPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ref, computed, watch } from 'vue'
+  import { ref, computed } from 'vue'
   import { useRouter } from 'vue-router'
   import { useMutation, useQueryClient } from '@tanstack/vue-query'
   import { ArrowLeft, Search, RefreshCw, Book, ImageOff, Star } from 'lucide-vue-next'
@@ -10,6 +10,7 @@
   import { useExternalSearch } from '@/composables/useExternalSearch'
   import type { ExternalMangaResult } from '@/composables/useExternalSearch'
   import { coverUrl } from '@/utils/coverUrl'
+  import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
 
   const router = useRouter()
   const qc = useQueryClient()
@@ -77,8 +78,8 @@
     mutationFn: () =>
       importManga({
         title: form.value.title,
-        edition: form.value.edition,
         language: form.value.language,
+        edition: form.value.edition || undefined,
         author: form.value.author || undefined,
         summary: form.value.summary || undefined,
         coverUrl: form.value.coverUrl || undefined,
@@ -130,58 +131,6 @@
     'other',
   ]
 
-  const frenchEditions = [
-    'Pika Édition',
-    'Glénat',
-    'Kana',
-    'Ki-oon',
-    'Kazé Manga',
-    'Kurokawa',
-    'Delcourt / Tonkam',
-    'Akata',
-    'Nobi Nobi!',
-    'Doki-Doki',
-    'Soleil Manga',
-    'Michel Lafon',
-    "J'ai Lu",
-    'Panini Comics',
-    'Bamboo Édition',
-    'Kami',
-    'Vega-Dupuis',
-    'Crunchryroll',
-  ]
-
-  const editionInput = ref('')
-  watch(
-    () => form.value.edition,
-    (v) => {
-      if (v !== editionInput.value) editionInput.value = v
-    },
-  )
-  const editionFiltered = computed(() => {
-    const q = editionInput.value.toLowerCase().trim()
-    if (!q) return frenchEditions
-    return frenchEditions.filter((e) => e.toLowerCase().includes(q))
-  })
-  const showEditionDropdown = ref(false)
-
-  function selectEdition(edition: string) {
-    form.value.edition = edition
-    editionInput.value = edition
-    showEditionDropdown.value = false
-  }
-
-  // Sync editionInput when form.edition changes (e.g. from applyResult)
-  function onEditionInput() {
-    form.value.edition = editionInput.value
-    showEditionDropdown.value = true
-  }
-
-  function onEditionBlur() {
-    setTimeout(() => {
-      showEditionDropdown.value = false
-    }, 150)
-  }
 </script>
 
 <template>
@@ -337,32 +286,12 @@
         </div>
 
         <!-- Edition -->
-        <div class="space-y-1 relative">
-          <label class="text-xs font-semibold text-base-content/60 uppercase tracking-wide">{{ t('manga.edition') }} *</label>
-          <input
-            v-model="editionInput"
-            type="text"
-            class="input input-bordered w-full"
-            placeholder="Pika, Glénat, Kana…"
-            required
-            autocomplete="off"
-            @input="onEditionInput"
-            @focus="showEditionDropdown = true"
-            @blur="onEditionBlur"
+        <div class="space-y-1">
+          <label class="text-xs font-semibold text-base-content/60 uppercase tracking-wide">{{ t('manga.edition') }}</label>
+          <BaseEditionSelector
+            :model-value="form.edition || null"
+            @update:model-value="form.edition = $event ?? ''"
           />
-          <ul
-            v-if="showEditionDropdown && editionFiltered.length"
-            class="absolute top-full left-0 right-0 z-30 mt-0.5 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-44 overflow-y-auto text-sm"
-          >
-            <li
-              v-for="ed in editionFiltered"
-              :key="ed"
-              class="px-3 py-2.5 cursor-pointer hover:bg-primary hover:text-primary-content transition-colors"
-              @mousedown.prevent="selectEdition(ed)"
-            >
-              {{ ed }}
-            </li>
-          </ul>
         </div>
 
         <div class="grid grid-cols-2 gap-3">

--- a/front/src/pages/CollectionPage.vue
+++ b/front/src/pages/CollectionPage.vue
@@ -20,7 +20,7 @@ const filtered = computed(() => {
   return collection.value.filter(
     (e) =>
       e.manga.title.toLowerCase().includes(q) ||
-      e.manga.edition.toLowerCase().includes(q) ||
+      (e.manga.edition?.toLowerCase().includes(q) ?? false) ||
       (e.manga.author?.toLowerCase().includes(q) ?? false),
   )
 })

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -21,6 +21,8 @@ import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
 import EnrichVolumeModal from '@/components/organisms/EnrichVolumeModal.vue'
 import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
+import { FRENCH_EDITIONS } from '@/data/editions'
+import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
 import type { ReadingStatus, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
 
@@ -64,7 +66,7 @@ const editingTitle = ref(false)
 const editingEdition = ref(false)
 const editingCover = ref(false)
 const editTitleValue = ref('')
-const editEditionValue = ref('')
+const editEditionValue = ref<string | null>(null)
 const editCoverValue = ref('')
 
 function startEditTitle() {
@@ -72,11 +74,15 @@ function startEditTitle() {
   editingTitle.value = true
 }
 function startEditEdition() {
-  editEditionValue.value = entry.value?.manga.edition ?? ''
+  editEditionValue.value = entry.value?.manga.edition ?? null
   editingEdition.value = true
 }
 function cancelEditTitle() { editingTitle.value = false }
 function cancelEditEdition() { editingEdition.value = false }
+
+const editionLogo = computed(() =>
+  FRENCH_EDITIONS.find((e) => e.name === entry.value?.manga.edition)?.logo ?? null,
+)
 
 function startEditCover() {
   editCoverValue.value = entry.value?.manga.coverUrl ?? ''
@@ -404,18 +410,31 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                 <!-- Inline edition edit -->
                 <div class="flex flex-wrap gap-1.5 mt-2">
                   <div v-if="editingEdition" class="flex items-center gap-1.5">
-                    <input
-                      v-model="editEditionValue"
-                      class="input input-bordered input-xs font-medium w-40"
-                      autofocus
-                      @keydown.enter="updateMangaMutation.mutate({ edition: editEditionValue })"
-                      @keydown.escape="cancelEditEdition"
+                    <BaseEditionSelector
+                      :model-value="editEditionValue"
+                      input-class="input input-bordered input-xs font-medium w-40"
+                      :autofocus="true"
+                      @update:model-value="editEditionValue = $event"
+                      @confirm="updateMangaMutation.mutate({ edition: editEditionValue ?? '' })"
+                      @cancel="cancelEditEdition"
                     />
-                    <button class="btn btn-primary btn-xs" @click="updateMangaMutation.mutate({ edition: editEditionValue })">✓</button>
+                    <button class="btn btn-primary btn-xs" @click="updateMangaMutation.mutate({ edition: editEditionValue ?? '' })">✓</button>
                     <button class="btn btn-ghost btn-xs" @click="cancelEditEdition">✕</button>
                   </div>
                   <div v-else class="group/edition flex items-center gap-1">
-                    <span class="badge badge-primary cursor-pointer" @click="startEditEdition">{{ entry.manga.edition }}</span>
+                    <span
+                      class="badge cursor-pointer gap-1.5"
+                      :class="entry.manga.edition ? 'badge-primary' : 'badge-ghost'"
+                      @click="startEditEdition"
+                    >
+                      <img
+                        v-if="editionLogo"
+                        :src="editionLogo"
+                        :alt="entry.manga.edition!"
+                        class="w-3.5 h-3.5 rounded-sm object-contain"
+                      />
+                      {{ entry.manga.edition ?? 'Édition inconnue' }}
+                    </span>
                     <button
                       class="btn btn-ghost btn-xs opacity-0 group-hover/edition:opacity-60 transition-opacity p-0 min-h-0 h-auto"
                       title="Modifier l'édition"

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -9,7 +9,7 @@ export interface Volume {
 export interface Manga {
   id: string
   title: string
-  edition: string
+  edition: string | null
   language: string
   author: string | null
   summary: string | null


### PR DESCRIPTION
## Summary
This PR makes the manga edition field optional throughout the application and introduces a reusable `BaseEditionSelector` component with visual edition logos. The edition is now nullable in the database and can be left empty when importing or editing manga.

## Key Changes

- **New Component**: Created `BaseEditionSelector.vue` - a reusable dropdown component for selecting French manga editions with:
  - Searchable dropdown with filtered results
  - Edition logos fetched from publisher favicons
  - Support for clearing the selection
  - Keyboard navigation (Enter to confirm, Escape to cancel)

- **Edition Data**: Extracted edition list to `src/data/editions.ts` with:
  - Centralized `FRENCH_EDITIONS` array containing edition names and logo URLs
  - Dynamic favicon generation for publisher logos

- **Database Migration**: Added migration to make the `edition` column nullable in the `mangas` table

- **Backend Changes**:
  - Updated `Manga` entity to allow nullable edition (`?string`)
  - Modified `ImportMangaRequest` to make edition optional (moved after language field)
  - Updated `ImportMangaCommand` to accept optional edition
  - Modified `UpdateMangaHandler` to treat empty string as null

- **Frontend Pages**:
  - **AddMangaPage**: Replaced inline edition input with `BaseEditionSelector` component
  - **MangaDetailPage**: 
    - Integrated `BaseEditionSelector` for inline edition editing
    - Added edition logo display in the edition badge
    - Shows "Édition inconnue" when edition is not set
  - **CollectionPage**: Added null-safe check for edition filtering

- **Type Updates**: Updated `Manga` interface to reflect nullable edition field

## Implementation Details

- The edition field is now truly optional - it can be `null` or an empty string
- The `BaseEditionSelector` component handles the distinction between null (no selection) and empty string (cleared selection)
- Edition logos are dynamically fetched using Google's favicon service for consistency
- The component emits `confirm` and `cancel` events for keyboard interactions, making it reusable in different contexts

https://claude.ai/code/session_01TKr12MoZYMPPaF6i8nggsX