### PR TITLE
feat(back,front): user-managed preferences with self-serve test + anonymized admin view

### DIFF
--- a/back/config/packages/messenger.yaml
+++ b/back/config/packages/messenger.yaml
@@ -34,6 +34,7 @@ framework:
             App\Notification\Application\Fetch\FetchRssFeedMessage: async
             App\Notification\Application\Fetch\FetchJikanNewsMessage: async
             App\Notification\Application\Discord\SendSchedulerDiscordSummaryMessage: async
+            App\Notification\Application\Test\SendTestNotificationMessage: async
             # Transactional emails are sent by the worker so a slow/unreachable
             # SMTP server never blocks the HTTP request that triggered them.
             Symfony\Component\Mailer\Messenger\SendEmailMessage: async

--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -172,6 +172,13 @@ services:
         arguments:
             $notificationEmail: '%notification_email%'
 
+    App\Notification\Application\Test\SendTestNotificationHandler:
+        arguments:
+            $notificationEmail: '%notification_email%'
+
+    App\Notification\Domain\TestNotificationRecipientResolverInterface:
+        alias: App\Auth\Infrastructure\Notification\DoctrineTestNotificationRecipientResolver
+
     App\Notification\Domain\DiscordNotifierInterface:
         alias: App\Notification\Infrastructure\Discord\DiscordNotifier
 

--- a/back/src/Auth/Application/Admin/ListUsers/UserListResult.php
+++ b/back/src/Auth/Application/Admin/ListUsers/UserListResult.php
@@ -12,6 +12,6 @@ final class UserListResult extends PaginatedResult
 {
     protected function serializeItems(): array
     {
-        return array_map(static fn (User $user) => $user->toArray(), $this->items);
+        return array_map(static fn (User $user) => $user->toAdminArray(), $this->items);
     }
 }

--- a/back/src/Auth/Application/Admin/UpdateUser/UpdateUserCommand.php
+++ b/back/src/Auth/Application/Admin/UpdateUser/UpdateUserCommand.php
@@ -14,8 +14,6 @@ final readonly class UpdateUserCommand
         public ?string $displayName,
         public ?UserStatusEnum $status,
         public ?NotificationChannelEnum $notificationChannel,
-        public ?string $notificationEmail,
-        public ?string $discordWebhookUrl,
     ) {
     }
 }

--- a/back/src/Auth/Application/Admin/UpdateUser/UpdateUserHandler.php
+++ b/back/src/Auth/Application/Admin/UpdateUser/UpdateUserHandler.php
@@ -33,10 +33,12 @@ final readonly class UpdateUserHandler
         }
 
         if ($command->notificationChannel !== null) {
+            // Preserve the user's saved destinations: the admin can change the
+            // channel but never sees or edits the actual email/webhook URL.
             $user->updateNotificationPreferences(
                 channel: $command->notificationChannel,
-                notificationEmail: $command->notificationEmail,
-                discordWebhookUrl: $command->discordWebhookUrl,
+                notificationEmail: $user->notificationEmail,
+                discordWebhookUrl: $user->discordWebhookUrl,
             );
         }
 

--- a/back/src/Auth/Domain/User.php
+++ b/back/src/Auth/Domain/User.php
@@ -153,4 +153,32 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
             'lastLoginAt'         => $this->lastLoginAt?->format('c'),
         ];
     }
+
+    /**
+     * Admin-safe serialization: the notification channel is visible, but the
+     * actual destination (email address or Discord webhook URL) is never
+     * leaked. The admin only needs to know which channel a user has picked,
+     * not the personal address behind it.
+     *
+     * @return array<string, mixed>
+     */
+    public function toAdminArray(): array
+    {
+        return [
+            'id'                     => $this->id,
+            'email'                  => $this->email,
+            'displayName'            => $this->displayName,
+            'role'                   => $this->role->value,
+            'status'                 => $this->status->value,
+            'notificationChannel'    => $this->notificationChannel->value,
+            'notificationConfigured' => match ($this->notificationChannel) {
+                NotificationChannelEnum::Email   => $this->notificationEmail !== null
+                    && $this->notificationEmail !== '',
+                NotificationChannelEnum::Discord => $this->discordWebhookUrl !== null
+                    && $this->discordWebhookUrl !== '',
+            },
+            'createdAt'              => $this->createdAt->format('c'),
+            'lastLoginAt'            => $this->lastLoginAt?->format('c'),
+        ];
+    }
 }

--- a/back/src/Auth/Infrastructure/Http/AdminUserController.php
+++ b/back/src/Auth/Infrastructure/Http/AdminUserController.php
@@ -57,7 +57,7 @@ final readonly class AdminUserController
         /** @var User $user */
         $user = $this->queryBus->ask(new GetUserQuery($id));
 
