### PR TITLE
Add staging environment with auto-deploy on main merge

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,182 @@
+name: Deploy — Staging
+
+# Continuous staging: every merge to `main` auto-deploys the staging
+# environment. Production stays tag-gated and manual (see deploy-production.yml)
+# — this is the only difference in trigger between the two environments.
+#
+# PR quality gates (qa.yml / tests.yml / frontend.yml) already ran before the
+# merge, so this workflow runs a fast smoke gate (PHPUnit + frontend build),
+# then deploys the three services to the staging environment, mirroring the
+# production deploy steps (worker → backend, frontend in parallel).
+#
+# Manual branch deploy: deploy ANY branch to staging BEFORE merging to main —
+# run this workflow ("Run workflow"), pick the branch in "Use workflow from"
+# and/or set the `ref` input. Every job checks out that ref and deploys it.
+#
+# Required GitHub secrets:
+#   RAILWAY_TOKEN                   — already set (shared with production)
+#   RAILWAY_PROJECT_ID              — already set (shared with production)
+#   RAILWAY_STAGING_ENVIRONMENT_ID  — NEW: the id of the `staging` environment
+#                                     (Railway dashboard URL ?environmentId=…,
+#                                      or `railway environment` after linking)
+on:
+  push:
+    branches: [main]
+  # Manual branch deploy: pick a branch in "Use workflow from" and/or fill the
+  # `ref` input to deploy that branch to staging BEFORE merging it to main.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branche/ref à déployer sur staging (vide = la branche choisie dans 'Use workflow from')"
+        required: false
+        type: string
+        default: ''
+
+# Never run two staging deploys at once; the most recent run wins.
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+env:
+  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+  RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+  RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_STAGING_ENVIRONMENT_ID }}
+
+jobs:
+
+  # --- Smoke gate: backend test suite ----------------------------------------
+
+  tests:
+    name: "Gate: PHPUnit"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: back
+    env:
+      DATABASE_URL: postgresql://ziggy:ziggy@127.0.0.1:5432/ziggytheque?serverVersion=17&charset=utf8
+      APP_SECRET: ci-secret-not-used
+      JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE || 'ci-jwt-passphrase' }}
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: ziggy
+          POSTGRES_PASSWORD: ziggy
+          POSTGRES_DB: ziggytheque
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo_pgsql, intl
+          tools: composer
+          coverage: none
+      - uses: actions/cache@v5
+        with:
+          path: back/vendor
+          key: composer-${{ hashFiles('back/composer.lock') }}
+          restore-keys: composer-
+      - run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Generate JWT keys
+        run: |
+          mkdir -p config/jwt
+          openssl genrsa -passout pass:${JWT_PASSPHRASE} -out config/jwt/private.pem 4096
+          openssl rsa -pubout -passin pass:${JWT_PASSPHRASE} -in config/jwt/private.pem -out config/jwt/public.pem
+      - run: php bin/console doctrine:database:create --env=test --if-not-exists
+      - run: php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration --env=test
+      - run: php bin/phpunit --no-progress
+
+  # --- Smoke gate: frontend type-check + build -------------------------------
+
+  frontend:
+    name: "Gate: Frontend (vue-tsc + build)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: front/package-lock.json
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run build
+
+  # --- Deploy API: worker first (messenger:consume), then backend ------------
+
+  deploy-api:
+    name: "Staging: Deploy API (worker → backend)"
+    runs-on: ubuntu-latest
+    needs: [tests, frontend]
+    env:
+      DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Deploy worker service (messenger:consume)
+        # Swap in worker/railway.json so Railway uses dockerBuildTarget: "worker".
+        # Restore the original railway.json afterwards for the backend step.
+        run: |
+          cp worker/railway.json railway.json
+          for attempt in 1 2; do
+            railway up \
+              --service ziggytheque-worker \
+              --ci \
+              -m "$DEPLOY_MSG" && break
+            echo "Attempt $attempt failed — retrying in 30s..."
+            sleep 30
+          done
+          git checkout railway.json
+      - name: Deploy backend service (frankenphp run)
+        run: |
+          for attempt in 1 2; do
+            railway up \
+              --service ziggytheque-back \
+              --ci \
+              -m "$DEPLOY_MSG" && break
+            echo "Attempt $attempt failed — retrying in 30s..."
+            sleep 30
+          done
+
+  # --- Deploy Frontend (parallel with API) -----------------------------------
+
+  deploy-front:
+    name: "Staging: Deploy Frontend"
+    runs-on: ubuntu-latest
+    needs: [tests, frontend]
+    env:
+      DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Deploy frontend service
+        working-directory: front
+        run: |
+          for attempt in 1 2; do
+            railway up \
+              --service ziggytheque-front \
+              --ci \
+              -m "$DEPLOY_MSG" && break
+            echo "Attempt $attempt failed — retrying in 30s..."
+            sleep 30
+          done

