### PR TITLE
feat(docker): split worker stage, fix migration race, pin Composer, fix runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Version control
+.git
+.github
+.gitignore
+
+# Claude / tooling
+.claude
+
+# PHP dependencies and generated files
+back/vendor/
+back/var/cache/
+back/var/log/
+back/.env.local
+back/.env.*.local
+
+# JWT keys — generated at container startup by the entrypoint
+back/config/jwt/
+
+# Node dependencies and build output (rebuilt inside Docker)
+front/node_modules/
+front/dist/
+
+# Test / QA artefacts (not needed in production image)
+back/tests/
+back/phpunit.xml
+back/phpunit.xml.dist
+back/.phpunit.result.cache
+back/phpstan.neon
+back/phpcs.xml
+back/deptrac.yaml
+
+# Dev Docker files
+docker-compose.yml
+back/Dockerfile.dev
+back/compose.yaml
+back/compose.override.yaml
+
+# Documentation and misc
+*.md
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# ── Stage 1: Frontend build ───────────────────────────────────────────────────
+# ── Stage 1: Frontend build ────────────────────────────────────────────────────
 FROM node:22-alpine AS frontend
 
 WORKDIR /app
@@ -22,24 +22,29 @@ RUN install-php-extensions \
     opcache \
     apcu
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.7 /usr/bin/composer /usr/bin/composer
 
-# ── Stage 3: Production ───────────────────────────────────────────────────────
-FROM base AS prod
+# ── Stage 3: PHP application code (shared by server and worker) ───────────────
+FROM base AS app
 
 ENV APP_ENV=prod
 ENV APP_DEBUG=0
+# FrankenPHP runs as root; without this Composer silently disables all plugins,
+# including symfony/runtime, so vendor/autoload_runtime.php is never generated.
+ENV COMPOSER_ALLOW_SUPERUSER=1
 # PORT is injected by Railway at runtime; Caddyfile binds to :{$PORT:80}
 
 COPY back/ .
 
 RUN composer install \
     --no-dev \
-    --no-interaction \
-    --no-scripts && \
+    --no-interaction && \
     composer dump-autoload \
     --optimize \
     --classmap-authoritative
+
+# ── Stage 4: Production server (app + SPA + FrankenPHP/Caddy) ─────────────────
+FROM app AS prod
 
 # Copy built Vue SPA into Symfony public directory (served by FrankenPHP as static files)
 COPY --from=frontend /app/dist /app/public/spa
@@ -52,3 +57,13 @@ EXPOSE 80
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+
+# ── Stage 5: Messenger worker (no SPA, no Caddy — pure PHP consumer) ──────────
+FROM app AS worker
+
+COPY back/worker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php", "bin/console", "messenger:consume", "async", "scheduler_default", \
+     "--time-limit=3600", "--memory-limit=128M", "-vv"]

--- a/back/worker-entrypoint.sh
+++ b/back/worker-entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 set -e
 
+# Generate JWT keypair if missing — needed for the DI container to compile
+# (the back service owns key generation; this is a fallback for cold starts)
+if [ ! -f config/jwt/private.pem ]; then
+    echo "[worker] Generating JWT keypair..."
+    php bin/console lexik:jwt:generate-keypair --no-interaction
+fi
+
 echo "[worker] Warming up Symfony cache..."
 php bin/console cache:warmup --env=prod
-
-echo "[worker] Running database migrations..."
-php bin/console doctrine:migrations:migrate --no-interaction --env=prod
 
 echo "[worker] Starting Messenger consumer..."
 exec "$@"

--- a/worker/railway.json
+++ b/worker/railway.json
@@ -2,11 +2,10 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
+    "dockerfilePath": "Dockerfile",
+    "dockerBuildTarget": "worker"
   },
   "deploy": {
-    "startCommand": "php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv",
-    "restartPolicyType": "ALWAYS",
-    "restartPolicyMaxRetries": 5
+    "restartPolicyType": "ALWAYS"
   }
 }


### PR DESCRIPTION
## Summary

Overhaul of the Railway production Docker setup. Fixes the worker deploy loop and makes both the backend and worker images leaner and more reliable.

## Changes

### `COMPOSER_ALLOW_SUPERUSER=1` — fixes the worker crash loop
FrankenPHP containers run as root. Composer silently disables **all plugins** in that case, including `symfony/runtime`. Without the plugin, `vendor/autoload_runtime.php` is never generated and every `php bin/console` call crashes:
```
LogicException: Symfony Runtime is missing.
```
Setting `COMPOSER_ALLOW_SUPERUSER=1` re-enables plugins. `--no-scripts` is also removed (belt-and-suspenders) so `post-autoload-dump` fires through the full `post-install-cmd` chain.

### `app` + `worker` Dockerfile stages — lean worker image
The old worker built the full `prod` target (Vue SPA + Caddy config included) and threw it away to run `php bin/console`. New structure:

```
frontend  →  base  →  app  →  prod    (FrankenPHP server + SPA)
                           →  worker  (pure PHP consumer, no SPA, no Caddy)
```

The `worker` stage inherits from `app`, so the SPA build artefacts and Caddyfile never land in the worker image.

### Migration race condition fixed
Both the `back` and `worker` services previously ran `doctrine:migrations:migrate` in their entrypoints simultaneously on every deploy. Doctrine's advisory lock made one of them fail. Now only `back` (the `prod` stage entrypoint) runs migrations. The worker entrypoint skips migrations entirely.

### `worker/railway.json` — worker can never permanently die
- Targets the new `worker` build stage (`dockerBuildTarget: "worker"`)
- `startCommand` removed — the CMD in the Dockerfile is the single source of truth
- `restartPolicyMaxRetries` removed — with `ALWAYS` restart policy, a cap means Railway permanently kills the worker after N rapid crashes; the consumer must restart unconditionally

### `.dockerignore` (new)
Excludes `vendor/`, `node_modules/`, `var/`, tests, JWT keys and dev-only files from the build context, speeding up all three Railway service builds.

### Composer pinned to `2.7`
Was `composer:latest`, now pinned for reproducible builds.

## Merge order

> This PR should be merged **after** #82 (the standalone `COMPOSER_ALLOW_SUPERUSER` hotfix). Both target `main`; once #82 lands this branch can be rebased cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_0135GbyyGAUQKbNBgBUwp2fr)_