-        return new JsonResponse($user->toArray());
+        return new JsonResponse($user->toAdminArray());
     }
 
     #[Route('/{id}', methods: ['PATCH'])]
@@ -69,11 +69,9 @@ final readonly class AdminUserController
             displayName: $request->displayName,
             status: $request->status,
             notificationChannel: $request->notificationChannel,
-            notificationEmail: $request->notificationEmail,
-            discordWebhookUrl: $request->discordWebhookUrl,
         ));
 
-        return new JsonResponse($user->toArray());
+        return new JsonResponse($user->toAdminArray());
     }
 
     #[Route('/{id}/approve', methods: ['POST'])]

--- a/back/src/Auth/Infrastructure/Http/Request/UpdateUserRequest.php
+++ b/back/src/Auth/Infrastructure/Http/Request/UpdateUserRequest.php
@@ -15,11 +15,6 @@ final readonly class UpdateUserRequest
         public ?string $displayName = null,
         public ?UserStatusEnum $status = null,
         public ?NotificationChannelEnum $notificationChannel = null,
-        #[Assert\Email]
-        #[Assert\Length(max: 180)]
-        public ?string $notificationEmail = null,
-        #[Assert\Length(max: 500)]
-        public ?string $discordWebhookUrl = null,
     ) {
     }
 }

--- a/back/src/Auth/Infrastructure/Notification/DoctrineTestNotificationRecipientResolver.php
+++ b/back/src/Auth/Infrastructure/Notification/DoctrineTestNotificationRecipientResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Infrastructure\Notification;
+
+use App\Auth\Domain\UserRepositoryInterface;
+use App\Notification\Domain\TestNotificationRecipient;
+use App\Notification\Domain\TestNotificationRecipientResolverInterface;
+use App\Shared\Domain\Exception\NotFoundException;
+
+final readonly class DoctrineTestNotificationRecipientResolver implements TestNotificationRecipientResolverInterface
+{
+    public function __construct(private UserRepositoryInterface $userRepository)
+    {
+    }
+
+    public function resolve(string $userId): TestNotificationRecipient
+    {
+        $user = $this->userRepository->findById($userId);
+        if ($user === null) {
+            throw new NotFoundException('User', $userId);
+        }
+
+        return new TestNotificationRecipient(
+            user: $user,
+            displayName: $user->displayName,
+            channel: $user->notificationChannel->value,
+            notificationEmail: $user->notificationEmail,
+            discordWebhookUrl: $user->discordWebhookUrl,
+        );
+    }
+}

