### PR TITLE
Wrap messenger consumer in restart loop for graceful recovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,10 +61,7 @@ services:
     build:
       context: ./back
       dockerfile: Dockerfile.dev
-    # --time-limit=3600: worker gracefully restarts every hour to prevent memory leaks.
-    # restart: unless-stopped ensures Docker immediately relaunches it after each cycle.
-    # Both async (user-triggered jobs) and scheduler_default (cron tasks) run in this process.
-    command: php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv
+    command: sh -c 'while true; do php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv; echo "[worker] Restarting messenger consumer..."; done'
     restart: unless-stopped
     env_file:
       - ./back/.env.local


### PR DESCRIPTION
## Summary
Modified the worker service to wrap the messenger consumer command in a shell loop that automatically restarts the process after each graceful shutdown, replacing the previous inline comments with an explicit implementation.

## Key Changes
- Replaced direct `messenger:consume` command with a shell loop (`sh -c 'while true; do ... done'`) that continuously restarts the consumer
- Added explicit logging message `"[worker] Restarting messenger consumer..."` to track restart cycles
- Removed inline comments explaining the time-limit and restart behavior, as the logic is now self-documenting through the loop implementation

## Implementation Details
- The consumer still respects the `--time-limit=3600` flag to gracefully restart every hour and prevent memory leaks
- The `restart: unless-stopped` policy remains unchanged and will handle container-level restarts
- The loop ensures the messenger consumer immediately restarts after each graceful shutdown cycle, improving resilience and making the restart behavior explicit in the command itself

https://claude.ai/code/session_01AfMyybDZ4so1dHW6tAYhXa