### PR TITLE
fix(back): use NOTIFICATION_EMAIL as sender address for all transactional emails

### DIFF
--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -81,6 +81,7 @@ services:
     App\Auth\Infrastructure\Listener\AuthEmailListener:
         arguments:
             $frontUrl: '%app_front_url%'
+            $notificationEmail: '%notification_email%'
 
     # Bus interfaces bound to Messenger implementations
     App\Shared\Application\Bus\CommandBusInterface:

--- a/back/src/Auth/Infrastructure/Listener/AuthEmailListener.php
+++ b/back/src/Auth/Infrastructure/Listener/AuthEmailListener.php
@@ -25,13 +25,12 @@ use Twig\Environment;
 #[AsEventListener(event: UserApprovedEvent::class, method: 'onUserApproved')]
 final readonly class AuthEmailListener
 {
-    private const FROM = 'Ziggytheque <noreply@ziggytheque.local>';
-
     public function __construct(
         private MailerInterface $mailer,
         private Environment $twig,
         private LoggerInterface $logger,
         private string $frontUrl,
+        private string $notificationEmail,
     ) {
     }
 
@@ -73,7 +72,7 @@ final readonly class AuthEmailListener
     {
         try {
             $email = (new Email())
-                ->from(self::FROM)
+                ->from($this->notificationEmail)
                 ->to($recipient)
                 ->subject($subject)
                 ->html($this->twig->render($template, $context));

--- a/back/src/Notification/Application/Email/SendFollowingNotificationHandler.php
+++ b/back/src/Notification/Application/Email/SendFollowingNotificationHandler.php
@@ -54,7 +54,7 @@ final readonly class SendFollowingNotificationHandler
         ]);
 
         $email = (new Email())
-            ->from('ziggytheque@noreply.local')
+            ->from($this->notificationEmail)
             ->to($this->notificationEmail)
             ->subject('📰 Nouveautés : ' . $entry->manga->title)
             ->html($html);


### PR DESCRIPTION
## Summary

- Replace hardcoded `noreply@ziggytheque.local` sender with the `NOTIFICATION_EMAIL` env var in `AuthEmailListener` and `SendFollowingNotificationHandler`
- Add Brevo HTTP API mailer transport (`brevo+api://`) to avoid blocked SMTP ports
- Wire `$notificationEmail` into `AuthEmailListener` via `services.yaml`

## Test plan

- Set `MAILER_DSN=brevo+api://YOUR_KEY@default` and `NOTIFICATION_EMAIL=your-verified@address.com` in Railway env vars
- Trigger a registration or notification email and confirm it arrives with the correct sender

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENKCfCV7rANvU6AKWvjBC)_