### PR TITLE
Restore crawl_runs and crawl_jobs tables dropped by migration

### DIFF
--- a/back/config/packages/doctrine.yaml
+++ b/back/config/packages/doctrine.yaml
@@ -3,6 +3,9 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
         server_version: '17'
         profiling_collect_backtrace: '%kernel.debug%'
+        # Tables not mapped to ORM entities (managed via raw SQL or framework
+        # transports). Excluded so schema diff/validate never drops them.
+        schema_filter: '~^(?!crawl_runs$|crawl_jobs$|cache_items$|messenger_messages$).+~'
         types:
             isbn: App\Manga\Infrastructure\Doctrine\Type\IsbnType
     orm:

--- a/back/migrations/Version20260520000000.php
+++ b/back/migrations/Version20260520000000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260520000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recreate crawl_runs and crawl_jobs tables erroneously dropped by Version20260510164355';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE crawl_runs (
+                id          VARCHAR(36)                 NOT NULL,
+                status      VARCHAR(16)                 NOT NULL DEFAULT 'running',
+                started_at  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                finished_at TIMESTAMP WITHOUT TIME ZONE NULL,
+                PRIMARY KEY (id)
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE crawl_jobs (
+                id          VARCHAR(36)                 NOT NULL,
+                run_id      VARCHAR(36)                 NOT NULL,
+                status      VARCHAR(16)                 NOT NULL DEFAULT 'pending',
+                finished_at TIMESTAMP WITHOUT TIME ZONE NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_crawl_jobs_run FOREIGN KEY (run_id) REFERENCES crawl_runs(id) ON DELETE CASCADE
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX idx_crawl_jobs_run_status ON crawl_jobs (run_id, status)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE crawl_jobs');
+        $this->addSql('DROP TABLE crawl_runs');
+    }
+}


### PR DESCRIPTION
## Summary
Recreates the `crawl_runs` and `crawl_jobs` tables that were erroneously dropped by a previous migration (Version20260510164355), and configures Doctrine to exclude these tables from schema validation since they are managed via raw SQL rather than ORM entities.

## Changes
- **New migration (Version20260520000000)**: Recreates both tables with their original schema:
  - `crawl_runs`: stores crawl execution metadata (id, status, timestamps)
  - `crawl_jobs`: stores individual job records linked to runs via foreign key with cascade delete
  - Includes index on `(run_id, status)` for efficient querying
  
- **Doctrine configuration**: Added `schema_filter` to `doctrine.yaml` to exclude `crawl_runs`, `crawl_jobs`, `cache_items`, and `messenger_messages` from schema validation. These tables are managed outside the ORM and should never be dropped by `doctrine:schema:validate` or `doctrine:schema:update` commands.

## Implementation Details
- The migration is reversible (down method drops both tables)
- Foreign key constraint uses `ON DELETE CASCADE` to maintain referential integrity
- Schema filter uses a negative lookahead regex to preserve these four tables while validating all ORM-mapped entities

https://claude.ai/code/session_01KtLCx3xaaD2CDHpLNya5W8