### PR TITLE
fix(deploy): resilient entrypoints, health check, correct deploy order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["php", "bin/console", "messenger:consume", "async", "scheduler_default", \
-     "--time-limit=3600", "--memory-limit=128M", "-vv"]
+     "--time-limit=3600", "--memory-limit=128M"]

--- a/back/worker-entrypoint.sh
+++ b/back/worker-entrypoint.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
-set -e
 
-# Generate JWT keypair if missing — needed for the DI container to compile
-# (the back service owns key generation; this is a fallback for cold starts)
+# Generate JWT keypair if missing — the back service owns key generation;
+# this is a fallback so the DI container compiles on cold starts.
 if [ ! -f config/jwt/private.pem ]; then
     echo "[worker] Generating JWT keypair..."
-    php bin/console lexik:jwt:generate-keypair --no-interaction
+    php bin/console lexik:jwt:generate-keypair --no-interaction \
+        || echo "[worker] Warning: JWT keygen failed"
 fi
 
 echo "[worker] Warming up Symfony cache..."
-php bin/console cache:warmup --env=prod
+php bin/console cache:warmup --env=prod \
+    || echo "[worker] Warning: cache warmup failed, continuing..."
 
 echo "[worker] Starting Messenger consumer..."
 exec "$@"


### PR DESCRIPTION
Four root causes of the 502 / log-spam:

1. docker-entrypoint.sh (back) used set -e — cache:warmup or migrations failing exited the script before exec frankenphp. Fix: removed set -e; each step uses || echo "Warning…".

2. worker-entrypoint.sh had the same set -e bug — cache:warmup failure killed the worker before messenger:consume started. Fix: same pattern as the back entrypoint.

3. No Railway health check — traffic was routed to the container during the 30-120 s startup window before FrankenPHP was listening. Fix: GET /health → {"status":"ok"} (no JWT, no DB), health firewall (security: false), healthcheckPath + healthcheckTimeout in railway.json.

4. Worker ran with -vv, causing Zenstruck Monitor's normal per-heartbeat cache stampede-prevention log ("Lock acquired, now computing item zenstruck_messenger_monitor.worker.*") to flood production output. Fix: removed -vv from the messenger:consume CMD.

Deploy order: deploy-worker and deploy-back merged into a single deploy-api job — worker first, then backend.

https://claude.ai/code/session_014WEynZ9j4yfThgUbXy6NWw