### PR TITLE
Refactor production deployment to manual tag-based workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,9 +1,15 @@
 name: Deploy — Production
 
+# Manually triggered. Pick a release tag (e.g. v1.4.0) and deploy that exact
+# revision to Railway. Merging a PR to main does NOT trigger this workflow —
+# create a release with the "Release" workflow first, then run this one.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (e.g. v1.4.0)'
+        required: true
+        type: string
 
 env:
   RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
@@ -11,17 +17,35 @@ env:
   RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_PRODUCTION_ENVIRONMENT_ID }}
 
 # ---------------------------------------------------------------------------
-# Quality gate — identical to staging; every deploy must pass all checks
-# before the approval gate is presented
+# Quality gate — every gate is re-run against the selected tag so we never
+# deploy a revision that does not pass CI.
 # ---------------------------------------------------------------------------
 
 jobs:
+
+  # --- Verify the tag exists -------------------------------------------------
+
+  verify-tag:
+    name: "Gate: Verify tag exists"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Check tag exists
+        run: |
+          if ! git rev-parse --verify "refs/tags/${{ inputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag '${{ inputs.tag }}' does not exist. Run the Release workflow first."
+            exit 1
+          fi
+          echo "Deploying tag ${{ inputs.tag }} ($(git rev-parse refs/tags/${{ inputs.tag }}))"
 
   # --- Backend: code style ---------------------------------------------------
 
   phpcs:
     name: "Gate: PHP_CodeSniffer"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: back
@@ -30,6 +54,8 @@ jobs:
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE || 'ci-jwt-passphrase' }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -48,6 +74,7 @@ jobs:
   deptrac:
     name: "Gate: Deptrac"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: back
@@ -56,6 +83,8 @@ jobs:
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE || 'ci-jwt-passphrase' }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -74,6 +103,7 @@ jobs:
   phpstan:
     name: "Gate: PHPStan"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: back
@@ -97,6 +127,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -123,6 +155,7 @@ jobs:
   db-migrations:
     name: "Gate: DB Migrations"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: back
@@ -146,6 +179,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -170,6 +205,7 @@ jobs:
   tests:
     name: "Gate: PHPUnit"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: back
@@ -193,6 +229,8 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -219,11 +257,14 @@ jobs:
   frontend:
     name: "Gate: Frontend (vue-tsc + ESLint)"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     defaults:
       run:
         working-directory: front
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -238,8 +279,11 @@ jobs:
   docker-build:
     name: "Gate: Docker Build (prod + frontend)"
     runs-on: ubuntu-latest
+    needs: [verify-tag]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - uses: docker/setup-buildx-action@v4
       - name: Build backend prod stage
         uses: docker/build-push-action@v7