--- a/back/scripts/anonymize-staging.sql
+++ b/back/scripts/anonymize-staging.sql
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Ziggytheque — anonymisation RGPD de la base STAGING
+-- ============================================================================
+-- À exécuter UNE FOIS, juste après avoir restauré un dump de PROD sur la base
+-- de l'environnement STAGING. Scrub toutes les données personnelles : e-mails,
+-- noms affichés, e-mails de notification, webhooks Discord, jetons d'auth, et
+-- le journal d'activité (dont la metadata peut contenir des traces PII).
+--
+-- ⚠️  NE JAMAIS exécuter sur la base de PRODUCTION.
+--     Vérifie deux fois la connexion (host/db) avant de lancer.
+--
+-- Usage typique (depuis une machine de confiance, connectée à la base staging) :
+--   psql "$STAGING_DATABASE_URL" -f back/scripts/anonymize-staging.sql
+--
+-- Les données métier (mangas, volumes, collections, wishlist, articles) ne
+-- contiennent pas de PII et sont volontairement conservées telles quelles —
+-- c'est ce qu'on veut tester en staging.
+-- ============================================================================
+
+BEGIN;
+
+-- 1) Utilisateurs : on garde la structure (rôles, statuts, canal de notif) mais
+--    on neutralise toute donnée personnelle.
+--    - email : déterministe et UNIQUE (basé sur l'id), domaine .invalid non routable
+--    - password_hash : hash bcrypt volontairement INUTILISABLE (aucun mot de
+--      passe ne peut s'y vérifier). Crée ensuite un admin de staging via
+--      `php bin/console app:bootstrap-admin …` pour pouvoir te connecter.
+UPDATE users SET
+    email               = 'user-' || id || '@staging.invalid',
+    display_name        = 'Staging User ' || substr(id, 1, 8),
+    notification_email  = NULL,
+    discord_webhook_url = NULL,
+    password_hash       = '$2y$13$00000000000000000000000000000000000000000000000000000'
+;
+
+-- 2) Jetons d'authentification (reset de mot de passe, vérification e-mail) :
+--    on ne conserve JAMAIS de jetons réels en staging.
+DELETE FROM auth_tokens;
+
+-- 3) Journal d'activité : sa metadata (JSON) et ses messages d'erreur peuvent
+--    contenir des e-mails / URLs de webhook → purge complète de l'historique.
+DELETE FROM activity_logs;
+
+COMMIT;
+
+-- ── Vérification post-anonymisation (doit ne montrer que des @staging.invalid) :
+--   SELECT email, display_name, notification_email, discord_webhook_url
+--   FROM users ORDER BY created_at LIMIT 10;
+--   SELECT count(*) AS auth_tokens_restants FROM auth_tokens;   -- attendu : 0
+--   SELECT count(*) AS activity_logs_restants FROM activity_logs; -- attendu : 0

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,162 @@
+# Environnement Staging (Railway)
+
+Staging est un **réplica isolé de la production** sur le même projet Railway :
+les mêmes 4 services (backend FrankenPHP, worker Messenger, frontend nginx,
+PostgreSQL), déployés en continu à chaque merge sur `main`, avec une copie des
+**données de prod anonymisées** (RGPD).
+
+| | Production | Staging |
+|---|---|---|
+| Déclencheur de déploiement | Tag + dispatch manuel (`deploy-production.yml`) | Merge sur `main` (`deploy-staging.yml`) |
+| Données | Réelles | Copie de prod **anonymisée** |
+| Base de données | Postgres prod | Postgres staging (séparée) |
+| Domaine | `www.ziggytheque.fr` | domaine staging dédié |
+
+> Railway « duplique » un environnement en copiant **services + variables +
+> config**. La base reçoit une **DB fraîche vide** (les données ne sont pas
+> copiées) et les variables **sealed** ne sont pas copiées — il faut les
+> re-saisir. La copie de données réelles se fait séparément (étape 4).
+
+---
+
+## 1. Créer l'environnement staging (dashboard, une fois)
+
+1. Dashboard Railway → projet Ziggytheque → menu déroulant d'environnement (en
+   haut) → **New Environment → Duplicate** → source **production**, nom
+   **`staging`**.
+2. Railway « stage » les 4 services + leurs variables. Clique **Deploy** pour
+   matérialiser l'environnement.
+3. Récupère l'**id de l'environnement staging** : il est dans l'URL du
+   dashboard (`…?environmentId=<ID>`) ou via `railway environment` après
+   `railway link`.
+
+### Alternative CLI (en local, CLI déjà authentifiée)
+
+```bash
+railway link --project <Ziggytheque>
+railway environment new staging --duplicate production   # copie services+vars+config
+railway environment                                       # récupère l'id de staging
+```
+
+---
+
+## 2. Régler les variables propres au staging
+
+La duplication copie les variables non-sealed. À ajuster / re-saisir **par
+service** dans le dashboard (onglet *Variables* de chaque service, env staging) :
+
+| Service | Variable | Pourquoi |
+|---|---|---|
+| backend | `CORS_ALLOW_ORIGIN` | origine du domaine staging, ex. `^https://staging\.ziggytheque\.fr$` |
+| backend | `MERCURE_PUBLIC_URL` | URL publique du hub Mercure côté staging |
+| backend | `MERCURE_URL` | hub interne (si *reference variable*, se ré-résout seul) |
+| backend | `GATE_PASSWORD` | **sealed** → re-saisir |
+| backend | `GOOGLE_BOOKS_API_KEY` | **sealed** → re-saisir |
+| backend | `MAILER_DSN` (Resend) | **sealed** → re-saisir (ou un DSN de test) |
+| backend | `MERCURE_PUBLISHER_JWT_KEY` / `MERCURE_SUBSCRIBER_JWT_KEY` | **sealed** → re-saisir |
+| backend | clés/passphrase JWT (`JWT_*`) | **sealed** → re-saisir ou régénérer |
+| backend | `MONITOR_USER` / `MONITOR_PASSWORD` | **sealed** → re-saisir |
+| frontend | `BACKEND_URL` | URL interne du backend staging (si `${{backend.RAILWAY_PRIVATE_DOMAIN}}`, auto) |
+| Postgres | `DATABASE_URL` | nouvelle DB auto-provisionnée (reference → auto) |
+
+**Domaines** : génère un domaine Railway pour le frontend staging (et le backend
+si besoin) ou ajoute un sous-domaine `staging.ziggytheque.fr`, puis aligne
+`CORS_ALLOW_ORIGIN` et `MERCURE_*` dessus.
+
+**Migrations** : staging utilise la même image Docker que prod — les migrations
+s'appliquent donc de la même façon qu'en prod (au boot du backend). Au besoin,
+en manuel :
+
+```bash
+railway run --environment staging --service ziggytheque-back -- \
+  php bin/console doctrine:migrations:migrate --no-interaction
+```
+
+---
+
+## 3. Auto-déploiement au merge sur `main`
+
+Le workflow [`.github/workflows/deploy-staging.yml`](../.github/workflows/deploy-staging.yml)
+déploie staging **à chaque merge sur `main`** : smoke gate (PHPUnit + build
+frontend) puis `railway up` des 3 services vers l'environnement staging
+(worker → backend, frontend en parallèle). La prod reste tag-gated et manuelle.
+
+### Déployer une branche sur staging *avant* de merger sur `main`
+
+Pour tester une branche sur staging avant le merge :
+
+1. GitHub → onglet **Actions** → workflow **« Deploy — Staging »** → **Run workflow**.
+2. Dans **« Use workflow from »**, choisis ta branche *(et/ou renseigne le champ
+   `ref`)*.
+3. Lance : le smoke gate s'exécute sur cette branche, puis les 3 services sont
+   déployés sur staging (même environnement → le déploiement le plus récent
+   écrase le précédent).
+
+> Le workflow n'est dispatchable que s'il existe sur la branche par défaut
+> (`main`) : cette PR doit donc être mergée une première fois pour que l'option
+> « Run workflow » apparaisse.
+
+**Secret GitHub à ajouter** (Settings → Secrets and variables → Actions) :
+
+| Secret | Valeur |
+|---|---|
+| `RAILWAY_STAGING_ENVIRONMENT_ID` | id de l'environnement staging (étape 1.3) |
+
+`RAILWAY_TOKEN` et `RAILWAY_PROJECT_ID` existent déjà (partagés avec la prod).
+
+> Pour ajuster le déclencheur (ex. déployer depuis une branche `staging` plutôt
+> que `main`), modifie le bloc `on:` du workflow.
+
+---
+
+## 4. Copier les données de prod (anonymisées RGPD)
+
+⚠️ À faire depuis une **machine de confiance**. Ne **jamais** committer un dump.
+
+```bash
+# 1) Récupère les URLs de connexion (onglet "Connect" du service Postgres,
+#    ou `railway variables`), pour prod ET staging.
+export PROD_DATABASE_URL="postgresql://…@…prod…/railway"
+export STAGING_DATABASE_URL="postgresql://…@…staging…/railway"
+
+# 2) Dump de prod (lecture seule)
+pg_dump "$PROD_DATABASE_URL" --no-owner --no-privileges -Fc -f /tmp/prod.dump
+
+# 3) Restaure dans la base staging (vide)
+pg_restore --clean --if-exists --no-owner --no-privileges \
+  -d "$STAGING_DATABASE_URL" /tmp/prod.dump
+
+# 4) Anonymise IMMÉDIATEMENT (voir back/scripts/anonymize-staging.sql)
+psql "$STAGING_DATABASE_URL" -f back/scripts/anonymize-staging.sql
+
+# 5) Supprime le dump local
+shred -u /tmp/prod.dump 2>/dev/null || rm -f /tmp/prod.dump
+```
+
+Le script [`back/scripts/anonymize-staging.sql`](../back/scripts/anonymize-staging.sql)
+scrub : `users.email`, `display_name`, `notification_email`, `discord_webhook_url`,
+rend les mots de passe inutilisables, et purge `auth_tokens` + `activity_logs`.
+
+**Connexion à staging après anonymisation** (les mots de passe sont neutralisés) :
+crée un admin de staging avec l'outil existant —
+
+```bash
+railway run --environment staging --service ziggytheque-back -- \
+  php bin/console app:bootstrap-admin   # suis les options de la commande
+```
+
+> **Note RGPD** : avec cette procédure, des données réelles transitent
+> brièvement par la base staging (entre la restauration et l'anonymisation).
+> Pour une conformité stricte, anonymise le dump **avant** restauration (ou
+> dumpe depuis un replica), et n'expose jamais staging publiquement avec des
+> données réelles.
+
+---
+
+## Récapitulatif des actions manuelles (hors repo)
+
+- [ ] Dupliquer l'env `production` → `staging` (dashboard ou CLI).
+- [ ] Re-saisir les variables sealed + régler CORS/Mercure/domaine staging.
+- [ ] Ajouter le secret GitHub `RAILWAY_STAGING_ENVIRONMENT_ID`.
+- [ ] (optionnel) Copier + anonymiser les données de prod.
+- [ ] Vérifier un premier déploiement (merge sur `main` ou `workflow_dispatch`).


### PR DESCRIPTION
## Summary

Introduces a fully automated staging environment on Railway that mirrors production infrastructure and deploys continuously on every merge to `main`. Staging receives anonymized production data for realistic testing while keeping production tag-gated and manual.

## Changes

- **`.github/workflows/deploy-staging.yml`** — New CI/CD workflow that:
  - Runs on every push to `main` (or manual dispatch)
  - Executes smoke gates: PHPUnit test suite + frontend build
  - Deploys three services in parallel (worker → backend, frontend) to the staging environment via Railway CLI
  - Implements retry logic (2 attempts, 30s backoff) for resilience
  - Uses concurrency control to cancel in-progress runs when a newer commit arrives

- **`docs/staging.md`** — Comprehensive setup and operations guide covering:
  - One-time environment duplication from production (dashboard or CLI)
  - Variable configuration per service (CORS, Mercure, sealed secrets, domain)
  - Auto-deployment trigger via GitHub Actions
  - Data anonymization workflow (RGPD-compliant)
  - Manual admin account creation for staging access

- **`back/scripts/anonymize-staging.sql`** — SQL script that scrubs all PII from a restored production dump:
  - Replaces user emails with deterministic `user-{id}@staging.invalid` addresses
  - Neutralizes password hashes to prevent login
  - Clears auth tokens and activity logs (which may contain sensitive metadata)
  - Preserves all business data (manga, volumes, collections, wishlist) for realistic testing

## Implementation Details

- **Staging as a Railway environment duplicate** — shares the same project and services as production but with isolated databases and variables, enabling safe continuous deployment
- **Smoke gates before deploy** — PHPUnit + frontend build ensure basic quality before staging is updated, mirroring the PR quality gates already in place
- **Deterministic email anonymization** — uses user ID to generate consistent staging emails, enabling reproducible test scenarios
- **No manual DB cleanup** — DAMA PHPUnit extension (already configured) handles test isolation via savepoints
- **GitHub secret required** — `RAILWAY_STAGING_ENVIRONMENT_ID` must be added to Actions secrets; `RAILWAY_TOKEN` and `RAILWAY_PROJECT_ID` are reused from production setup

## Next Steps (Manual, Out-of-Repo)

1. Duplicate the `production` environment to `staging` in Railway dashboard
2. Re-configure sealed variables and domain settings for staging
3. Add `RAILWAY_STAGING_ENVIRONMENT_ID` secret to GitHub Actions
4. (Optional) Restore and anonymize production data to staging
5. Verify first deployment via merge to `main` or manual workflow dispatch

https://claude.ai/code/session_01KkJWbzJvmVs2bafTGqSoWj