### PR TITLE
fix(back): add Brevo HTTP API mailer transport for blocked SMTP port

### DIFF
--- a/back/composer.json
+++ b/back/composer.json
@@ -15,6 +15,7 @@
         "lcobucci/jwt": "^5.0",
         "lexik/jwt-authentication-bundle": "^3.2",
         "nelmio/cors-bundle": "^2.6",
+        "symfony/brevo-mailer": "8.0.*",
         "symfony/console": "8.0.*",
         "symfony/doctrine-messenger": "8.0.*",
         "symfony/dotenv": "8.0.*",

--- a/back/composer.lock
+++ b/back/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9934d3219450635c257e88ac0b8b0686",
+    "content-hash": "45e71f7ae29d0345a7531b8d2e2400d7",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2168,6 +2168,76 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/brevo-mailer",
+            "version": "v8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/brevo-mailer.git",
+                "reference": "ba5d44aa012a948810dcdcc69ccb53f4b4e040bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/brevo-mailer/zipball/ba5d44aa012a948810dcdcc69ccb53f4b4e040bb",
+                "reference": "ba5d44aa012a948810dcdcc69ccb53f4b4e040bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/mailer": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/webhook": "^7.4|^8.0"
+            },
+            "type": "symfony-mailer-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\Bridge\\Brevo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pierre Tanguy",
+                    "homepage": "https://github.com/petanguy"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Brevo Mailer Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/brevo-mailer/tree/v8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-04T07:36:47+00:00"
         },
         {
             "name": "symfony/cache",
@@ -10086,5 +10156,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/brevo-smtp.md
+++ b/docs/brevo-smtp.md
@@ -1,4 +1,4 @@
-# Brevo as SMTP provider
+# Brevo as email provider
 
 This document explains how to send Ziggytheque's transactional emails (email
 verification, password reset, account-approved, and the "new chapters" follow
@@ -22,37 +22,57 @@ framework:
         dsn: '%env(MAILER_DSN)%'
 ```
 
-Two processes send mail, so **both** must receive the Brevo DSN:
-
-| Process | Container | Sends |
-|---|---|---|
-| `back`   | FrankenPHP | verification / password-reset / account-approved emails (synchronous, during the HTTP request) |
-| `worker` | Messenger consumer | "new chapters" follow notifications (from the crawl) |
+`SendEmailMessage` is routed to the `async` Messenger transport, so every email
+— auth (verification / password-reset / account-approved) and the "new
+chapters" follow notifications — is delivered by the **worker** container, never
+during the HTTP request. The `worker` service therefore needs the same
+`MAILER_DSN` as `back`.
 
 Default (local): `MAILER_DSN=smtp://mailer:1025` → Mailpit, UI at <http://localhost:8025>.
 
+Brevo offers two transports. **Prefer the HTTP API transport** — it talks to
+Brevo over HTTPS (port 443), which no cloud platform blocks. The SMTP transport
+is a fallback for when the API cannot be used.
+
 ---
 
-## 2. Get your Brevo SMTP credentials
+## 2. Get your Brevo credentials
 
 1. Create a free account at <https://www.brevo.com> (the free plan allows 300
    emails/day).
-2. In the dashboard open **SMTP & API → SMTP**.
-3. Note the connection details shown there:
-   - **Server:** `smtp-relay.brevo.com`
-   - **Port:** `587` (STARTTLS — recommended)
-   - **Login:** your Brevo login — an email address.
-4. Click **Generate a new SMTP key** and copy it. This key is the SMTP
-   *password* — it is shown only once.
+2. In the dashboard open **SMTP & API**:
+   - **API Keys** tab → **Generate a new API key** → copy the **API v3 key**.
+     This is what the recommended HTTP API transport uses.
+   - **SMTP** tab → note the server `smtp-relay.brevo.com` and your login (an
+     email address), then **Generate a new SMTP key**. Only the fallback SMTP
+     transport needs this. The key is shown once.
 
 ---
 
 ## 3. Build the `MAILER_DSN`
 
-Symfony's generic SMTP transport needs no extra package:
+### Recommended — Brevo HTTP API
+
+The `symfony/brevo-mailer` bridge is already a project dependency, so no extra
+install is needed. Use the **API v3 key** from step 2:
+
+```dotenv
+MAILER_DSN=brevo+api://KEY@default
+```
+
+This delivers over HTTPS (port 443). It is immune to the SMTP-port blocking
+that produces `Connection could not be established` / connection-timeout
+errors on platforms such as Railway.
+
+### Fallback — generic SMTP
+
+If you must use SMTP, point at `smtp-relay.brevo.com`. **Use port `2525`, not
+`587`** — many platforms (Railway included) block outbound `587`, which
+surfaces as a connection timeout. Port `2525` is Brevo's documented
+alternative and carries the same STARTTLS traffic.
 
 ```
-smtp://<LOGIN>:<SMTP_KEY>@smtp-relay.brevo.com:587
+smtp://<LOGIN>:<SMTP_KEY>@smtp-relay.brevo.com:2525
 ```
 
 > **URL-encode special characters.** The login is an email address, so its `@`
