### PR TITLE
Add cache table and improve worker restart resilience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY back/worker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["sh", "-c", "while true; do php bin/console messenger:consume async scheduler_default --time-limit=3600 --memory-limit=128M; echo '[worker] Restarting messenger consumer...'; done"]
+CMD ["sh", "-c", "while true; do timeout 4200 php bin/console messenger:consume async scheduler_default --time-limit=3600 --memory-limit=128M; echo \"[worker] Restarting messenger consumer at $(date -u +%Y-%m-%dT%H:%M:%SZ)...\"; sleep 2; done"]
 
 # ── Stage 5: Production server (app + SPA + FrankenPHP/Caddy) — DEFAULT TARGET ─
 FROM app AS prod

--- a/back/migrations/Version20260518000000.php
+++ b/back/migrations/Version20260518000000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260518000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create cache_items table required by cache.adapter.doctrine_dbal';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE cache_items (
+                item_id       VARCHAR(255) NOT NULL,
+                item_data     BYTEA        NOT NULL,
+                item_lifetime INT          DEFAULT NULL,
+                item_time     INT          NOT NULL,
+                PRIMARY KEY (item_id)
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE cache_items');
+    }
+}

--- a/back/migrations/Version20260519000000.php
+++ b/back/migrations/Version20260519000000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recreate crawl_runs and crawl_jobs tables dropped by Version20260510164355; add DC2Type comment for volumes.isbn';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE crawl_runs (
+                id          VARCHAR(36)                 NOT NULL,
+                status      VARCHAR(16)                 NOT NULL DEFAULT 'running',
+                started_at  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                finished_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY (id)
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE crawl_jobs (
+                id          VARCHAR(36)                 NOT NULL,
+                run_id      VARCHAR(36)                 NOT NULL,
+                status      VARCHAR(16)                 NOT NULL DEFAULT 'pending',
+                finished_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY (id)
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX IDX_7E23573484E3FEC4 ON crawl_jobs (run_id)');
+        $this->addSql('CREATE INDEX idx_crawl_jobs_run_status ON crawl_jobs (run_id, status)');
+        $this->addSql('ALTER TABLE crawl_jobs ADD CONSTRAINT fk_crawl_jobs_run FOREIGN KEY (run_id) REFERENCES crawl_runs (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->addSql("COMMENT ON COLUMN volumes.isbn IS '(DC2Type:isbn)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crawl_jobs DROP CONSTRAINT fk_crawl_jobs_run');
+        $this->addSql('DROP TABLE crawl_jobs');
+        $this->addSql('DROP TABLE crawl_runs');
+        $this->addSql("COMMENT ON COLUMN volumes.isbn IS NULL");
+    }
+}

--- a/back/src/Manga/Infrastructure/Doctrine/Type/IsbnType.php
+++ b/back/src/Manga/Infrastructure/Doctrine/Type/IsbnType.php
@@ -50,4 +50,9 @@ final class IsbnType extends StringType
 
         return $platform->getStringTypeDeclarationSQL($column);
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
     build:
       context: ./back
       dockerfile: Dockerfile.dev
-    command: sh -c 'while true; do php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv; echo "[worker] Restarting messenger consumer..."; done'
+    command: sh -c 'while true; do timeout 4200 php bin/console messenger:consume async scheduler_default --time-limit=3600 -vv; echo "[worker] Restarting messenger consumer at $(date -u +%Y-%m-%dT%H:%M:%SZ)..."; sleep 2; done'
     restart: unless-stopped
     env_file:
       - ./back/.env.local


### PR DESCRIPTION
## Summary
This PR adds database infrastructure for Symfony's Doctrine DBAL cache adapter and improves the worker container's restart behavior with better timeout handling and logging.

## Key Changes

- **New migration `Version20260518000000`**: Creates `cache_items` table required by `cache.adapter.doctrine_dbal` with columns for item ID, data (bytea), lifetime, and timestamp.

- **New migration `Version20260519000000`**: Recreates `crawl_runs` and `crawl_jobs` tables that were previously dropped, restoring the schema with proper foreign key constraints and indexes.

- **Worker container improvements**:
  - Added `timeout 4200` wrapper around the messenger consumer command (4200s = 70 minutes, allowing 10 minutes buffer beyond the 3600s time limit for graceful shutdown)
  - Enhanced restart logging with ISO 8601 UTC timestamps
  - Added 2-second sleep between restarts to prevent rapid restart loops
  - Applied same improvements to both production Dockerfile and development docker-compose.yml

## Implementation Details

The migrations follow Doctrine conventions with proper DDL for PostgreSQL. The worker timeout ensures the process terminates cleanly before the container orchestration layer forcefully kills it, preventing orphaned messenger processes. The timestamp logging aids in debugging worker lifecycle issues in production logs.

https://claude.ai/code/session_01HoW9pdmc9RZibn8HjNCumT