--- a/back/src/Notification/Application/Test/SendTestNotificationHandler.php
+++ b/back/src/Notification/Application/Test/SendTestNotificationHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Test;
+
+use App\Notification\Domain\Notification;
+use App\Notification\Domain\NotificationRepositoryInterface;
+use App\Notification\Domain\TestNotificationRecipient;
+use App\Notification\Domain\TestNotificationRecipientResolverInterface;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+use Twig\Environment;
+
+/**
+ * Sends a one-off "test" notification to the user's configured channel so they
+ * can verify their setup. Unlike regular notifications, a delivery failure
+ * here is surfaced back to the user via a Notification entity — they need
+ * actionable feedback to fix their preferences.
+ *
+ * The handler stays free of any Auth\Domain dependency: it resolves what it
+ * needs via TestNotificationRecipientResolverInterface, whose implementation
+ * lives in Auth\Infrastructure.
+ */
+#[AsMessageHandler]
+final readonly class SendTestNotificationHandler
+{
+    private const CHANNEL_EMAIL      = 'email';
+    private const CHANNEL_DISCORD    = 'discord';
+    private const DISCORD_COLOR_BLUE = 3_447_003;
+
+    public function __construct(
+        private TestNotificationRecipientResolverInterface $recipientResolver,
+        private NotificationRepositoryInterface $notificationRepository,
+        private MailerInterface $mailer,
+        private HttpClientInterface $httpClient,
+        private Environment $twig,
+        private LoggerInterface $logger,
+        private string $notificationEmail,
+    ) {
+    }
+
+    public function __invoke(SendTestNotificationMessage $message): void
+    {
+        $recipient = $this->recipientResolver->resolve($message->userId);
+
+        try {
+            match ($recipient->channel) {
+                self::CHANNEL_EMAIL   => $this->sendEmailTest($recipient),
+                self::CHANNEL_DISCORD => $this->sendDiscordTest($recipient),
+                default               => throw new TestNotificationConfigurationException(
+                    sprintf('Unknown channel "%s".', $recipient->channel),
+                ),
+            };
+        } catch (Throwable $exception) {
+            $this->logger->warning('Test notification delivery failed', [
+                'user_id' => $message->userId,
+                'channel' => $recipient->channel,
+                'error'   => $exception->getMessage(),
+            ]);
+
+            $this->notifyUserOfFailure($recipient, $exception);
+        }
+    }
+
+    private function sendEmailTest(TestNotificationRecipient $recipient): void
+    {
+        $address = $recipient->notificationEmail;
+        if ($address === null || $address === '') {
+            throw new TestNotificationConfigurationException('No notification email configured.');
+        }
+
+        $html = $this->twig->render('emails/notification_test.html.twig', [
+            'displayName' => $recipient->displayName,
+        ]);
+
+        $email = (new Email())
+            ->from($this->notificationEmail)
+            ->to($address)
+            ->subject('Ziggytheque — Test de notification')
+            ->text(sprintf('Bonjour %s, ceci est ton test.', $recipient->displayName))
+            ->html($html);
+
+        $this->mailer->send($email);
+    }
+
+    private function sendDiscordTest(TestNotificationRecipient $recipient): void
+    {
+        $webhook = $recipient->discordWebhookUrl;
+        if ($webhook === null || $webhook === '') {
+            throw new TestNotificationConfigurationException('No Discord webhook configured.');
+        }
+
+        $payload = [
+            'embeds' => [[
+                'title'       => '🔔 Test de notification',
+                'description' => sprintf('Bonjour %s, ceci est ton test.', $recipient->displayName),
+                'color'       => self::DISCORD_COLOR_BLUE,
+                'footer'      => ['text' => 'Ziggytheque'],
+                'timestamp'   => (new DateTimeImmutable())->format(DateTimeInterface::ATOM),
+            ]],
+        ];
+
+        $response = $this->httpClient->request('POST', $webhook, [
+            'json'    => $payload,
+            'timeout' => 5,
+        ]);
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw new TestNotificationConfigurationException(
+                sprintf('Discord webhook returned HTTP %d.', $status),
+            );
+        }
+    }
+
+    private function notifyUserOfFailure(TestNotificationRecipient $recipient, Throwable $exception): void
+    {
+        $channelLabel = $recipient->channel === self::CHANNEL_DISCORD ? 'Discord' : 'email';
+
+        $notification = new Notification(
+            id: Uuid::v4()->toRfc4122(),
+            type: 'test_failure',
+            message: sprintf(
+                'Le test de notification %s a échoué : %s',
+                $channelLabel,
+                $exception->getMessage(),
+            ),
+            owner: $recipient->user,
+        );
+
+        $this->notificationRepository->save($notification);
+    }
+}

--- a/back/src/Notification/Application/Test/SendTestNotificationMessage.php
+++ b/back/src/Notification/Application/Test/SendTestNotificationMessage.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Test;
+
+final readonly class SendTestNotificationMessage
+{
+    public function __construct(public string $userId)
+    {
+    }
+}

--- a/back/src/Notification/Application/Test/TestNotificationConfigurationException.php
+++ b/back/src/Notification/Application/Test/TestNotificationConfigurationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Test;
+
+use RuntimeException;
+
+final class TestNotificationConfigurationException extends RuntimeException
+{
+}

--- a/back/src/Notification/Domain/TestNotificationRecipient.php
+++ b/back/src/Notification/Domain/TestNotificationRecipient.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain;
+
+use App\Auth\Domain\User;
+
+/**
+ * Carrier for the data the test-notification handler needs to deliver a
+ * test message and persist a fallback Notification entity on failure.
+ *
+ * Lives in Notification\Domain so the application handler stays free of any
+ * Auth\Domain dependency: it only sees this VO and the channel string.
+ */
+final readonly class TestNotificationRecipient
+{
+    public function __construct(
+        public User $user,
+        public string $displayName,
+        public string $channel,
+        public ?string $notificationEmail,
+        public ?string $discordWebhookUrl,
+    ) {
+    }
+}

--- a/back/src/Notification/Domain/TestNotificationRecipientResolverInterface.php
+++ b/back/src/Notification/Domain/TestNotificationRecipientResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain;
+
+use App\Shared\Domain\Exception\NotFoundException;
+
+interface TestNotificationRecipientResolverInterface
+{
+    /** @throws NotFoundException when no user matches the given id */
+    public function resolve(string $userId): TestNotificationRecipient;
+}

