### PR TITLE
fix(docker): remove --no-scripts so symfony/runtime generates autoload_runtime.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ COPY back/ .
 
 RUN composer install \
     --no-dev \
-    --no-interaction \
-    --no-scripts && \
+    --no-interaction && \
     composer dump-autoload \
     --optimize \
     --classmap-authoritative


### PR DESCRIPTION
## Problem

Every `php bin/console` call in the worker container crashes with:

```
Fatal error: Uncaught LogicException: Symfony Runtime is missing.
Try running "composer require symfony/runtime". in /app/bin/console:12
```

This kills JWT keypair generation, cache warmup, and `messenger:consume` — the worker never starts.

## Root cause

`vendor/autoload_runtime.php` is generated by the `symfony/runtime` Composer plugin in its `post-autoload-dump` event handler. Both commands in the Dockerfile were silently skipping that event:

| Command | Why `post-autoload-dump` never fired |
|---|---|
| `composer install --no-scripts` | `--no-scripts` suppresses all `ScriptEvents`, including `post-autoload-dump` |
| `composer dump-autoload` | internally calls `Installer::setRunScripts(false)` — always, unconditionally |

So `autoload_runtime.php` was never written into the image.

## Fix

Drop `--no-scripts` from `composer install`. Symfony's `post-install-cmd` auto-scripts (`cache:clear`, `assets:install`) are safe during Docker builds — the DI container compiles with env-var placeholder strings (`%env(DATABASE_URL)%`), not real connection values, so no DB or secrets are needed at build time.

## Why the backend appeared unaffected

Railway was serving a cached image for the `prod` service built before this issue surfaced. The worker gets a fresh build on every deploy, so it hit the missing file every time.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135GbyyGAUQKbNBgBUwp2fr)_