@@ -259,44 +303,17 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ---------------------------------------------------------------------------
-  # Gate 1: approve the release — all quality gates must pass first.
-  # The release tag is created immediately after this approval so reviewers
-  # can inspect it before the production deployment is authorised.
-  # ---------------------------------------------------------------------------
-
-  approve-release:
-    name: "Approval Gate: Release"
-    runs-on: ubuntu-latest
-    environment: release
-    needs: [phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
-    steps:
-      - run: echo "Release approved — creating tag and release notes"
-
-  # ---------------------------------------------------------------------------
-  # Release — tag + GitHub release notes created right after release approval,
-  # before anything is deployed to production.
-  # ---------------------------------------------------------------------------
-
-  release:
-    name: "Publish Release"
-    needs: [approve-release]
-    uses: Floberrot/Ziggytheque/.github/workflows/release.yml@main
-    secrets: inherit
-    permissions:
-      contents: write
-
-  # ---------------------------------------------------------------------------
-  # Gate 2: approve the production deployment — release must exist first so
-  # the approver can review the exact tag that will be deployed.
+  # Approval gate — all quality gates must pass, then a reviewer must approve
+  # the `production` environment before Railway is touched.
   # ---------------------------------------------------------------------------
 
   approve:
     name: "Approval Gate: Production"
     runs-on: ubuntu-latest
     environment: production
-    needs: [release]
+    needs: [phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
     steps:
-      - run: echo "Production deployment approved — proceeding"
+      - run: echo "Production deployment of ${{ inputs.tag }} approved — proceeding"
 
   # ---------------------------------------------------------------------------
   # Deploy to production — single API job: worker first (messenger:consume),
@@ -308,9 +325,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [approve]
     env:
-      COMMIT_MSG: ${{ github.event.head_commit.message }}
+      DEPLOY_MSG: "Deploy ${{ inputs.tag }}"
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy worker service (messenger:consume)
@@ -322,7 +341,7 @@ jobs:
             railway up \
               --service ziggytheque-worker \
               --ci \
-              -m "Deploy ${{ github.sha }} — $COMMIT_MSG" && break
+              -m "$DEPLOY_MSG" && break
             echo "Attempt $attempt failed — retrying in 30s..."
             sleep 30
           done
@@ -333,7 +352,7 @@ jobs:
             railway up \
               --service ziggytheque-back \
               --ci \
-              -m "Deploy ${{ github.sha }} — $COMMIT_MSG" && break
+              -m "$DEPLOY_MSG" && break
             echo "Attempt $attempt failed — retrying in 30s..."
             sleep 30
           done
@@ -344,18 +363,20 @@ jobs:
     needs: [approve]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy frontend service
         working-directory: front
         env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DEPLOY_MSG: "Deploy ${{ inputs.tag }}"
         run: |
           for attempt in 1 2; do
             railway up \
               --service ziggytheque-front \
               --ci \
-              -m "Deploy ${{ github.sha }} — $COMMIT_MSG" && break
+              -m "$DEPLOY_MSG" && break
             echo "Attempt $attempt failed — retrying in 30s..."
             sleep 30
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 name: Release
 
-# Called automatically by deploy-production.yml after all services deploy successfully.
-# Can also be triggered manually as a fallback.
+# Manually triggered: computes the next semver tag from the commits between
+# the latest existing tag and HEAD on the current branch, then creates a
+# GitHub release with auto-generated notes. Does NOT deploy.
 on:
-  workflow_call: {}
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason for manual release'
+        description: 'Reason for this release'
         required: false
         default: 'Manual release'
 


### PR DESCRIPTION
## Summary

Restructure the production deployment workflow from automatic push-triggered to manual tag-based, decoupling release creation from deployment. The `deploy-production.yml` workflow now accepts a release tag as input, re-runs all quality gates against that specific tag, and deploys only after explicit approval. The `release.yml` workflow becomes a standalone manual trigger for creating releases.

## Key Changes

- **deploy-production.yml**: Changed trigger from `push: [main]` to `workflow_dispatch` with required `tag` input parameter
  - Added `verify-tag` job to validate the tag exists before proceeding
  - All quality gate jobs (`phpcs`, `deptrac`, `phpstan`, `db-migrations`, `tests`, `frontend`, `docker-build`) now depend on `verify-tag` and check out the specified tag via `ref: ${{ inputs.tag }}`
  - Removed `approve-release` and `release` jobs — release creation is now separate
  - Simplified approval gate to depend directly on quality gates (not release job)
  - Updated deployment jobs to check out the tag and use `DEPLOY_MSG` environment variable instead of `github.sha` and commit message

- **release.yml**: Changed from `workflow_call` (automatic, called by deploy-production) to standalone `workflow_dispatch`
  - Updated description to clarify it creates releases without deploying
  - Adjusted input description for clarity

## Implementation Details

- Tag verification uses `git rev-parse --verify "refs/tags/${{ inputs.tag }}"` to ensure the tag exists before any CI runs
- All checkout steps now include `ref: ${{ inputs.tag }}` to guarantee every gate and deployment uses the exact tagged revision
- Deployment messages now use the tag name directly (`Deploy v1.4.0`) instead of commit SHA, improving clarity in Railway logs
- The workflow enforces a strict sequence: create release first (via Release workflow), then manually trigger production deployment with the tag

This change ensures that:
1. Only tagged, released versions can be deployed to production
2. All quality gates are re-verified against the exact tag being deployed
3. Reviewers can inspect the release before approving production deployment
4. Deployment is fully manual and auditable

https://claude.ai/code/session_01NNkVJ3jsQshW31TkHb1unf