### PR TITLE
ci(deploy): pick deploy tag via the native Run-workflow dropdown

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,15 +1,11 @@
 name: Deploy — Production
 
-# Manually triggered. Pick a release tag (e.g. v1.4.0) and deploy that exact
-# revision to Railway. Merging a PR to main does NOT trigger this workflow —
-# create a release with the "Release" workflow first, then run this one.
+# Manually triggered. To deploy: click "Run workflow", switch the
+# "Use workflow from" dropdown to the "Tags" tab, pick the release tag.
+# GitHub fetches the tag list live from its API — nothing to maintain here.
+# Merging a PR to main does NOT trigger this workflow.
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to deploy (e.g. v1.4.0)'
-        required: true
-        type: string
 
 env:
   RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
@@ -23,29 +19,26 @@ env:
 
 jobs:
 
-  # --- Verify the tag exists -------------------------------------------------
+  # --- Guard: must be dispatched from a tag, not a branch --------------------
 
-  verify-tag:
-    name: "Gate: Verify tag exists"
+  guard:
+    name: "Gate: Dispatched from a tag"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Check tag exists
+      - name: Check ref is a tag
         run: |
-          if ! git rev-parse --verify "refs/tags/${{ inputs.tag }}" >/dev/null 2>&1; then
-            echo "::error::Tag '${{ inputs.tag }}' does not exist. Run the Release workflow first."
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            echo "::error::This workflow must be dispatched from a tag. Open the Run workflow dialog, switch to the Tags tab, and pick a release tag (e.g. v2.0.5)."
             exit 1
           fi
-          echo "Deploying tag ${{ inputs.tag }} ($(git rev-parse refs/tags/${{ inputs.tag }}))"
+          echo "Deploying tag ${{ github.ref_name }} (${{ github.sha }})"
 
   # --- Backend: code style ---------------------------------------------------
 
   phpcs:
     name: "Gate: PHP_CodeSniffer"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: back
@@ -54,8 +47,6 @@ jobs:
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE || 'ci-jwt-passphrase' }}
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -74,7 +65,7 @@ jobs:
   deptrac:
     name: "Gate: Deptrac"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: back
@@ -83,8 +74,6 @@ jobs:
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE || 'ci-jwt-passphrase' }}
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -103,7 +92,7 @@ jobs:
   phpstan:
     name: "Gate: PHPStan"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: back
@@ -127,8 +116,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -155,7 +142,7 @@ jobs:
   db-migrations:
     name: "Gate: DB Migrations"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: back
@@ -179,8 +166,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -205,7 +190,7 @@ jobs:
   tests:
     name: "Gate: PHPUnit"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: back
@@ -229,8 +214,6 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -257,14 +240,12 @@ jobs:
   frontend:
     name: "Gate: Frontend (vue-tsc + ESLint)"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     defaults:
       run:
         working-directory: front
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -279,11 +260,9 @@ jobs:
   docker-build:
     name: "Gate: Docker Build (prod + frontend)"
     runs-on: ubuntu-latest
-    needs: [verify-tag]
+    needs: [guard]
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - uses: docker/setup-buildx-action@v4
       - name: Build backend prod stage
         uses: docker/build-push-action@v7
@@ -313,7 +292,7 @@ jobs:
     environment: production
     needs: [phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
     steps:
-      - run: echo "Production deployment of ${{ inputs.tag }} approved — proceeding"
+      - run: echo "Production deployment of ${{ github.ref_name }} approved — proceeding"
 
   # ---------------------------------------------------------------------------
   # Deploy to production — single API job: worker first (messenger:consume),
@@ -325,11 +304,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [approve]
     env:
-      DEPLOY_MSG: "Deploy ${{ inputs.tag }}"
+      DEPLOY_MSG: "Deploy ${{ github.ref_name }}"
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy worker service (messenger:consume)
@@ -363,14 +340,12 @@ jobs:
     needs: [approve]
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag }}
       - name: Install Railway CLI
         run: npm install -g @railway/cli
       - name: Deploy frontend service
         working-directory: front
         env:
-          DEPLOY_MSG: "Deploy ${{ inputs.tag }}"
+          DEPLOY_MSG: "Deploy ${{ github.ref_name }}"
         run: |
           for attempt in 1 2; do
             railway up \


### PR DESCRIPTION
## Summary

Replace the manual `tag` string input with GitHub's native ref picker. The "Use workflow from" dropdown in the Run-workflow dialog already lists every branch and tag, populated live from the GitHub API and sorted by date — no YAML to maintain, no risk of typos.

## How to deploy now

1. Actions → **Deploy — Production** → **Run workflow**
2. In the **Use workflow from** dropdown, switch to the **Tags** tab
3. Pick the release tag (e.g. `v2.0.5`) → **Run workflow**

## Changes

- Remove the `tag` input from `workflow_dispatch`.
- Replace the `verify-tag` job with a `guard` job that fails fast if the workflow was dispatched from a branch instead of a tag (checks `github.ref_type == 'tag'`).
- All `actions/checkout@v5` use the default ref (= the dispatched tag), so gates and the Railway deploy operate on the exact tagged revision.
- Deploy messages now use `${{ github.ref_name }}` (the tag name).

## Test plan

- [ ] Open Actions → Deploy — Production → Run workflow, switch to Tags tab, confirm tags are listed.
- [ ] Dispatching from a branch fails at the `guard` job with the explicit error message.
- [ ] Dispatching from an existing tag runs all gates against that tag and deploys it to Railway after approval.

https://claude.ai/code/session_01NNkVJ3jsQshW31TkHb1unf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNkVJ3jsQshW31TkHb1unf)_