### PR TITLE
Add announced volumes batch operation feature

### DIFF
--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
-  ArrowLeft, Star, RefreshCw, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info,
+  ArrowLeft, Star, RefreshCw, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info, Bell, BellOff,
 } from 'lucide-vue-next'
 import {
   getCollectionEntry,
@@ -182,6 +182,9 @@ function selectOwned() {
 function selectUnread() {
   selectedIds.value = new Set(sortedVolumes.value.filter((v) => v.isOwned && !v.isRead).map((v) => v.id))
 }
+function selectAnnounced() {
+  selectedIds.value = new Set(sortedVolumes.value.filter((v) => v.isAnnounced && !v.isOwned).map((v) => v.id))
+}
 
 // ── Context menu ──
 const contextMenu = ref<{ ve: VolumeEntry; x: number; y: number } | null>(null)
@@ -284,7 +287,7 @@ const ratingMutation = useMutation({
 // ── Batch operations ──
 const isBatchProcessing = ref(false)
 
-async function batchToggle(field: 'isOwned' | 'isRead' | 'isWished') {
+async function batchToggle(field: 'isOwned' | 'isRead' | 'isWished' | 'isAnnounced') {
   if (selectedIds.value.size === 0) return
   const count = selectedIds.value.size
   const ids = [...selectedIds.value]
@@ -631,6 +634,7 @@ function volumeOpacityClass(ve: VolumeEntry): string {
           <button class="btn btn-xs btn-ghost" @click="selectAll">Tout</button>
           <button class="btn btn-xs btn-ghost" @click="selectOwned">Possédés</button>
           <button class="btn btn-xs btn-ghost" @click="selectUnread">Non lus</button>
+          <button class="btn btn-xs btn-ghost" @click="selectAnnounced">Annoncés</button>
           <button class="btn btn-xs btn-ghost text-base-content/30" @click="selectedIds = new Set()">Vider</button>
         </div>
 
@@ -890,6 +894,24 @@ function volumeOpacityClass(ve: VolumeEntry): string {
             >
               <Star class="h-4 w-4" />
               Wishlist
+            </button>
+            <button
+              v-if="selectedVolumes.some((v) => !v.isOwned && !v.isAnnounced)"
+              class="btn btn-secondary btn-sm btn-outline gap-1.5"
+              :disabled="isBatchProcessing"
+              @click="batchToggle('isAnnounced')"
+            >
+              <Bell class="h-4 w-4" />
+              Marquer annoncés
+            </button>
+            <button
+              v-if="selectedVolumes.some((v) => !v.isOwned && v.isAnnounced)"
+              class="btn btn-secondary btn-sm gap-1.5"
+              :disabled="isBatchProcessing"
+              @click="batchToggle('isAnnounced')"
+            >
+              <BellOff class="h-4 w-4" />
+              Retirer annoncés
             </button>
           </div>
           <button class="btn btn-ghost btn-sm shrink-0" @click="selectedIds = new Set()">


### PR DESCRIPTION
## Summary
This PR adds support for marking volumes as "announced" in batch operations, allowing users to track upcoming releases that haven't been purchased yet.

## Key Changes
- Added `Bell` and `BellOff` icons from lucide-vue-next for visual representation of announced status
- Implemented `selectAnnounced()` function to filter and select volumes that are announced but not yet owned
- Extended `batchToggle()` function to support the `isAnnounced` field alongside existing fields (`isOwned`, `isRead`, `isWished`)
- Added "Annoncés" (Announced) quick-select button in the batch selection toolbar
- Added two conditional batch action buttons:
  - "Marquer annoncés" (Mark as announced) - shown when selected volumes contain unannounced items
  - "Retirer annoncés" (Remove announced) - shown when selected volumes contain announced items
- Both buttons use secondary styling with appropriate icons and are disabled during batch processing

## Implementation Details
- The announced status filtering follows the same pattern as existing batch operations
- Buttons conditionally render based on the state of selected volumes to provide relevant actions
- The feature integrates seamlessly with the existing batch operation infrastructure

https://claude.ai/code/session_012F1Np2begLWizwFyP33FVE