### PR TITLE
Route transactional emails through async messenger worker

### DIFF
--- a/back/config/packages/messenger.yaml
+++ b/back/config/packages/messenger.yaml
@@ -34,9 +34,16 @@ framework:
             App\Notification\Application\Fetch\FetchRssFeedMessage: async
             App\Notification\Application\Fetch\FetchJikanNewsMessage: async
             App\Notification\Application\Discord\SendSchedulerDiscordSummaryMessage: async
+            # Transactional emails are sent by the worker so a slow/unreachable
+            # SMTP server never blocks the HTTP request that triggered them.
+            Symfony\Component\Mailer\Messenger\SendEmailMessage: async
 
 when@test:
     framework:
         messenger:
             transports:
                 async: 'in-memory://'
+            routing:
+                # Handle inline in tests so MailerAssertionsTrait collects the
+                # actual send (the in-memory async transport is never consumed).
+                Symfony\Component\Mailer\Messenger\SendEmailMessage: sync


### PR DESCRIPTION
## Summary
Configure Symfony's `SendEmailMessage` to be routed through the async messenger transport in production, while keeping it synchronous in tests to ensure `MailerAssertionsTrait` can collect sent emails.

## Changes
- **Production routing**: `SendEmailMessage` now routes to the `async` transport, preventing slow or unreachable SMTP servers from blocking HTTP requests that trigger email sends
- **Test routing**: Added explicit `sync` routing for `SendEmailMessage` in the `when@test:` environment so that the in-memory async transport is bypassed and emails are sent inline, allowing test assertions to verify actual sends
- Added clarifying comments explaining the rationale for each routing decision

## Implementation Details
This follows the established pattern in the codebase where long-running operations (RSS feed fetches, Jikan news fetches, Discord summaries) are already routed to async. Transactional emails now follow the same pattern to improve HTTP response times and resilience.

The test-specific routing ensures that existing mail assertion tests continue to work correctly without requiring manual consumption of the async transport queue.

https://claude.ai/code/session_01UrZ7F58TqGxjjVupBVmvNy