--- a/back/src/Notification/Infrastructure/Http/NotificationTestController.php
+++ b/back/src/Notification/Infrastructure/Http/NotificationTestController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\Http;
+
+use App\Notification\Application\Test\SendTestNotificationMessage;
+use App\Shared\Domain\Security\CurrentUserProviderInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/me/notifications')]
+#[IsGranted('ROLE_USER')]
+final readonly class NotificationTestController
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+        private CurrentUserProviderInterface $currentUserProvider,
+    ) {
+    }
+
+    #[Route('/test', methods: ['POST'])]
+    public function send(): JsonResponse
+    {
+        $this->messageBus->dispatch(new SendTestNotificationMessage(
+            userId: $this->currentUserProvider->currentUserId(),
+        ));
+
+        return new JsonResponse(
+            ['message' => 'Test notification dispatched.'],
+            Response::HTTP_ACCEPTED,
+        );
+    }
+}

--- a/back/templates/emails/notification_test.html.twig
+++ b/back/templates/emails/notification_test.html.twig
@@ -1,0 +1,9 @@
+{% extends 'emails/auth/layout.html.twig' %}
+
+{% block title %}Test de notification — Ziggytheque{% endblock %}
+
+{% block content %}
+  <h1>Bonjour {{ displayName }},</h1>
+  <p>Ceci est ton test.</p>
+  <p class="muted">Si tu reçois cet email, c'est que ta configuration de notification est opérationnelle.</p>
+{% endblock %}

--- a/back/tests/Functional/Auth/ProfileControllerTest.php
+++ b/back/tests/Functional/Auth/ProfileControllerTest.php
@@ -52,4 +52,18 @@ final class ProfileControllerTest extends AbstractApiTestCase
         $response = $this->jsonRequest('PATCH', '/api/me/notifications', []);
         $this->assertJsonStatus(400, $response);
     }
+
+    // ── POST /api/me/notifications/test ───────────────────────────────────
+
+    public function testTestNotificationReturns202(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/me/notifications/test');
+        $this->assertSame(202, $response->getStatusCode());
+    }
+
+    public function testTestNotificationRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/me/notifications/test', auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
 }

--- a/back/tests/Unit/Auth/Domain/UserTest.php
+++ b/back/tests/Unit/Auth/Domain/UserTest.php
@@ -131,4 +131,39 @@ final class UserTest extends TestCase
         $this->assertArrayHasKey('status', $array);
         $this->assertArrayHasKey('notificationChannel', $array);
     }
+
+    public function testToAdminArrayMasksEmailAndDiscordWebhook(): void
+    {
+        $user = new User(
+            id: 'id-1',
+            email: 'user@example.com',
+            passwordHash: 'hash',
+            displayName: 'Alice',
+            notificationChannel: NotificationChannelEnum::Email,
+            notificationEmail: 'private@example.com',
+            discordWebhookUrl: 'https://discord.com/api/webhooks/x/y',
+        );
+
+        $array = $user->toAdminArray();
+
+        $this->assertArrayNotHasKey('notificationEmail', $array);
+        $this->assertArrayNotHasKey('discordWebhookUrl', $array);
+        $this->assertSame('email', $array['notificationChannel']);
+        $this->assertTrue($array['notificationConfigured']);
+    }
+
+    public function testToAdminArrayReportsUnconfiguredWhenChannelHasNoDestination(): void
+    {
+        $user = new User(
+            id: 'id-1',
+            email: 'user@example.com',
+            passwordHash: 'hash',
+            displayName: 'Alice',
+            notificationChannel: NotificationChannelEnum::Discord,
+            notificationEmail: 'private@example.com',
+            discordWebhookUrl: null,
+        );
+
+        $this->assertFalse($user->toAdminArray()['notificationConfigured']);
+    }
 }