@@ -62,7 +82,7 @@ smtp://<LOGIN>:<SMTP_KEY>@smtp-relay.brevo.com:587
 Example — login `mailer@ziggytheque.com`, key `xsmtpsib-abc123`:
 
 ```
-MAILER_DSN=smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:587
+MAILER_DSN=smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:2525
 ```
 
 ---
@@ -88,7 +108,7 @@ services:
 ```yaml
 # docker-compose.yml — back service AND worker service
 environment:
-  MAILER_DSN: "smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:587"
+  MAILER_DSN: "brevo+api://KEY@default"
 ```
 
 Then `docker compose up -d back worker` (or `make dev`).
@@ -103,7 +123,7 @@ environment:
 
 ```dotenv
 # .env  (project root, git-ignored)
-MAILER_DSN=smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:587
+MAILER_DSN=brevo+api://KEY@default
 ```
 
 ### Bare-metal / non-Docker backend
@@ -111,7 +131,7 @@ MAILER_DSN=smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:
 Put it in `back/.env.local` (git-ignored, overrides `back/.env`):
 
 ```dotenv
-MAILER_DSN=smtp://mailer%40ziggytheque.com:xsmtpsib-abc123@smtp-relay.brevo.com:587
+MAILER_DSN=brevo+api://KEY@default
 ```
 
 ---
@@ -157,27 +177,20 @@ which shows every accepted/blocked message.
 
 | Symptom | Cause / fix |
 |---|---|
-| `Connection could not be established` | Wrong host/port, or the platform blocks port 587 — try `2525`. |
-| `535 Authentication failed` | Wrong login or SMTP key; regenerate the key. Check the `@` in the login is `%40` in the DSN. |
+| `Connection could not be established` / `Connection timed out` | The platform blocks the SMTP port. Switch to the **HTTP API** transport (`brevo+api://KEY@default`), or change the SMTP port from `587` to `2525`. |
+| `535 Authentication failed` | Wrong credentials. For SMTP: regenerate the SMTP key and check the `@` in the login is `%40`. For the API: check the **API v3** key (the SMTP key will not work for `brevo+api://`). |
 | Email accepted by Brevo but never delivered | Sender not verified — see section 5. Check the Brevo logs. |
 | Emails work locally but not in Docker | `MAILER_DSN` is still the Mailpit value in `docker-compose.yml` — see section 4. |
-| Auth emails silently missing | `AuthEmailListener` catches and logs delivery errors so a mail failure never breaks signup — check the `back` container logs. |
+| Auth emails silently missing | `AuthEmailListener` catches and logs delivery errors so a mail failure never breaks signup. The actual send runs in the `worker`; check its logs, and inspect failed sends with `php bin/console messenger:failed:show`. |
 
 ---
 
-## 8. Optional — the Brevo API transport
+## 8. The Brevo API transport — details
 
-For webhooks and richer delivery tracking you can use Brevo's HTTP API instead
-of SMTP via the official Symfony bridge:
+The HTTP API transport (`brevo+api://`, recommended above) is provided by the
+official `symfony/brevo-mailer` bridge, which is already declared in
+`back/composer.json`. Besides sidestepping SMTP-port blocking, it also unlocks
+Brevo's webhooks and richer delivery tracking should you need them later.
 
-```bash
-docker compose exec back composer require symfony/brevo-mailer
-```
-
-```dotenv
-# KEY = a Brevo API v3 key from SMTP & API → API Keys
-MAILER_DSN=brevo+api://KEY@default
-```
-
-The generic `smtp://` transport in section 3 is sufficient for this project;
-the bridge is only worth it if you later need delivery webhooks.
+No code or configuration change is required to switch transports — only the
+`MAILER_DSN` environment variable.


### PR DESCRIPTION
## Problem

`SendEmailMessage` fails in production:

```
Connection could not be established with host "smtp-relay.brevo.com:587":
stream_socket_client(): Unable to connect to smtp-relay.brevo.com:587 (Connection timed out)
```

The TCP connection to Brevo's SMTP relay on port **587** times out because the host platform (Railway) blocks outbound port 587. After 3 retries the message lands in the `failed` transport.

## Fix

- Add the `symfony/brevo-mailer` bridge (v8.0.0) so `MAILER_DSN` can use the `brevo+api://KEY@default` transport, which delivers over HTTPS (port 443) — immune to SMTP port blocking. Switching transports is purely DSN-driven; no code or config change needed.
- Rewrite `docs/brevo-smtp.md` to recommend the HTTP API DSN as primary, with **port 2525** SMTP as the fallback (replacing the timing-out 587). Also corrects the stale note that auth emails send synchronously during the HTTP request — they now go through the `async` worker.

## Required follow-up (runtime config)

The fix is dormant until `MAILER_DSN` is updated. In Railway, for **both** the `back` and `worker` services, set:

```
MAILER_DSN=brevo+api://KEY@default
```

`KEY` is a Brevo **API v3 key** (not the SMTP key). Then redeploy both services and re-queue the failed message with `php bin/console messenger:failed:retry`.

## Tests

No tests added — this change touches only a Composer dependency and documentation, with no production endpoint, entity, or handler affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrcMZJJHnfCbr95hayun8K)_