--- a/back/tests/Unit/Notification/Application/Test/SendTestNotificationHandlerTest.php
+++ b/back/tests/Unit/Notification/Application/Test/SendTestNotificationHandlerTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Application\Test;
+
+use App\Auth\Domain\NotificationChannelEnum;
+use App\Auth\Domain\User;
+use App\Notification\Application\Test\SendTestNotificationHandler;
+use App\Notification\Application\Test\SendTestNotificationMessage;
+use App\Notification\Domain\Notification;
+use App\Notification\Domain\NotificationRepositoryInterface;
+use App\Notification\Domain\TestNotificationRecipient;
+use App\Notification\Domain\TestNotificationRecipientResolverInterface;
+use App\Shared\Domain\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface as MailerTransportException;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Twig\Environment;
+
+#[AllowMockObjectsWithoutExpectations]
+final class SendTestNotificationHandlerTest extends TestCase
+{
+    private TestNotificationRecipientResolverInterface&MockObject $recipientResolver;
+    private NotificationRepositoryInterface&MockObject $notificationRepository;
+    private MailerInterface&MockObject $mailer;
+    private HttpClientInterface&MockObject $httpClient;
+    private Environment&MockObject $twig;
+
+    protected function setUp(): void
+    {
+        $this->recipientResolver      = $this->createMock(TestNotificationRecipientResolverInterface::class);
+        $this->notificationRepository = $this->createMock(NotificationRepositoryInterface::class);
+        $this->mailer                 = $this->createMock(MailerInterface::class);
+        $this->httpClient             = $this->createMock(HttpClientInterface::class);
+        $this->twig                   = $this->createMock(Environment::class);
+
+        $this->twig->method('render')->willReturn('<html>body</html>');
+    }
+
+    public function testEmailSentSilentlyOnSuccess(): void
+    {
+        $this->recipientResolver->method('resolve')
+            ->willReturn($this->emailRecipient('user@example.com'));
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email): bool {
+                $this->assertSame('Ziggytheque — Test de notification', $email->getSubject());
+                $this->assertNotEmpty($email->getTo());
+                $this->assertSame('user@example.com', $email->getTo()[0]->getAddress());
+                $this->assertStringContainsString('ceci est ton test', (string) $email->getTextBody());
+                return true;
+            }));
+
+        $this->notificationRepository->expects($this->never())->method('save');
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testEmailFailureSurfacesAsUserNotification(): void
+    {
+        $recipient = $this->emailRecipient('user@example.com');
+        $this->recipientResolver->method('resolve')->willReturn($recipient);
+        $this->mailer->method('send')->willThrowException($this->mailerException());
+
+        $this->notificationRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (Notification $notif) use ($recipient): bool {
+                $this->assertSame('test_failure', $notif->type);
+                $this->assertSame($recipient->user, $notif->owner);
+                $this->assertStringContainsString('email', $notif->message);
+                return true;
+            }));
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testEmailMissingAddressCreatesFailureNotification(): void
+    {
+        $this->recipientResolver->method('resolve')->willReturn($this->emailRecipient(null));
+
+        $this->mailer->expects($this->never())->method('send');
+        $this->notificationRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (Notification $notif): bool {
+                $this->assertSame('test_failure', $notif->type);
+                $this->assertStringContainsString('email', $notif->message);
+                return true;
+            }));
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testDiscordSuccessSendsToWebhook(): void
+    {
+        $this->recipientResolver->method('resolve')
+            ->willReturn($this->discordRecipient('https://discord.com/api/webhooks/1/abc'));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(204);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://discord.com/api/webhooks/1/abc', $this->callback(function (array $opts): bool {
+                $this->assertArrayHasKey('json', $opts);
+                $this->assertArrayHasKey('embeds', $opts['json']);
+                return true;
+            }))
+            ->willReturn($response);
+
+        $this->notificationRepository->expects($this->never())->method('save');
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testDiscordNon2xxSurfacesAsUserNotification(): void
+    {
+        $this->recipientResolver->method('resolve')
+            ->willReturn($this->discordRecipient('https://discord.com/api/webhooks/1/abc'));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(404);
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->notificationRepository->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (Notification $notif): bool {
+                $this->assertSame('test_failure', $notif->type);
+                $this->assertStringContainsString('Discord', $notif->message);
+                return true;
+            }));
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testDiscordMissingWebhookCreatesFailureNotification(): void
+    {
+        $this->recipientResolver->method('resolve')->willReturn($this->discordRecipient(null));
+
+        $this->httpClient->expects($this->never())->method('request');
+        $this->notificationRepository->expects($this->once())->method('save');
+
+        $this->handler()(new SendTestNotificationMessage('user-1'));
+    }
+
+    public function testUnknownUserPropagatesNotFound(): void
+    {
+        $this->recipientResolver->method('resolve')
+            ->willThrowException(new NotFoundException('User', 'ghost'));
+
+        $this->expectException(NotFoundException::class);
+
+        $this->handler()(new SendTestNotificationMessage('ghost'));
+    }
+
+    private function handler(): SendTestNotificationHandler
+    {
+        return new SendTestNotificationHandler(
+            $this->recipientResolver,
+            $this->notificationRepository,
+            $this->mailer,
+            $this->httpClient,
+            $this->twig,
+            new NullLogger(),
+            'notifications@ziggytheque.fr',
+        );
+    }
+
+    private function emailRecipient(?string $address): TestNotificationRecipient
+    {
+        return new TestNotificationRecipient(
+            user: $this->makeUser(NotificationChannelEnum::Email, $address, null),
+            displayName: 'Alice',
+            channel: 'email',
+            notificationEmail: $address,
+            discordWebhookUrl: null,
+        );
+    }
+
+    private function discordRecipient(?string $webhook): TestNotificationRecipient
+    {
+        return new TestNotificationRecipient(
+            user: $this->makeUser(NotificationChannelEnum::Discord, null, $webhook),
+            displayName: 'Alice',
+            channel: 'discord',
+            notificationEmail: null,
+            discordWebhookUrl: $webhook,
+        );
+    }
+
+    private function makeUser(
+        NotificationChannelEnum $channel,
+        ?string $notificationEmail,
+        ?string $discordWebhookUrl,
+    ): User {
+        return new User(
+            id: 'user-1',
+            email: 'user@example.com',
+            passwordHash: 'hash',
+            displayName: 'Alice',
+            notificationChannel: $channel,
+            notificationEmail: $notificationEmail,
+            discordWebhookUrl: $discordWebhookUrl,
+        );
+    }
+
+    private function mailerException(): MailerTransportException
+    {
+        return new class extends RuntimeException implements MailerTransportException {
+            public function __construct()
+            {
+                parent::__construct('SMTP unreachable');
+            }
+
+            public function getDebug(): string
+            {
+                return '';
+            }
+
+            public function appendDebug(string $debug): void
+            {
+            }
+        };
+    }
+}

--- a/front/src/api/admin.ts
+++ b/front/src/api/admin.ts
@@ -29,8 +29,6 @@ export interface UpdateUserPayload {
   displayName?: string | null
   status?: User['status'] | null
   notificationChannel?: User['notificationChannel'] | null
-  notificationEmail?: string | null
-  discordWebhookUrl?: string | null
 }
 
 export async function patchUser(id: string, payload: UpdateUserPayload): Promise<User> {

--- a/front/src/api/auth.ts
+++ b/front/src/api/auth.ts
@@ -7,8 +7,12 @@ export interface User {
   role: 'ROLE_USER' | 'ROLE_ADMIN'
   status: 'pending_email_verification' | 'pending_admin_approval' | 'active' | 'disabled'
   notificationChannel: 'email' | 'discord'
-  notificationEmail: string | null
-  discordWebhookUrl: string | null
+  /** Null when the response is the admin-safe representation. */
+  notificationEmail?: string | null
+  /** Null when the response is the admin-safe representation. */
+  discordWebhookUrl?: string | null
+  /** Present only in the admin-safe representation. */
+  notificationConfigured?: boolean
 }
 
 export async function postLogin(email: string, password: string): Promise<{ token: string }> {
@@ -52,4 +56,8 @@ export async function patchNotificationPreferences(
   discordWebhookUrl: string | null,
 ): Promise<void> {
   await client.patch('/me/notifications', { channel, notificationEmail, discordWebhookUrl })
+}
+
+export async function postNotificationTest(): Promise<void> {
+  await client.post('/me/notifications/test')
 }

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -91,7 +91,23 @@
     "noFollowed": "Enable notifications on a series to see its news",
     "follow": "Follow",
     "following": "Following ✓",
-    "markRead": "Mark as read"
+    "markRead": "Mark as read",
+    "systemTitle": "System notifications",
+    "settings": {
+      "title": "My notification preferences",
+      "description": "Pick how you want to be notified about new articles. You can send a test to make sure it works.",
+      "channel": "Channel",
+      "channelEmail": "Email",
+      "channelDiscord": "Discord (webhook)",
+      "email": "Email address",
+      "discord": "Discord webhook URL",
+      "save": "Save",
+      "test": "Test",
+      "savedToast": "Preferences saved.",
+      "saveErrorToast": "Save failed.",
+      "testDispatchedToast": "Test sent. You'll get an alert here if it fails.",
+      "testErrorToast": "Could not send the test."
+    }
   },
   "status": {
     "not_started": "Not started",

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -91,7 +91,23 @@
     "noFollowed": "Activez le suivi sur une série pour voir ses actualités",
     "follow": "Suivre",
     "following": "Suivi ✓",
-    "markRead": "Marquer comme lu"
+    "markRead": "Marquer comme lu",
+    "systemTitle": "Notifications système",
+    "settings": {
+      "title": "Mes préférences de notification",
+      "description": "Choisis comment tu veux être prévenu·e des nouveaux articles. Tu peux envoyer un test pour vérifier ta configuration.",
+      "channel": "Canal",
+      "channelEmail": "Email",
+      "channelDiscord": "Discord (webhook)",
+      "email": "Adresse email",
+      "discord": "URL du webhook Discord",
+      "save": "Enregistrer",
+      "test": "Tester",
+      "savedToast": "Préférences enregistrées.",
+      "saveErrorToast": "L'enregistrement a échoué.",
+      "testDispatchedToast": "Test envoyé. En cas d'échec, tu recevras un message ici.",
+      "testErrorToast": "Impossible d'envoyer le test."
+    }
   },
   "status": {
     "not_started": "Non commencé",

--- a/front/src/pages/AdminUsersPage.vue
+++ b/front/src/pages/AdminUsersPage.vue
@@ -67,12 +67,12 @@ const saving = ref(false)
 
 function openEdit(user: User): void {
   editing.value = user
+  // The admin never sees or edits the user's actual notification email
+  // or Discord webhook URL — only the channel choice is admin-editable.
   editForm.value = {
     displayName: user.displayName,
     status: user.status,
     notificationChannel: user.notificationChannel,
-    notificationEmail: user.notificationEmail,
-    discordWebhookUrl: user.discordWebhookUrl,
   }
 }
 
@@ -198,6 +198,10 @@ async function copyResetLink(user: User): Promise<void> {
             </td>
             <td class="text-sm">
               <span class="capitalize">{{ user.notificationChannel }}</span>
+              <span
+                v-if="user.notificationConfigured === false"
+                class="ml-1 text-xs text-base-content/40"
+              >(non configuré)</span>
             </td>
             <td class="text-right">
               <div class="flex justify-end gap-1">
@@ -292,26 +296,9 @@ async function copyResetLink(user: User): Promise<void> {
               <option value="email">Email</option>
               <option value="discord">Discord</option>
             </select>
-          </div>
-
-          <div v-if="editForm.notificationChannel === 'email'">
-            <label class="text-sm font-medium">Email de notification</label>
-            <input
-              v-model="editForm.notificationEmail"
-              type="email"
-              class="input w-full mt-1.5"
-              placeholder="adresse@exemple.com"
-            />
-          </div>
-
-          <div v-if="editForm.notificationChannel === 'discord'">
-            <label class="text-sm font-medium">Webhook Discord</label>
-            <input
-              v-model="editForm.discordWebhookUrl"
-              type="url"
-              class="input w-full mt-1.5"
-              placeholder="https://discord.com/api/webhooks/…"
-            />
+            <p class="mt-1.5 text-xs text-base-content/50">
+              L'adresse email et l'URL du webhook sont gérées par l'utilisateur depuis son onglet Notifications et ne sont jamais visibles ici.
+            </p>
           </div>
         </div>
 

--- a/front/src/pages/NotificationsPage.vue
+++ b/front/src/pages/NotificationsPage.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
-import { useQuery } from '@tanstack/vue-query'
-import { getArticles } from '@/api/notification'
+import { ref, computed, watch, onMounted } from 'vue'
+import { useQuery, useQueryClient } from '@tanstack/vue-query'
+import { getArticles, getNotifications } from '@/api/notification'
 import { getCollection } from '@/api/collection'
+import { patchNotificationPreferences, postNotificationTest } from '@/api/auth'
+import { useAuthStore } from '@/stores/useAuthStore'
+import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
 import ArticleCard from '@/components/molecules/ArticleCard.vue'
 import type { CollectionEntry } from '@/types'
 
 const { t } = useI18n()
+const auth = useAuthStore()
+const ui = useUiStore()
+const queryClient = useQueryClient()
 
 const page = ref(1)
 const limit = 12
@@ -29,13 +35,167 @@ const { data: articlePage, isPending } = useQuery({
 
 watch(selectedCollectionId, () => { page.value = 1 })
 
+// ── Notification preferences form ──────────────────────────────────────
+
+const channel = ref<'email' | 'discord'>('email')
+const notificationEmail = ref<string>('')
+const discordWebhookUrl = ref<string>('')
+const saving = ref(false)
+const testing = ref(false)
+
+function syncFormFromUser(): void {
+  if (auth.user === null) return
+  channel.value = auth.user.notificationChannel
+  notificationEmail.value = auth.user.notificationEmail ?? ''
+  discordWebhookUrl.value = auth.user.discordWebhookUrl ?? ''
+}
+
+onMounted(syncFormFromUser)
+watch(() => auth.user, syncFormFromUser)
+
+const canTest = computed(() => {
+  if (channel.value === 'email') return notificationEmail.value.trim() !== ''
+  return discordWebhookUrl.value.trim() !== ''
+})
+
+async function savePreferences(): Promise<void> {
+  saving.value = true
+  try {
+    await patchNotificationPreferences(
+      channel.value,
+      channel.value === 'email' ? (notificationEmail.value.trim() || null) : null,
+      channel.value === 'discord' ? (discordWebhookUrl.value.trim() || null) : null,
+    )
+    await auth.loadUser()
+    ui.addToast(t('notifications.settings.savedToast'), 'success')
+  } catch {
+    ui.addToast(t('notifications.settings.saveErrorToast'), 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function sendTest(): Promise<void> {
+  testing.value = true
+  try {
+    // Save first so the test reflects what the user just typed.
+    await patchNotificationPreferences(
+      channel.value,
+      channel.value === 'email' ? (notificationEmail.value.trim() || null) : null,
+      channel.value === 'discord' ? (discordWebhookUrl.value.trim() || null) : null,
+    )
+    await auth.loadUser()
+    await postNotificationTest()
+    ui.addToast(t('notifications.settings.testDispatchedToast'), 'info')
+    // Refresh the unread notifications shortly after so any async failure
+    // surfaces in the page without the user having to reload.
+    setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: ['notifications', 'unread'] })
+    }, 5000)
+  } catch {
+    ui.addToast(t('notifications.settings.testErrorToast'), 'error')
+  } finally {
+    testing.value = false
+  }
+}
+
+// ── Unread async notifications (test failures, etc.) ───────────────────
+
+const { data: unread } = useQuery({
+  queryKey: ['notifications', 'unread'],
+  queryFn: () => getNotifications(),
+  refetchInterval: 15_000,
+})
+
 </script>
 
 <template>
   <div class="p-4 sm:p-6 space-y-6">
     <h1 class="text-2xl font-bold">{{ t('notifications.title') }}</h1>
 
-    <div class="max-w-4xl mx-auto px-6 py-8 space-y-6">
+    <div class="max-w-4xl mx-auto px-6 py-8 space-y-8">
+      <!-- Settings form -->
+      <section class="card bg-base-200/40 border border-base-300">
+        <div class="card-body space-y-4">
+          <div>
+            <h2 class="card-title text-lg">{{ t('notifications.settings.title') }}</h2>
+            <p class="text-sm text-base-content/60 mt-1">
+              {{ t('notifications.settings.description') }}
+            </p>
+          </div>
+
+          <div class="form-control">
+            <label class="label py-1">
+              <span class="label-text font-medium">{{ t('notifications.settings.channel') }}</span>
+            </label>
+            <select v-model="channel" class="select select-bordered">
+              <option value="email">{{ t('notifications.settings.channelEmail') }}</option>
+              <option value="discord">{{ t('notifications.settings.channelDiscord') }}</option>
+            </select>
+          </div>
+
+          <div v-if="channel === 'email'" class="form-control">
+            <label class="label py-1">
+              <span class="label-text font-medium">{{ t('notifications.settings.email') }}</span>
+            </label>
+            <input
+              v-model="notificationEmail"
+              type="email"
+              class="input input-bordered"
+              placeholder="adresse@exemple.com"
+            />
+          </div>
+
+          <div v-if="channel === 'discord'" class="form-control">
+            <label class="label py-1">
+              <span class="label-text font-medium">{{ t('notifications.settings.discord') }}</span>
+            </label>
+            <input
+              v-model="discordWebhookUrl"
+              type="url"
+              class="input input-bordered"
+              placeholder="https://discord.com/api/webhooks/…"
+            />
+          </div>
+
+          <div class="flex gap-2 justify-end pt-2">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              :disabled="!canTest || testing || saving"
+              @click="sendTest"
+            >
+              <span v-if="testing" class="loading loading-spinner loading-xs" />
+              {{ t('notifications.settings.test') }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              :disabled="saving || testing"
+              @click="savePreferences"
+            >
+              <span v-if="saving" class="loading loading-spinner loading-xs" />
+              {{ t('notifications.settings.save') }}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <!-- Async test failures / system notifications for this user -->
+      <section v-if="unread && unread.length > 0" class="space-y-2">
+        <h3 class="font-semibold text-sm uppercase tracking-wide text-base-content/70">
+          {{ t('notifications.systemTitle') }}
+        </h3>
+        <div
+          v-for="n in unread"
+          :key="n.id"
+          class="alert"
+          :class="n.type === 'test_failure' ? 'alert-error' : 'alert-info'"
+        >
+          <span class="text-sm">{{ n.message }}</span>
+        </div>
+      </section>
+
       <!-- Filter bar -->
       <div class="flex items-center gap-3 flex-wrap">
         <span class="text-sm text-base-content/60 shrink-0">{{ t('notifications.filterBy') }}</span>


### PR DESCRIPTION
…

Users can now configure their notification channel (email / Discord webhook) from the Notifications tab and click "Tester" to send themselves a "Bonjour {name}, ceci est ton test." message. Delivery happens asynchronously; on failure a Notification entity is persisted for the user so they see the error in the same page (worker/back errors keep going only to the admin Discord alert).

In the admin user list and edit modal, the notification channel (type) stays visible but the underlying email address and webhook URL are never returned nor editable — only the user owns those values. Admins can still change the channel without wiping the user's saved destinations.