### PR TITLE
feat(manga): edition discovery, ISBN scan relay, cover context refactor

### DIFF
--- a/.agents/plans/2026-05-29-collection-editions-scan-isbn.md
+++ b/.agents/plans/2026-05-29-collection-editions-scan-isbn.md
@@ -1,0 +1,586 @@
+# Collections par édition + découverte d'éditions + scan ISBN
+
+### TL;DR
+
+> [!NOTE]
+> Aujourd'hui, ajouter une série revient à enregistrer une **œuvre** (Berserk) avec une étiquette d'édition saisie en texte libre. On veut que chaque entrée de collection représente une **œuvre dans une édition précise** (éditeur + année + langue + visuel du tome 1), et pouvoir lister toutes ses collections par édition.
+>
+> Le plan se déroule en quatre phases livrables indépendamment (une phase = un PR = un commit). **(1)** On enrichit la fiche série avec un éditeur, une année d'édition et une clé d'œuvre pour regrouper les éditions d'une même œuvre, et on ajoute un nouvel écran « choisir l'édition » qui découvre automatiquement toutes les éditions existantes d'une œuvre dans une langue choisie (éditeur, année, couverture du tome 1, nombre de tomes), via Google Books en source principale et Open Library en complément. **(2)** On rend la recherche de couvertures fidèle à l'édition choisie : on transmet l'éditeur/l'année/la langue au moment de chercher une couverture, et on privilégie l'ancrage par ISBN (exact) plutôt que la recherche floue par titre. **(3)** On ajoute le scan d'un code-barres ISBN par tome : la caméra sur mobile, et sur ordinateur un QR code à scanner avec le téléphone qui renvoie l'ISBN en temps réel à l'écran (via Mercure, déjà en place pour la complétion de couvertures) ; saisie manuelle de l'ISBN en repli partout. **(4)** On câble tout le frontend : nouvel écran de choix d'édition dans le flux d'ajout, affichage éditeur/année sur la page série, et intégration du scan dans la fiche d'un tome.
+>
+> Aucune nouvelle dépendance d'infrastructure : Google Books, MangaDex, Open Library et le hub Mercure sont déjà configurés. Côté frontend on ajoute deux librairies clientes (lecture de code-barres + génération de QR code).
+
+---
+
+### Implementation
+
+#### État actuel
+
+```
+CollectionEntry ──► Manga (= "l'œuvre", mais porte déjà edition + language + coverUrl)
+                      └── Volume[] (number, coverUrl, price, releaseDate, isbn, spineUrl)
+```
+
+- `Manga` (`back/src/Manga/Domain/Manga.php`) : `title`, `edition` (texte libre, souvent un nom d'éditeur), `language`, `author`, `summary`, `coverUrl`, `genre`, `externalId`, `volumes[]`.
+- Rien n'empêche déjà d'avoir deux `Manga` « Berserk / Glénat » et « Berserk / Deluxe » : ce sont deux lignes avec un `edition` différent. **Les manques sont l'UX de découverte, la structuration de l'édition (pas d'éditeur ni d'année distincts), la fidélité des couvertures, et l'absence de regroupement par œuvre.**
+- Flux d'ajout (`front/src/pages/AddMangaPage.vue`) : étape 1 recherche d'œuvre via **Jikan** (`GET /api/manga/external`, aliasé sur `JikanMangaApiClient`) ; étape 2 formulaire avec `BaseEditionSelector` (liste d'éditeurs codée en dur dans `front/src/data/editions.ts`) ; étape 3 destination. À la validation : `POST /api/manga` (`ImportMangaHandler` crée le `Manga` + N tomes vierges depuis `totalVolumes`) puis `POST /api/collection`.
+- Couvertures par tome (`front/src/components/organisms/EnrichVolumeModal.vue`) : `GET /api/manga/volume-search` → `SearchVolumeExternalHandler` → `MangaCoverProviderInterface::findByContext(title, edition, volumeNumber, language)`. Providers `app.manga_cover_provider` (priorité : MangaDex 100 > OpenLibrary 50 > GoogleBooks 10) agrégés par `CompositeMangaCoverApiClient`. Complétion en masse via `StartCoverBatchHandler` → message async → `CoverBatchResolver` → progression poussée par **Mercure** (topic `https://ziggytheque.app/cover-batch/{id}`, `MercureCoverBatchProgressPublisher` + `MercureCoverBatchSubscriberAuthorizer`, consommée côté front par `useCoverBatchProgress` via `EventSource`).
+- `Isbn` (VO validé ISBN-10/13, `back/src/Manga/Domain/Isbn.php`) + type Doctrine `isbn` (`IsbnType`, colonne `VARCHAR(20)`). `Volume.isbn` existe déjà. `InvalidIsbnException extends DomainException` → **422** via `ExceptionListener`.
+
+#### État cible
+
+```
+              ┌──────────────────────────────────────────────────────────┐
+              │  Manga = "œuvre DANS son édition"                          │
+CollectionEntry ─► │  title, externalWorkId (regroupe les éditions d'une œuvre)│
+              │  publisher (éditeur), editionYear (année), edition (label  │
+              │  variante: Deluxe/Perfect/null), language, coverUrl (T1)   │
+              │  └── Volume[] (… isbn ← ancre l'édition exacte)            │
+              └──────────────────────────────────────────────────────────┘
+
+Flux d'ajout : [1] chercher l'ŒUVRE (Jikan) → [2] CHOISIR L'ÉDITION (découverte
+Google Books + Open Library, filtrée par langue) → [3] formulaire pré-rempli →
+[4] destination.
+
+Couvertures : findByContext(EditionContext{title,publisher,label,year,lang,workId}, n)
++ recherche par ISBN prioritaire (exacte). Scan ISBN : caméra mobile OU QR→téléphone
+→ ISBN poussé en temps réel via Mercure (topic scan-session/{id}).
+```
+
+#### Modèle de données (Phase 1)
+
+Nouveaux champs sur `Manga` (tous nullable, pas de défaut DB) :
+
+| Champ | Type | Sens |
+|---|---|---|
+| `publisher` | `?string` | Maison d'édition : « Glénat », « Ki-oon »… |
+| `editionYear` | `?int` | Année de début de cette édition |
+| `externalWorkId` | `?string` | Identifiant de l'œuvre abstraite (id Jikan/MAL ou slug normalisé) pour regrouper plusieurs éditions |
+
+`edition` est **conservé** mais resémantisé en **label de variante** (« Édition Deluxe », « Perfect Edition », `null` = standard). Migration de données : pour les lignes existantes, `publisher = edition` puis `edition = NULL` lorsque `publisher IS NULL` (les valeurs actuelles d'`edition` sont des noms d'éditeurs). `Manga::toArray()` expose `publisher`, `editionYear`, `externalWorkId` ; le frontend compose l'affichage (`publisher` + label + année). Couverture du `Manga` = visuel de l'édition (tome 1).
+
+#### Découverte d'éditions (Phase 1)
+
+Nouveau port `EditionDiscoveryInterface::discoverEditions(string $workTitle, string $language): ExternalEditionDto[]`.
+
+- `ExternalEditionDto` : `publisher`, `editionLabel`, `year`, `language`, `coverUrl` (tome 1), `volumeCount`, `sampleIsbn`, `source`.
+- `EditionGrouper` (service Domain **pur**, unit-testable) : reçoit une liste normalisée `{publisher, year, volumeNumber, title, coverUrl, isbn}` et **regroupe par éditeur** ; par groupe : `year = min(année)`, `coverUrl` = couverture du tome 1 (sinon plus petit numéro avec cover), `volumeCount = max(numéro)` ou compte, `sampleIsbn` = un ISBN-13 du groupe, `editionLabel` = variante détectée dans les titres (mots-clés : « perfect », « deluxe », « édition originale », « double », « collector »… sinon `null`).
+- `GoogleBooksEditionDiscoveryClient` (source principale) : `q={title}+manga`, `langRestrict={lang}`, parcourt quelques pages, normalise les items Google Books et délègue à `EditionGrouper`. Réutilise les patterns HTTP + l'apiKey existants.
+- `OpenLibraryEditionDiscoveryClient` (complément) : exploite le modèle natif Work→Editions d'Open Library (`search.json` avec champs `editions.*`, ou `works/{id}/editions.json`), filtré par langue → `ExternalEditionDto`. Couvertures via `https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg`.
+- `CompositeEditionDiscoveryClient` (`!tagged_iterator app.edition_discovery_provider`) : fusionne les providers, **déduplique par (publisher + year)**, Google Books d'abord puis Open Library comble les trous.
+- `NullEditionDiscoveryClient` : stub de test.
+- Query/handler `DiscoverEditionsQuery` / `DiscoverEditionsHandler` → route `GET /api/manga/editions?title=…&lang=fr` (JWT requis).
+
+#### Couvertures fidèles à l'édition (Phase 2)
+
+- Nouveau VO `EditionContext{mangaTitle, publisher, editionLabel, year, language, externalWorkId}`.
+- `MangaCoverProviderInterface::findByContext(EditionContext $context, int $volumeNumber)` remplace la signature `(title, edition, volumeNumber, language)`. Impacte Google/MangaDex/OpenLibrary/Composite/Null + `CoverBatchResolver` + `SearchVolumeExternalHandler` (un seul commit de refactor).
+- Google Books `findByContext` : requête `"{title}" tome {n} {publisher}` + `langRestrict`, filtrage sur l'éditeur quand fourni.
+- **Ancrage ISBN** : `SearchVolumeExternalQuery` + route `volume-search` acceptent un `isbn` optionnel ; si présent, `findByIsbn` (couverture exacte de l'édition) au lieu de `findByContext`. `CoverBatchResolver` privilégie déjà l'ISBN — on conserve.
+- `UpdateVolume` (command/handler/request) accepte `isbn` pour **persister** l'ISBN scanné sur le `Volume` (re-résolutions futures exactes).
+
+#### Scan ISBN (Phase 3)
+
+Deux flux, repli saisie manuelle partout :
+
+1. **Mobile (caméra)** — `useBarcodeScanner` (composable) : `BarcodeDetector` natif si présent, sinon ponyfill `barcode-detector` (ZXing-WASM, format `ean_13`). Gère le flux `getUserMedia({video:{facingMode:'environment'}})` et la boucle de détection. Composant `IsbnScanner.vue`.
+2. **Desktop (QR → téléphone, via Mercure)** — l'écran ouvre une **session de scan** (`POST /api/manga/scan-session` → `{sessionId, mercureUrl, subscriberToken, topic}`, calqué sur `StartCoverBatchHandler`/`StartCoverBatchResult`) et s'abonne au topic Mercure `https://ziggytheque.app/scan-session/{id}` (`useScanSession`, calqué sur `useCoverBatchProgress`). Il affiche un QR encodant `${origin}/scan/{sessionId}`. Le téléphone (authentifié) ouvre `ScanRelayPage.vue`, scanne l'EAN-13, `POST /api/manga/scan-session/{sessionId}/isbn {isbn}` → `PublishScannedIsbnHandler` valide via `Isbn::fromString` (422 si invalide) et publie l'ISBN sur le topic. L'écran desktop reçoit l'ISBN en temps réel.
+
+Ports Domain calqués sur l'existant : `ScanSessionAuthorizerInterface` (issue token/topic/hub) + `ScanSessionPublisherInterface` (`publishIsbn(sessionId, isbn)`), adaptateurs Mercure dédiés (topic `scan-session/{id}`). Une fois l'ISBN obtenu (n'importe quel flux), le front appelle `volume-search?isbn=…` puis `updateVolume(coverUrl, isbn)`.
+
+#### Flux de données (ajout d'une série, cible)
+
+```
+[FE] AddMangaPage
+  1. useExternalSearch ──► GET /api/manga/external (Jikan)         → choisir l'œuvre
+  2. discoverEditions ──► GET /api/manga/editions?title&lang        → choisir l'édition
+  3. importManga ──────► POST /api/manga {title,publisher,year,…}   → Manga + N tomes
+     addToCollection ─► POST /api/collection {mangaId}              → CollectionEntry
+  4. destination (collection | wishlist)
+```
+
+#### Découpage en phases / PRs (one commit per PR)
+
+- **Phase 1** (T1–T4) : modèle + découverte d'éditions (backend) + endpoint `/api/manga/editions`.
+- **Phase 2** (T5–T6) : couvertures fidèles (`EditionContext`, ISBN dans volume-search, ISBN persisté).
+- **Phase 3** (T7–T10) : scan ISBN (relais backend + composables + composants + page mobile).
+- **Phase 4** (T11–T13) : flux d'édition frontend (API/types, écran de choix d'édition, page série).
+- **T14** : boucle finale lint/test/review.
+
+Chaque phase est livrable seule ; les phases 2–4 dépendent de la 1 (champs + endpoint). Si tu préfères, chaque phase peut devenir un plan/PR séparé — le présent document les ordonne pour être exécutées séquentiellement.
+
+#### Code retiré / remplacé (audit en un point)
+
+- Signature `MangaCoverProviderInterface::findByContext(string, ?string, int, string)` → **supprimée** au profit de `findByContext(EditionContext, int)` (T5) : retire le paramètre `?string $edition` et `string $language` de toutes les implémentations + appels.
+- `SearchVolumeExternalHandler::mapDtoToArray` : `'language' => 'fr'` codé en dur → dérivé de l'`EditionContext` (T5).
+- Aucune suppression de fichier : `front/src/data/editions.ts` (logos éditeurs) et `BaseEditionSelector.vue` sont **conservés** comme repli de saisie manuelle et pour les logos d'éditeur.
+
+#### Risques / notes
+
+- **Qualité des données externes** : la « découverte d'éditions » est heuristique (regroupement par éditeur Google Books) ; couverture FR variable côté Open Library. `EditionGrouper` doit dégrader proprement (jamais d'exception ; éditions partielles acceptées). Le repli « saisie manuelle » reste disponible.
+- **getUserMedia** exige un contexte sécurisé : OK en prod (HTTPS) et sur `http://localhost`. Sur desktop sans caméra, le bouton caméra affiche « indisponible » et l'utilisateur passe par le QR.
+- **Auth du téléphone** : `ScanRelayPage` exige un JWT (`meta.requiresAuth`). Le QR ne transporte que le `sessionId` ; la publication ISBN est protégée par le JWT normal. Le token Mercure (desktop) reste scopé au topic de la session.
+- `doctrine:schema:validate` doit rester vert : générer la migration via `make migration` (pas de noms d'index/FK écrits à la main).
+
+---
+
+### Tasks
+
+- **T1** : enrichir l'entité `Manga` (publisher, editionYear, externalWorkId) + migration + import/update + tests.
+- **T2** : `ExternalEditionDto` + service Domain `EditionGrouper` (pur) + tests unitaires.
+- **T3** : `EditionDiscoveryInterface` + clients Google Books / Open Library / Composite / Null + câblage `services.yaml` + tests unitaires.
+- **T4** : `DiscoverEditionsQuery`/`Handler` + route `GET /api/manga/editions` + test fonctionnel.
+- **T5** : VO `EditionContext` + refactor `findByContext` + ancrage ISBN dans `volume-search` + tests.
+- **T6** : `UpdateVolume` accepte/persiste `isbn` + test fonctionnel.
+- **T7** : relais de session de scan backend (ports + adaptateurs Mercure + commands/handlers + routes + doubles de test) + tests.
+- **T8** : dépendances front + composable `useBarcodeScanner` + tests.
+- **T9** : composable `useScanSession` (EventSource desktop) + tests.
+- **T10** : composants `IsbnScanner.vue` / `ScanViaPhone.vue` / page `ScanRelayPage.vue` + route `/scan/:sessionId` + intégration `EnrichVolumeModal` + i18n + tests.
+- **T11** : couche API front (`discoverEditions`, `volume-search?isbn`, scan-session) + types.
+- **T12** : composants `EditionCard.vue` / `EditionPicker.vue` + étape « choisir l'édition » dans `AddMangaPage` + i18n + tests.
+- **T13** : page série (affichage éditeur/année + édition inline + passage de l'`EditionContext` à `EnrichVolumeModal`) + i18n.
+- **T14** : boucle finale lint / test / file-reviewer.
+
+---
+
+#### Task 1 : Enrichir l'entité `Manga` (œuvre-en-édition)
+
+Ajouter `publisher`, `editionYear`, `externalWorkId` à `Manga`, propager dans l'import et l'update, migrer les données existantes.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — conventions DDD/naming + gate QA (PHPStan/Deptrac) sur l'entité et les handlers.
+- `.claude/CLAUDE.md` — règles de mapping Doctrine (enum/length, défaut DB, `make migration`), tests obligatoires.
+- `.claude/backend.md` — R3 (handler orchestrateur), R10 (nommage).
+
+**Files:**
+- Modify `back/src/Manga/Domain/Manga.php` — propriétés `?string $publisher`, `?int $editionYear`, `?string $externalWorkId` dans le constructeur (après `externalId`) ; ajouter au `toArray()`.
+- Modify `back/src/Manga/Application/Import/ImportMangaCommand.php` — params `?string $publisher`, `?int $editionYear`, `?string $externalWorkId`.
+- Modify `back/src/Manga/Application/Import/ImportMangaHandler.php` — passer les nouveaux champs au `new Manga(...)`.
+- Modify `back/src/Manga/Infrastructure/Http/ImportMangaRequest.php` — champs `?string $publisher` (`Assert\Length(max:255)`), `?int $editionYear` (`Assert\Range(min:1900, max:2100)`), `?string $externalWorkId`.
+- Modify `back/src/Manga/Infrastructure/Http/MangaController.php` — `import()` mappe les 3 nouveaux champs ; `update()` passe `publisher`/`editionYear` (voir UpdateMangaCommand).
+- Modify `back/src/Manga/Application/Update/UpdateMangaCommand.php` + `UpdateMangaHandler.php` + `back/src/Manga/Infrastructure/Http/UpdateMangaRequest.php` — ajouter `?string $publisher`, `?int $editionYear` (appliqués si non-null).
+- Create `back/migrations/Version<timestamp>.php` — généré par `make migration` (ALTER TABLE `mangas` ADD `publisher`, `edition_year`, `external_work_id`), puis ajouter à la main le backfill data : `UPDATE mangas SET publisher = edition, edition = NULL WHERE publisher IS NULL`.
+- Modify `back/tests/Functional/Manga/MangaControllerTest.php` — import avec publisher/editionYear → vérifier exposition dans `GET /api/manga/{id}`.
+- Modify `back/tests/Unit/Manga/Domain/MangaTest.php` — `toArray()` expose les nouveaux champs.
+
+**Implementation**
+
+Champs nullable sans défaut DB → pas d'`options:['default']`. `VARCHAR(255)` par défaut pour les strings (pas de `length:` sauf besoin). `editionYear` = `INT NULL`. Après ajout, lancer `make migration` puis vérifier `doctrine:schema:validate`. Le backfill est une migration de **données** (pas de nom d'index/FK à la main) — autorisé. Garder `edition` comme label de variante.
+
+**Tests**
+
+- Unit `MangaTest` : construire un `Manga` avec publisher='Glénat', editionYear=2019, externalWorkId='mal-42' → `toArray()` contient ces clés.
+- Functional `MangaControllerTest` : `POST /api/manga {title, language, publisher:'Glénat', editionYear:2019}` (201) puis `GET /api/manga/{id}` → `publisher==='Glénat'`, `editionYear===2019`. Les cas 401/422/404 existants restent verts.
+
+**Verify**
+
+```bash
+docker compose exec back php bin/console doctrine:migrations:migrate --no-interaction
+docker compose exec back php bin/console doctrine:schema:validate
+docker compose exec back vendor/bin/phpunit tests/Functional/Manga/MangaControllerTest.php tests/Unit/Manga/Domain/MangaTest.php
+```
+Passe = migration appliquée, schéma valide, tests verts.
+
+---
+
+#### Task 2 : `ExternalEditionDto` + `EditionGrouper` (service Domain pur)
+
+Modéliser une édition découverte et la logique de regroupement par éditeur, sans I/O.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — service Domain pur, `final readonly`, naming.
+- `.claude/backend.md` — R3 (logique métier hors handler, dans un service Domain), R10 (nommage).
+- `.claude/CLAUDE.md` — tests unitaires obligatoires pour VO/service Domain.
+
+**Files:**
+- Create `back/src/Manga/Domain/ExternalEditionDto.php` — `final readonly` : `string $publisher`, `?string $editionLabel`, `?int $year`, `string $language`, `?string $coverUrl`, `?int $volumeCount`, `?string $sampleIsbn`, `string $source`. Méthode `toArray()`.
+- Create `back/src/Manga/Domain/Service/EditionGrouper.php` — `final readonly`. Méthode `group(array $rawVolumes, string $language): array` (retourne `ExternalEditionDto[]`). `$rawVolumes` = liste de `array{publisher:string, year:?int, volumeNumber:?int, title:string, coverUrl:?string, isbn:?string}`.
+- Create `back/tests/Unit/Manga/Domain/ExternalEditionDtoTest.php`.
+- Create `back/tests/Unit/Manga/Domain/Service/EditionGrouperTest.php`.
+
+**Implementation**
+
+`EditionGrouper::group` : ignore les items sans `publisher` ; regroupe par `publisher` normalisé (trim + casse) ; par groupe → `year = min(year non-null)`, `coverUrl` = cover de l'item `volumeNumber===1` sinon plus petit `volumeNumber` ayant une cover sinon premier item avec cover, `volumeCount = max(volumeNumber)` sinon `count`, `sampleIsbn` = premier `isbn` non-null, `editionLabel` = détection de variante via `str_contains` (mots-clés `perfect|deluxe|originale|double|collector|ultimate`) sur les titres, sinon `null`. Aucune exception levée ; entrée vide → `[]`. Nommage complet des variables (R10).
+
+**Tests**
+
+- `ExternalEditionDtoTest` : construction + `toArray()`.
+- `EditionGrouperTest` (toutes branches) : (a) 3 volumes même éditeur, années 2019/2020/2021 → 1 édition year=2019, volumeCount=3 ; (b) deux éditeurs distincts → 2 éditions ; (c) titre « Perfect Edition » → editionLabel='perfect' (ou libellé normalisé) ; (d) item sans publisher → ignoré ; (e) liste vide → `[]` ; (f) cover : tome 1 prioritaire sur tome 3.
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Unit/Manga/Domain/Service/EditionGrouperTest.php tests/Unit/Manga/Domain/ExternalEditionDtoTest.php
+```
+
+---
+
+#### Task 3 : Clients de découverte d'éditions + câblage
+
+Brancher la découverte sur Google Books (principal) et Open Library (complément), agrégés et dédupliqués.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — hexagonal (port Domain, adaptateurs Infrastructure), tagged iterator.
+- `.claude/backend.md` — R2/R4 (port Domain ↔ adaptateur Infrastructure), R6 (dépendances), R10.
+- `.claude/CLAUDE.md` — `NullMangaApiClient`/`when@test` pour stubber l'HTTP, External API (Google Books).
+
+**Files:**
+- Create `back/src/Manga/Domain/EditionDiscoveryInterface.php` — `discoverEditions(string $workTitle, string $language = 'fr'): array` (`ExternalEditionDto[]`).
+- Create `back/src/Manga/Infrastructure/ExternalApi/GoogleBooksEditionDiscoveryClient.php` — implémente `EditionDiscoveryInterface` ; injecte `HttpClientInterface`, `string $apiKey`, `EditionGrouper`, `LoggerInterface` ; parcourt 1–2 pages `/volumes` (`langRestrict`), normalise les items (`publisher`, année depuis `publishedDate`, `volumeNumber` depuis le titre/`seriesInfo`, `coverUrl` via la même extraction que `GoogleBooksMangaApiClient`, `isbn` depuis `industryIdentifiers`) → `EditionGrouper::group`.
+- Create `back/src/Manga/Infrastructure/ExternalApi/OpenLibraryEditionDiscoveryClient.php` — implémente `EditionDiscoveryInterface` ; `HttpClientInterface` + `string $baseUrl` (réutiliser `OPEN_LIBRARY_COVERS_BASE_URL` ou ajouter `OPEN_LIBRARY_BASE_URL=https://openlibrary.org`) ; `search.json?q={title}&fields=…,editions,editions.*`, filtre `editions.language` sur la langue cible, map → `ExternalEditionDto` (cover par ISBN).
+- Create `back/src/Manga/Infrastructure/ExternalApi/CompositeEditionDiscoveryClient.php` — `iterable $providers` (`!tagged_iterator app.edition_discovery_provider`) + logger ; concatène puis déduplique par `(publisher|year)`.
+- Create `back/src/Manga/Infrastructure/ExternalApi/NullEditionDiscoveryClient.php` — retourne `[]`.
+- Modify `back/config/services.yaml` — alias `App\Manga\Domain\EditionDiscoveryInterface: '@…CompositeEditionDiscoveryClient'` ; `CompositeEditionDiscoveryClient` `$providers: !tagged_iterator {tag: app.edition_discovery_provider}` ; taguer Google (priorité 100) et OpenLibrary (50) ; `GoogleBooksEditionDiscoveryClient` `$apiKey: '%env(GOOGLE_BOOKS_API_KEY)%'` ; `OpenLibraryEditionDiscoveryClient` `$baseUrl`. Dans `when@test:`, alias `EditionDiscoveryInterface → NullEditionDiscoveryClient`.
+- Modify `back/.env` — ajouter `OPEN_LIBRARY_BASE_URL=https://openlibrary.org` si non réutilisation du covers base url.
+- Create `back/tests/Unit/Manga/Infrastructure/GoogleBooksEditionDiscoveryClientTest.php`.
+- Create `back/tests/Unit/Manga/Infrastructure/OpenLibraryEditionDiscoveryClientTest.php`.
+- Create `back/tests/Unit/Manga/Infrastructure/CompositeEditionDiscoveryClientTest.php`.
+
+**Implementation**
+
+Suivre le style HTTP de `GoogleBooksMangaApiClient` (try/catch → `[]`, normalisation URL cover `http→https`, retrait `&edge=curl`). `EditionGrouper` est injecté dans le client Google (la grosse logique reste pure/testée en T2). Le Composite suit `CompositeMangaCoverApiClient` (itère le tagged iterator). `final readonly` partout. Pas de FQCN built-in (importer `Throwable`).
+
+**Tests** (`MockHttpClient` + `MockResponse`, calqués sur `GoogleBooksMangaApiClientTest`)
+
+- Google : réponse avec 2 éditeurs × 3 tomes → 2 `ExternalEditionDto` correctes ; HTTP 503 → `[]` ; items sans publisher → ignorés.
+- OpenLibrary : réponse `search.json` avec éditions FR/EN, langue='fr' → ne garde que FR.
+- Composite : deux providers renvoyant un doublon `(Glénat|2019)` → une seule édition (Google prioritaire).
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Unit/Manga/Infrastructure
+docker compose exec back php bin/console lint:container
+```
+
+---
+
+#### Task 4 : Endpoint `GET /api/manga/editions`
+
+Exposer la découverte d'éditions au frontend.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — CQRS query/handler, controller mince.
+- `.claude/backend.md` — R3 (handler orchestrateur).
+- `.claude/CLAUDE.md` — tests fonctionnels obligatoires (tous les codes HTTP).
+
+**Files:**
+- Create `back/src/Manga/Application/DiscoverEditions/DiscoverEditionsQuery.php` — `string $title`, `string $language = 'fr'`.
+- Create `back/src/Manga/Application/DiscoverEditions/DiscoverEditionsHandler.php` — `#[AsMessageHandler(bus:'query.bus')]`, injecte `EditionDiscoveryInterface`, mappe `ExternalEditionDto[]` → `array` via `toArray()`.
+- Modify `back/src/Manga/Infrastructure/Http/MangaController.php` — `#[Route('/editions', methods:['GET'])]` (placer **avant** `/{id}` pour éviter la capture par la route paramétrée) ; lit `title` + `lang` (défaut `fr`) → `DiscoverEditionsQuery`.
+- Modify `back/tests/Functional/Manga/MangaControllerTest.php` — `/api/manga/editions`.
+
+**Implementation**
+
+Comme `searchExternal`/`searchVolumeExternal` : lecture des query params, `queryBus->ask(...)`, `JsonResponse`. En test, `NullEditionDiscoveryClient` renvoie `[]`. Attention à l'ordre des routes : `/editions` et `/external`/`/volume-search` sont déjà déclarées avant `/{id}` → garder ce placement.
+
+**Tests**
+
+- `testDiscoverEditionsReturnsEmpty` : `GET /api/manga/editions?title=Berserk&lang=fr` → 200 + `[]` (Null en test).
+- `testDiscoverEditionsRequiresAuth` : sans token → 401.
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Functional/Manga/MangaControllerTest.php
+```
+
+---
+
+#### Task 5 : `EditionContext` + couvertures fidèles à l'édition
+
+Transmettre l'éditeur/année/langue à la résolution de couverture et permettre l'ancrage par ISBN.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — refactor d'interface propre, VO `final readonly`.
+- `.claude/backend.md` — R4 (port Domain), R10.
+- `.claude/CLAUDE.md` — mettre à jour tous les tests des objets modifiés.
+
+**Files:**
+- Create `back/src/Manga/Domain/EditionContext.php` — `final readonly` : `string $mangaTitle`, `?string $publisher`, `?string $editionLabel`, `?int $year`, `string $language = 'fr'`, `?string $externalWorkId = null`.
+- Modify `back/src/Manga/Domain/MangaCoverProviderInterface.php` — `findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto`.
+- Modify `back/src/Manga/Infrastructure/ExternalApi/GoogleBooksMangaApiClient.php` — nouvelle signature ; requête `"{title}" tome {n} {publisher}` + `langRestrict={context->language}` ; filtrage éditeur si fourni.
+- Modify `back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php` + `OpenLibraryCoversApiClient.php` + `CompositeMangaCoverApiClient.php` — nouvelle signature (MangaDex/OpenLibrary utilisent `context->language`/titre).
+- Modify `back/src/Manga/Infrastructure/ExternalApi/NullMangaCoverApiClient.php` — nouvelle signature.
+- Modify `back/src/Manga/Domain/Service/CoverBatchResolver.php` — `resolveCover` construit un `EditionContext` depuis le `Manga` (title, publisher, edition, editionYear, language, externalWorkId) ; conserve l'ISBN prioritaire.
+- Modify `back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalQuery.php` — ajouter `?string $isbn = null` ; champs `publisher`/`year`/`externalWorkId` optionnels (ou réutiliser `edition` comme label).
+- Modify `back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalHandler.php` — si `isbn` présent → `Isbn::tryFrom` puis `findByIsbn` ; sinon construire `EditionContext` et `findByContext`. `mapDtoToArray` : `language` issu du contexte (retirer le `'fr'` codé en dur).
+- Modify `back/src/Manga/Infrastructure/Http/MangaController.php` — `searchVolumeExternal()` lit `isbn`, `publisher`, `year` et les passe à la query.
+- Modify tests : `GoogleBooksMangaApiClientTest`, `MangaDexMangaApiClientTest`, `OpenLibraryCoversApiClientTest`, `CompositeMangaCoverApiClientTest`, `CoverBatchResolverTest` (nouvelle signature) ; `MangaControllerTest::testVolumeSearch*` (param `isbn`).
+
+**Implementation**
+
+Refactor en **un seul commit** (changement d'interface). Importer `EditionContext` partout. `findByContext` reçoit désormais `$context->mangaTitle`, `$context->publisher`, etc. Les implémentations MangaDex/OpenLibrary qui n'exploitaient que titre/volume restent fonctionnellement identiques (lisent `$context->mangaTitle`, `$context->language`). En test, `NullMangaCoverApiClient` renvoie `null` → `volume-search` reste `[]`.
+
+**Tests**
+
+- Providers : adapter les appels `findByContext(...)` à `new EditionContext(...)`. Ajouter pour Google : un cas où `publisher` est passé → la query contient l'éditeur (assert sur l'URL via `MockResponse` callback).
+- `CoverBatchResolverTest` : signature mise à jour, comportement inchangé (ISBN prioritaire).
+- Functional : `GET /api/manga/volume-search?q=x&isbn=9782344…` → 200 `[]` en test (Null) ; `isbn` invalide via volume-search ne doit pas crasher (tryFrom → ignore).
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Unit/Manga tests/Functional/Manga/MangaControllerTest.php
+```
+
+---
+
+#### Task 6 : `UpdateVolume` persiste l'ISBN
+
+Permettre d'enregistrer l'ISBN (scanné ou saisi) sur un tome.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — command/handler, validation.
+- `.claude/backend.md` — R3.
+- `.claude/CLAUDE.md` — VO `Isbn`, mapping 422, mise à jour du test fonctionnel.
+
+**Files:**
+- Modify `back/src/Manga/Application/UpdateVolume/UpdateVolumeCommand.php` — ajouter `?string $isbn = null`.
+- Modify `back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php` — si `isbn` non-null → `$volume->isbn = Isbn::fromString($command->isbn)` (lève `InvalidIsbnException` → 422).
+- Modify `back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php` — ajouter `?string $isbn = null`.
+- Modify `back/src/Manga/Infrastructure/Http/MangaController.php` — `updateVolume()` passe `isbn`.
+- Modify `back/tests/Functional/Manga/MangaControllerTest.php` — update volume avec isbn valide/invalide.
+
+**Implementation**
+
+`Isbn::fromString` côté handler garantit la validation (422 automatique via `ExceptionListener`). Ne pas écraser un ISBN existant par `null`.
+
+**Tests**
+
+- `testUpdateVolumeWithValidIsbn` : PATCH `{isbn:'9782344020812'}` → 204 ; `GET` détail → `isbn` persisté (forme canonique 13 chiffres).
+- `testUpdateVolumeWithInvalidIsbn` : PATCH `{isbn:'123'}` → 422.
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Functional/Manga/MangaControllerTest.php
+```
+
+---
+
+#### Task 7 : Relais de session de scan (backend)
+
+Démarrer une session, recevoir un ISBN scanné par le téléphone, le pousser en temps réel via Mercure.
+
+**Skills and docs to load:**
+- `/project-quality-setup` — ports Domain + adaptateurs Mercure, command/handler.
+- `.claude/backend.md` — R2/R4 (ports ↔ adaptateurs), R3, R10.
+- `.claude/CLAUDE.md` — `when@test` + doubles, tests fonctionnels (tous codes HTTP), Mercure.
+
+**Files:**
+- Create `back/src/Manga/Domain/ScanSessionAuthorizerInterface.php` — `issueSubscriberToken(string $sessionId, int $ttlSeconds): string`, `topicFor(string $sessionId): string`, `publicHubUrl(): string`.
+- Create `back/src/Manga/Domain/ScanSessionPublisherInterface.php` — `publishIsbn(string $sessionId, string $isbn): void`.
+- Create `back/src/Manga/Infrastructure/Mercure/MercureScanSessionAuthorizer.php` — calqué sur `MercureCoverBatchSubscriberAuthorizer`, topic `https://ziggytheque.app/scan-session/{id}`.
+- Create `back/src/Manga/Infrastructure/Mercure/MercureScanSessionPublisher.php` — calqué sur `MercureCoverBatchProgressPublisher` ; `publishIsbn` publie `json_encode(['type'=>'isbn_scanned','sessionId'=>…,'isbn'=>…])` (private=1).
+- Create `back/src/Manga/Application/StartScanSession/StartScanSessionCommand.php` (vide) + `StartScanSessionHandler.php` (`#[AsMessageHandler(bus:'command.bus')]`, génère `sessionId` via `Uuid`, issue token/topic/hub) + `StartScanSessionResult.php` (`sessionId, mercureUrl, subscriberToken, topic` + `toArray()`).
+- Create `back/src/Manga/Application/PublishScannedIsbn/PublishScannedIsbnCommand.php` (`string $sessionId`, `string $isbn`) + `PublishScannedIsbnHandler.php` (valide `Isbn::fromString`, appelle `publishIsbn`).
+- Create `back/src/Manga/Infrastructure/Http/ScanIsbnRequest.php` — `#[Assert\NotBlank] string $isbn`.
+- Modify `back/src/Manga/Infrastructure/Http/MangaController.php` — `POST /api/manga/scan-session` (202 → `result->toArray()`) ; `POST /api/manga/scan-session/{sessionId}/isbn` (`#[MapRequestPayload] ScanIsbnRequest`, 202).
+- Modify `back/config/services.yaml` — aliases `ScanSessionAuthorizerInterface`/`ScanSessionPublisherInterface` → adaptateurs Mercure (mêmes `$…JwtKey`/`$hubUrl`/`$publicHubUrlValue` que cover-batch) ; `when@test:` → doubles.
+- Create `back/tests/Doubles/Manga/StubScanSessionAuthorizer.php` + `InMemoryScanSessionPublisher.php` (calqués sur les doubles cover-batch existants).
+- Create `back/tests/Functional/Manga/ScanSessionControllerTest.php`.
+- Create `back/tests/Unit/Manga/Application/PublishScannedIsbnHandlerTest.php` (avec `InMemoryScanSessionPublisher`).
+
+**Implementation**
+
+Réutiliser intégralement le pattern cover-batch (déjà testé en prod). `StartScanSessionResult` a la même forme que `StartCoverBatchResult` + `sessionId`. `PublishScannedIsbnHandler` : `Isbn::fromString($command->isbn)` (422 si invalide), puis `publishIsbn($sessionId, $isbn->value)`. La publication est **synchrone** (comme l'issue de token cover-batch). Importer `Throwable`/`Uuid` proprement.
+
+**Tests**
+
+- Functional : `POST /api/manga/scan-session` → 202 + clés `sessionId,mercureUrl,subscriberToken,topic` (topic contient sessionId, via `StubScanSessionAuthorizer`) ; 401 sans token. `POST …/{id}/isbn {isbn:'9782344020812'}` → 202 ; `{isbn:'123'}` → 422 ; 401 sans token.
+- Unit `PublishScannedIsbnHandlerTest` : ISBN valide → 1 event dans `InMemoryScanSessionPublisher` (sessionId+isbn canonique) ; ISBN invalide → `InvalidIsbnException`.
+
+**Verify**
+
+```bash
+docker compose exec back vendor/bin/phpunit tests/Functional/Manga/ScanSessionControllerTest.php tests/Unit/Manga/Application/PublishScannedIsbnHandlerTest.php
+docker compose exec back php bin/console lint:container
+```
+
+---
+
+#### Task 8 : Dépendances front + composable `useBarcodeScanner`
+
+Lecture d'un code-barres EAN-13 via la caméra, avec ponyfill desktop.
+
+**Skills and docs to load:**
+- `/create-adaptable-composable` — entrées `MaybeRefOrGetter`, normalisation `toValue()`, effets réactifs + nettoyage.
+- `/vue-best-practices` — `<script setup>` + TS, lifecycle.
+- `/vue-testing-best-practices` — mock de `BarcodeDetector`/`getUserMedia` sous jsdom.
+
+**Files:**
+- Modify `front/package.json` — deps `barcode-detector` (ponyfill) + `qrcode` ; dev `@types/qrcode`.
+- Create `front/src/composables/useBarcodeScanner.ts`.
+- Create `front/src/composables/__tests__/useBarcodeScanner.spec.ts`.
+
+**Implementation**
+
+`useBarcodeScanner(videoRef: MaybeRefOrGetter<HTMLVideoElement | null>)` : expose `{ isSupported, isScanning, error, start(), stop(), onDetected(cb) }`. Détecteur : `('BarcodeDetector' in globalThis)` → natif, sinon `import('barcode-detector/ponyfill')` → `new BarcodeDetector({formats:['ean_13']})`. `start()` : `getUserMedia({video:{facingMode:'environment'}})`, attache au `<video>`, boucle `requestAnimationFrame`/`setInterval(detect, 250ms)` ; au 1er code `ean_13` valide → callback + `stop()`. `stop()` coupe les `MediaStreamTrack` et la boucle. Nettoyage via `onScopeDispose` (cf. `useCoverBatchProgress`). `isSupported=false` si ni natif ni ponyfill ni caméra.
+
+**Tests**
+
+- Mock `navigator.mediaDevices.getUserMedia` + stub global `BarcodeDetector` renvoyant `[{rawValue:'9782344020812', format:'ean_13'}]` → `onDetected` reçoit la valeur, `stop()` libère les tracks (spy `track.stop`).
+- Sans `getUserMedia` → `isSupported=false`, `start()` positionne `error`.
+
+**Verify**
+
+```bash
+cd front && npm install && npm run test -- useBarcodeScanner && npm run type-check
+```
+
+---
+
+#### Task 9 : Composable `useScanSession` (desktop)
+
+Démarrer une session et recevoir l'ISBN poussé par le téléphone.
+
+**Skills and docs to load:**
+- `/create-adaptable-composable` — composable réactif + nettoyage `onScopeDispose`.
+- `/vue-best-practices` — TS, `<script setup>`.
+- `/vue-testing-best-practices` — mock `EventSource`.
+
+**Files:**
+- Create `front/src/composables/useScanSession.ts`.
+- Create `front/src/composables/__tests__/useScanSession.spec.ts`.
+
+**Implementation**
+
+Calqué sur `useCoverBatchProgress`. `start(callbacks:{onIsbn:(isbn:string)=>void})` : appelle `startScanSession()` (api, T11) → `{sessionId,mercureUrl,subscriberToken,topic}` ; construit l'`EventSource(`${mercureUrl}?topic=…&authorization=token`)` ; `onmessage` → parse, si `type==='isbn_scanned'` → `onIsbn(isbn)`. Expose `{ sessionId, pairingUrl, start, close }` où `pairingUrl = `${location.origin}/scan/${sessionId}``. `close()` ferme l'`EventSource` ; `onScopeDispose(close)`.
+
+**Tests**
+
+- Mock global `EventSource` ; après `start`, simuler un message `{"type":"isbn_scanned","isbn":"9782344020812"}` → `onIsbn` appelé ; `pairingUrl` contient le sessionId ; `close()` appelle `eventSource.close`.
+
+**Verify**
+
+```bash
+cd front && npm run test -- useScanSession && npm run type-check
+```
+
+---
+
+#### Task 10 : Composants de scan + page mobile + intégration
+
+UI de scan caméra (mobile), QR « envoyer sur le téléphone » (desktop), page de relais mobile, branchement dans la fiche tome.
+
+**Skills and docs to load:**
+- `/vue-best-practices` — composants `<script setup>` + TS, props/emits typés.
+- `/vue-router-best-practices` — route `/scan/:sessionId` + `meta.requiresAuth` + param.
+- `/vue-testing-best-practices` — montage @vue/test-utils, mock des composables.
+
+**Files:**
+- Create `front/src/components/molecules/IsbnScanner.vue` — utilise `useBarcodeScanner` ; `<video>` + bouton start/stop ; `@detected="isbn"` ; affiche « caméra indisponible » si `!isSupported`.
+- Create `front/src/components/molecules/ScanViaPhone.vue` — utilise `useScanSession` + `qrcode` (rendu dans un `<canvas>`/`<img>`) ; émet `@isbn`.
+- Create `front/src/pages/ScanRelayPage.vue` — plein écran ; lit `route.params.sessionId` ; `IsbnScanner` ; au scan → `postScannedIsbn(sessionId, isbn)` (T11) → toast « Envoyé » ; permet d'enchaîner les scans.
+- Modify `front/src/router/index.ts` — route top-level `{ path:'/scan/:sessionId', name:'scan-relay', component: ScanRelayPage, meta:{ requiresAuth:true, title:'Scanner' } }`.
+- Modify `front/src/components/organisms/EnrichVolumeModal.vue` — section « Scanner l'ISBN » : `IsbnScanner` (caméra) + `ScanViaPhone` (desktop) + champ ISBN manuel ; à l'obtention d'un ISBN → `searchVolumeExternal(q, 1, vol.number, edition, provider, isbn)` puis `updateVolume(mangaId, volumeId, {coverUrl, isbn})`.
+- Modify `front/src/i18n/fr.json` + `front/src/i18n/en.json` — namespace `scan.*` (`title`, `cameraUnavailable`, `viaPhone`, `scanWithPhone`, `manualIsbn`, `sent`, `apply`…).
+- Create `front/src/components/molecules/__tests__/IsbnScanner.spec.ts` + `__tests__/ScanViaPhone.spec.ts`.
+
+**Implementation**
+
+`EnrichVolumeModal` reçoit déjà `mangaEdition` ; lui ajouter `mangaPublisher`/`mangaEditionYear`/`mangaExternalWorkId` (props) pour la recherche par contexte (passés par `MangaDetailPage`, T13). Heuristique d'affichage : toujours proposer caméra + QR + saisie ; sur desktop sans caméra, `IsbnScanner` montre « indisponible » et l'utilisateur utilise le QR. Réutiliser `coverUrl()` pour l'aperçu.
+
+**Tests**
+
+- `IsbnScanner.spec` : avec `useBarcodeScanner` mocké (`isSupported=true`), déclencher `onDetected` → l'événement `detected` est émis avec l'ISBN ; `isSupported=false` → message d'indisponibilité rendu.
+- `ScanViaPhone.spec` : `useScanSession` mocké → un QR est rendu (présence du `<canvas>`/`<img>`), un message `onIsbn` émet `isbn`.
+
+**Verify**
+
+```bash
+cd front && npm run test && npm run type-check && npm run lint:check
+```
+
+---
+
+#### Task 11 : Couche API frontend + types
+
+Exposer les nouveaux endpoints et champs au frontend.
+
+**Skills and docs to load:**
+- `/vue-best-practices` — typage TS strict de la couche API.
+- `.claude/CLAUDE.md` — couche API front (`api/*.ts`), endpoints.
+
+**Files:**
+- Modify `front/src/api/manga.ts` — `discoverEditions(title, lang)` → `GET /api/manga/editions` ; étendre `searchVolumeExternal(..., isbn?)` ; `updateVolume` payload `+ isbn?` ; `startScanSession()` → `POST /api/manga/scan-session` ; `postScannedIsbn(sessionId, isbn)` → `POST /api/manga/scan-session/{id}/isbn`. Ajouter type `DiscoveredEdition` et `ScanSessionStartResponse`.
+- Modify `front/src/api/collection.ts` — n/a (inchangé) sauf si types partagés.
+- Modify `front/src/types/index.ts` — `Manga` : `publisher: string | null`, `editionYear: number | null`, `externalWorkId: string | null`. `importManga` payload (dans api/manga.ts) `+ publisher?, editionYear?, externalWorkId?`.
+
+**Implementation**
+
+`DiscoveredEdition = { publisher:string; editionLabel:string|null; year:number|null; language:string; coverUrl:string|null; volumeCount:number|null; sampleIsbn:string|null; source:string }`. `ScanSessionStartResponse = { sessionId; mercureUrl; subscriberToken; topic }` (réutiliser la forme de `CoverBatchStartResponse`).
+
+**Verify**
+
+```bash
+cd front && npm run type-check
+```
+
+---
+
+#### Task 12 : Écran « choisir l'édition » dans le flux d'ajout
+
+Insérer l'étape de découverte d'éditions entre la recherche d'œuvre et le formulaire.
+
+**Skills and docs to load:**
+- `/vue-best-practices` — `<script setup>`, état d'étapes, vue-query (`useQuery`).
+- `/vue-testing-best-practices` — montage + mock API.
+- `.claude/CLAUDE.md` — seules les pages appellent `useQuery`/`useMutation`.
+
+**Files:**
+- Create `front/src/components/molecules/EditionCard.vue` — affiche logo éditeur (via `FRENCH_EDITIONS`), `publisher`, `year`, cover tome 1, `volumeCount` ; `@select`.
+- Create `front/src/components/organisms/EditionPicker.vue` — sélecteur de langue (FR par défaut) + grille d'`EditionCard` depuis `discoverEditions` ; état vide → bouton « Saisir manuellement ».
+- Modify `front/src/pages/AddMangaPage.vue` — nouvelle étape 2 « Choisir l'édition » : après `applyResult(work)`, appeler `discoverEditions(work.title, lang)` ; sélection d'une édition → pré-remplir `form` (`publisher`, `editionYear`, `edition` label, `coverUrl`, `totalVolumes`, `externalWorkId`) ; renuméroter les étapes (1 recherche / 2 édition / 3 infos / 4 destination) ; le formulaire (ex-étape 2) gagne les champs `publisher`/`editionYear`.
+- Modify `front/src/i18n/fr.json` + `en.json` — `add.chooseEdition`, `add.editionsFor`, `add.noEditionsFound`, `manga.publisher`, `manga.editionYear`.
+- Create `front/src/components/organisms/__tests__/EditionPicker.spec.ts`.
+
+**Implementation**
+
+`discoverEditions` via `useQuery` côté page (clé `['editions', title, lang]`, `enabled` quand on entre à l'étape 2). `applyResult` ne saute plus directement au formulaire mais à l'étape « édition ». `importManga` (mutation) envoie désormais `publisher`/`editionYear`/`externalWorkId`. Conserver le repli « Saisir manuellement » qui passe à l'étape formulaire avec un form vide.
+
+**Tests**
+
+- `EditionPicker.spec` : `discoverEditions` mocké renvoyant 2 éditions → 2 `EditionCard` ; clic → événement `select` avec l'édition ; réponse vide → bouton manuel visible.
+
+**Verify**
+
+```bash
+cd front && npm run test -- EditionPicker && npm run type-check && npm run lint:check
+```
+
+---
+
+#### Task 13 : Page série — affichage éditeur/année + contexte d'édition
+
+Afficher l'édition structurée et alimenter la recherche de couverture par le contexte d'édition.
+
+**Skills and docs to load:**
+- `/vue-best-practices` — `<script setup>`, édition inline, props typées.
+- `.claude/CLAUDE.md` — atomic design, pages appellent les mutations.
+
+**Files:**
+- Modify `front/src/pages/MangaDetailPage.vue` — en-tête : afficher `publisher` (logo via `FRENCH_EDITIONS`) + `editionYear` + label `edition` ; édition inline pour `publisher`/`editionYear` (étendre `updateMangaMutation` payload `{publisher?, editionYear?}`) ; passer `mangaPublisher`/`mangaEditionYear`/`mangaExternalWorkId` à `<EnrichVolumeModal>`.
+- Modify `front/src/api/manga.ts` — `updateManga` payload `+ publisher?, editionYear?`.
+- Modify `front/src/i18n/fr.json` + `en.json` — libellés `manga.publisher`/`manga.editionYear` (réutilisés de T12).
+
+**Implementation**
+
+L'affichage compose `publisher` + (`edition` ? « — »+label) + (`editionYear` ? « ("+year+") »). `BaseEditionSelector` reste pour éditer le `publisher` (la liste `FRENCH_EDITIONS` correspond à des éditeurs) ; ajouter un petit champ année. `EnrichVolumeModal` (T10) consomme les nouveaux props pour `searchVolumeExternal`.
+
+**Tests**
+
+Pas de test ajouté (page d'intégration ; la logique testable — recherche par contexte/scan — est couverte en T8–T12). Vérification manuelle + type-check.
+
+**Verify**
+
+```bash
+cd front && npm run type-check && npm run lint:check && npm run build
+```
+
+---
+
+#### Task 14 : Final lint, test, and review loop.
+
+Once finished, run lint and test for the affected sub-directories, dump the git diff in a tmp file with `git diff HEAD > /tmp/last-review.diff`, then spawn a `file-reviewer` subagent with the prompt: *"Review the diff at /tmp/last-review.diff. Invoke the `code-review` skill, follow its 'Load thematic rules by file type' step using the diff's file paths, and write structured findings."*
+Fix every finding, then redo all three steps. Repeat until lint passes, tests pass, and the subagent returns no findings (max 5 iterations).

--- a/back/.env
+++ b/back/.env
@@ -35,6 +35,12 @@ MONITOR_PASSWORD=monitor
 GOOGLE_BOOKS_API_KEY=change_me
 MANGADEX_BASE_URL=https://api.mangadex.org
 OPEN_LIBRARY_COVERS_BASE_URL=https://covers.openlibrary.org
+OPEN_LIBRARY_BASE_URL=https://openlibrary.org
+BNF_SRU_BASE_URL=https://catalogue.bnf.fr/api/SRU
+DNB_SRU_BASE_URL=https://services.dnb.de/sru/dnb
+NDL_SRU_BASE_URL=https://ndlsearch.ndl.go.jp/api/sru
+LOC_SRU_BASE_URL=https://www.loc.gov/sru
+BNE_SRU_BASE_URL=https://www.bne.es/SRUBib
 ###< manga external apis ###
 
 ###> mercure ###

--- a/back/config/reference.php
+++ b/back/config/reference.php
@@ -1,0 +1,1529 @@
+<?php
+
+// This file is auto-generated and is for apps only. Bundles SHOULD NOT rely on its content.
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Config\Loader\ParamConfigurator as Param;
+
+/**
+ * This class provides array-shapes for configuring the services and bundles of an application.
+ *
+ * Services declared with the config() method below are autowired and autoconfigured by default.
+ *
+ * This is for apps only. Bundles SHOULD NOT use it.
+ *
+ * Example:
+ *
+ *     ```php
+ *     // config/services.php
+ *     namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+ *
+ *     return App::config([
+ *         'services' => [
+ *             'App\\' => [
+ *                 'resource' => '../src/',
+ *             ],
+ *         ],
+ *     ]);
+ *     ```
+ *
+ * @psalm-type ImportsConfig = list<string|array{
+ *     resource: string,
+ *     type?: string|null,
+ *     ignore_errors?: bool,
+ * }>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
+ * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
+ * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
+ * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
+ * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator
+ * @psalm-type DeprecationType = array{package: string, version: string, message?: string}
+ * @psalm-type DefaultsType = array{
+ *     public?: bool,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ * }
+ * @psalm-type InstanceofType = array{
+ *     shared?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     properties?: array<string, mixed>,
+ *     configurator?: CallbackType,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ * }
+ * @psalm-type DefinitionType = array{
+ *     class?: string,
+ *     file?: string,
+ *     parent?: string,
+ *     shared?: bool,
+ *     synthetic?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     abstract?: bool,
+ *     deprecated?: DeprecationType,
+ *     factory?: CallbackType,
+ *     configurator?: CallbackType,
+ *     arguments?: ArgumentsType,
+ *     properties?: array<string, mixed>,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     decorates?: string,
+ *     decoration_inner_name?: string,
+ *     decoration_priority?: int,
+ *     decoration_on_invalid?: 'exception'|'ignore'|null,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ *     from_callable?: CallbackType,
+ * }
+ * @psalm-type AliasType = string|array{
+ *     alias: string,
+ *     public?: bool,
+ *     deprecated?: DeprecationType,
+ * }
+ * @psalm-type PrototypeType = array{
+ *     resource: string,
+ *     namespace?: string,
+ *     exclude?: string|list<string>,
+ *     parent?: string,
+ *     shared?: bool,
+ *     lazy?: bool|string,
+ *     public?: bool,
+ *     abstract?: bool,
+ *     deprecated?: DeprecationType,
+ *     factory?: CallbackType,
+ *     arguments?: ArgumentsType,
+ *     properties?: array<string, mixed>,
+ *     configurator?: CallbackType,
+ *     calls?: list<CallType>,
+ *     tags?: TagsType,
+ *     resource_tags?: TagsType,
+ *     autowire?: bool,
+ *     autoconfigure?: bool,
+ *     bind?: array<string, mixed>,
+ *     constructor?: string,
+ * }
+ * @psalm-type StackType = array{
+ *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
+ *     public?: bool,
+ *     deprecated?: DeprecationType,
+ * }
+ * @psalm-type ServicesConfig = array{
+ *     _defaults?: DefaultsType,
+ *     _instanceof?: InstanceofType,
+ *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
+ * }
+ * @psalm-type ExtensionType = array<string, mixed>
+ * @psalm-type FrameworkConfig = array{
+ *     secret?: scalar|Param|null,
+ *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
+ *     allowed_http_method_override?: list<string|Param>|null,
+ *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     test?: bool|Param,
+ *     default_locale?: scalar|Param|null, // Default: "en"
+ *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
+ *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
+ *     enabled_locales?: list<scalar|Param|null>,
+ *     trusted_hosts?: list<scalar|Param|null>,
+ *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
+ *     trusted_headers?: list<scalar|Param|null>,
+ *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
+ *     csrf_protection?: bool|array{
+ *         enabled?: scalar|Param|null, // Default: null
+ *         stateless_token_ids?: list<scalar|Param|null>,
+ *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *     },
+ *     form?: bool|array{ // Form configuration
+ *         enabled?: bool|Param, // Default: false
+ *         csrf_protection?: bool|array{
+ *             enabled?: scalar|Param|null, // Default: null
+ *             token_id?: scalar|Param|null, // Default: null
+ *             field_name?: scalar|Param|null, // Default: "_token"
+ *             field_attr?: array<string, scalar|Param|null>,
+ *         },
+ *     },
+ *     http_cache?: bool|array{ // HTTP cache configuration
+ *         enabled?: bool|Param, // Default: false
+ *         debug?: bool|Param, // Default: "%kernel.debug%"
+ *         trace_level?: "none"|"short"|"full"|Param,
+ *         trace_header?: scalar|Param|null,
+ *         default_ttl?: int|Param,
+ *         private_headers?: list<scalar|Param|null>,
+ *         skip_response_headers?: list<scalar|Param|null>,
+ *         allow_reload?: bool|Param,
+ *         allow_revalidate?: bool|Param,
+ *         stale_while_revalidate?: int|Param,
+ *         stale_if_error?: int|Param,
+ *         terminate_on_cache_hit?: bool|Param,
+ *     },
+ *     esi?: bool|array{ // ESI configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     ssi?: bool|array{ // SSI configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     fragments?: bool|array{ // Fragments configuration
+ *         enabled?: bool|Param, // Default: false
+ *         hinclude_default_template?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Default: "/_fragment"
+ *     },
+ *     profiler?: bool|array{ // Profiler configuration
+ *         enabled?: bool|Param, // Default: false
+ *         collect?: bool|Param, // Default: true
+ *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         only_exceptions?: bool|Param, // Default: false
+ *         only_main_requests?: bool|Param, // Default: false
+ *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: true|Param, // Default: true
+ *     },
+ *     workflows?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         workflows?: array<string, array{ // Default: []
+ *             audit_trail?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *             },
+ *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
+ *             marking_store?: array{
+ *                 type?: "method"|Param,
+ *                 property?: scalar|Param|null,
+ *                 service?: scalar|Param|null,
+ *             },
+ *             supports?: list<scalar|Param|null>,
+ *             definition_validators?: list<scalar|Param|null>,
+ *             support_strategy?: scalar|Param|null,
+ *             initial_marking?: list<scalar|Param|null>,
+ *             events_to_dispatch?: list<string|Param>|null,
+ *             places?: list<array{ // Default: []
+ *                 name?: scalar|Param|null,
+ *                 metadata?: array<string, mixed>,
+ *             }>,
+ *             transitions?: list<array{ // Default: []
+ *                 name?: string|Param,
+ *                 guard?: string|Param, // An expression to block the transition.
+ *                 from?: list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
+ *                 }>,
+ *                 to?: list<array{ // Default: []
+ *                     place?: string|Param,
+ *                     weight?: int|Param, // Default: 1
+ *                 }>,
+ *                 weight?: int|Param, // Default: 1
+ *                 metadata?: array<string, mixed>,
+ *             }>,
+ *             metadata?: array<string, mixed>,
+ *         }>,
+ *     },
+ *     router?: bool|array{ // Router configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resource?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|Param|null, // Default: 80
+ *         https_port?: scalar|Param|null, // Default: 443
+ *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         utf8?: bool|Param, // Default: true
+ *     },
+ *     session?: bool|array{ // Session configuration
+ *         enabled?: bool|Param, // Default: false
+ *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|Param|null,
+ *         cookie_lifetime?: scalar|Param|null,
+ *         cookie_path?: scalar|Param|null,
+ *         cookie_domain?: scalar|Param|null,
+ *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
+ *         cookie_httponly?: bool|Param, // Default: true
+ *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
+ *         use_cookies?: bool|Param,
+ *         gc_divisor?: scalar|Param|null,
+ *         gc_probability?: scalar|Param|null,
+ *         gc_maxlifetime?: scalar|Param|null,
+ *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
+ *     },
+ *     request?: bool|array{ // Request configuration
+ *         enabled?: bool|Param, // Default: false
+ *         formats?: array<string, string|list<scalar|Param|null>>,
+ *     },
+ *     assets?: bool|array{ // Assets configuration
+ *         enabled?: bool|Param, // Default: false
+ *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *         version_strategy?: scalar|Param|null, // Default: null
+ *         version?: scalar|Param|null, // Default: null
+ *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|Param|null, // Default: null
+ *         base_path?: scalar|Param|null, // Default: ""
+ *         base_urls?: list<scalar|Param|null>,
+ *         packages?: array<string, array{ // Default: []
+ *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
+ *             version_strategy?: scalar|Param|null, // Default: null
+ *             version?: scalar|Param|null,
+ *             version_format?: scalar|Param|null, // Default: null
+ *             json_manifest_path?: scalar|Param|null, // Default: null
+ *             base_path?: scalar|Param|null, // Default: ""
+ *             base_urls?: list<scalar|Param|null>,
+ *         }>,
+ *     },
+ *     asset_mapper?: bool|array{ // Asset Mapper configuration
+ *         enabled?: bool|Param, // Default: false
+ *         paths?: array<string, scalar|Param|null>,
+ *         excluded_patterns?: list<scalar|Param|null>,
+ *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
+ *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
+ *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
+ *         extensions?: array<string, scalar|Param|null>,
+ *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|Param|null>,
+ *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
+ *             enabled?: bool|Param, // Default: false
+ *             formats?: list<scalar|Param|null>,
+ *             extensions?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     translator?: bool|array{ // Translator configuration
+ *         enabled?: bool|Param, // Default: false
+ *         fallbacks?: list<scalar|Param|null>,
+ *         logging?: bool|Param, // Default: false
+ *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|Param|null>,
+ *         pseudo_localization?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             accents?: bool|Param, // Default: true
+ *             expansion_factor?: float|Param, // Default: 1.0
+ *             brackets?: bool|Param, // Default: true
+ *             parse_html?: bool|Param, // Default: false
+ *             localizable_html_attributes?: list<scalar|Param|null>,
+ *         },
+ *         providers?: array<string, array{ // Default: []
+ *             dsn?: scalar|Param|null,
+ *             domains?: list<scalar|Param|null>,
+ *             locales?: list<scalar|Param|null>,
+ *         }>,
+ *         globals?: array<string, string|array{ // Default: []
+ *             value?: mixed,
+ *             message?: string|Param,
+ *             parameters?: array<string, scalar|Param|null>,
+ *             domain?: string|Param,
+ *         }>,
+ *     },
+ *     validation?: bool|array{ // Validation configuration
+ *         enabled?: bool|Param, // Default: true
+ *         enable_attributes?: bool|Param, // Default: true
+ *         static_method?: list<scalar|Param|null>,
+ *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
+ *         mapping?: array{
+ *             paths?: list<scalar|Param|null>,
+ *         },
+ *         not_compromised_password?: bool|array{
+ *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
+ *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *         },
+ *         disable_translation?: bool|Param, // Default: false
+ *         auto_mapping?: array<string, array{ // Default: []
+ *             services?: list<scalar|Param|null>,
+ *         }>,
+ *     },
+ *     serializer?: bool|array{ // Serializer configuration
+ *         enabled?: bool|Param, // Default: true
+ *         enable_attributes?: bool|Param, // Default: true
+ *         name_converter?: scalar|Param|null,
+ *         circular_reference_handler?: scalar|Param|null,
+ *         max_depth_handler?: scalar|Param|null,
+ *         mapping?: array{
+ *             paths?: list<scalar|Param|null>,
+ *         },
+ *         default_context?: array<string, mixed>,
+ *         named_serializers?: array<string, array{ // Default: []
+ *             name_converter?: scalar|Param|null,
+ *             default_context?: array<string, mixed>,
+ *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
+ *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
+ *         }>,
+ *     },
+ *     property_access?: bool|array{ // Property access configuration
+ *         enabled?: bool|Param, // Default: true
+ *         magic_call?: bool|Param, // Default: false
+ *         magic_get?: bool|Param, // Default: true
+ *         magic_set?: bool|Param, // Default: true
+ *         throw_exception_on_invalid_index?: bool|Param, // Default: false
+ *         throw_exception_on_invalid_property_path?: bool|Param, // Default: true
+ *     },
+ *     type_info?: bool|array{ // Type info configuration
+ *         enabled?: bool|Param, // Default: true
+ *         aliases?: array<string, scalar|Param|null>,
+ *     },
+ *     property_info?: bool|array{ // Property info configuration
+ *         enabled?: bool|Param, // Default: true
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
+ *     },
+ *     cache?: array{ // Cache configuration
+ *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|Param|null,
+ *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|Param|null, // Default: null
+ *         pools?: array<string, array{ // Default: []
+ *             adapters?: list<scalar|Param|null>,
+ *             tags?: scalar|Param|null, // Default: null
+ *             public?: bool|Param, // Default: false
+ *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|Param|null,
+ *             clearer?: scalar|Param|null,
+ *         }>,
+ *     },
+ *     php_errors?: array{ // PHP errors handling configuration
+ *         log?: mixed, // Use the application logger instead of the PHP logger for logging PHP errors. // Default: true
+ *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
+ *     },
+ *     exceptions?: array<string, array{ // Default: []
+ *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *     }>,
+ *     web_link?: bool|array{ // Web links configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     lock?: bool|string|array{ // Lock configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, string|list<scalar|Param|null>>,
+ *     },
+ *     semaphore?: bool|string|array{ // Semaphore configuration
+ *         enabled?: bool|Param, // Default: false
+ *         resources?: array<string, scalar|Param|null>,
+ *     },
+ *     messenger?: bool|array{ // Messenger configuration
+ *         enabled?: bool|Param, // Default: true
+ *         routing?: array<string, string|array{ // Default: []
+ *             senders?: list<scalar|Param|null>,
+ *         }>,
+ *         serializer?: array{
+ *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             symfony_serializer?: array{
+ *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 context?: array<string, mixed>,
+ *             },
+ *         },
+ *         transports?: array<string, string|array{ // Default: []
+ *             dsn?: scalar|Param|null,
+ *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *             options?: array<string, mixed>,
+ *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             retry_strategy?: string|array{
+ *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
+ *             },
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *         }>,
+ *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|Param|null>,
+ *         default_bus?: scalar|Param|null, // Default: null
+ *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
+ *             default_middleware?: bool|string|array{
+ *                 enabled?: bool|Param, // Default: true
+ *                 allow_no_handlers?: bool|Param, // Default: false
+ *                 allow_no_senders?: bool|Param, // Default: true
+ *             },
+ *             middleware?: list<string|array{ // Default: []
+ *                 id?: scalar|Param|null,
+ *                 arguments?: list<mixed>,
+ *             }>,
+ *         }>,
+ *     },
+ *     scheduler?: bool|array{ // Scheduler configuration
+ *         enabled?: bool|Param, // Default: true
+ *     },
+ *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
+ *     http_client?: bool|array{ // HTTP Client configuration
+ *         enabled?: bool|Param, // Default: true
+ *         max_host_connections?: int|Param, // The maximum number of connections to a single host.
+ *         default_options?: array{
+ *             headers?: array<string, mixed>,
+ *             vars?: array<string, mixed>,
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                 sha1?: mixed,
+ *                 pin-sha256?: mixed,
+ *                 md5?: mixed,
+ *             },
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             extra?: array<string, mixed>,
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             caching?: bool|array{ // Caching configuration.
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *             },
+ *             retry_failed?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
+ *                 }>,
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *             },
+ *         },
+ *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         scoped_clients?: array<string, string|array{ // Default: []
+ *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|Param|null>,
+ *             headers?: array<string, mixed>,
+ *             max_redirects?: int|Param, // The maximum number of redirects to follow.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
+ *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
+ *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
+ *                 sha1?: mixed,
+ *                 pin-sha256?: mixed,
+ *                 md5?: mixed,
+ *             },
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             extra?: array<string, mixed>,
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             caching?: bool|array{ // Caching configuration.
+ *                 enabled?: bool|Param, // Default: false
+ *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
+ *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *             },
+ *             retry_failed?: bool|array{
+ *                 enabled?: bool|Param, // Default: false
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
+ *                     code?: int|Param,
+ *                     methods?: list<string|Param>,
+ *                 }>,
+ *                 max_retries?: int|Param, // Default: 3
+ *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
+ *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: delay * (multiple ^ retries). // Default: 2
+ *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
+ *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
+ *             },
+ *         }>,
+ *     },
+ *     mailer?: bool|array{ // Mailer configuration
+ *         enabled?: bool|Param, // Default: true
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|Param|null, // Default: null
+ *         transports?: array<string, scalar|Param|null>,
+ *         envelope?: array{ // Mailer Envelope configuration
+ *             sender?: scalar|Param|null,
+ *             recipients?: list<scalar|Param|null>,
+ *             allowed_recipients?: list<scalar|Param|null>,
+ *         },
+ *         headers?: array<string, string|array{ // Default: []
+ *             value?: mixed,
+ *         }>,
+ *         dkim_signer?: bool|array{ // DKIM signer configuration
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|Param|null, // Default: ""
+ *             select?: scalar|Param|null, // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
+ *             options?: array<string, mixed>,
+ *         },
+ *         smime_signer?: bool|array{ // S/MIME signer configuration
+ *             enabled?: bool|Param, // Default: false
+ *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|Param|null, // Default: null
+ *             sign_options?: int|Param, // Default: null
+ *         },
+ *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
+ *             enabled?: bool|Param, // Default: false
+ *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
+ *         },
+ *     },
+ *     secrets?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
+ *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *     },
+ *     notifier?: bool|array{ // Notifier configuration
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|Param|null>,
+ *         texter_transports?: array<string, scalar|Param|null>,
+ *         notification_on_failed_messages?: bool|Param, // Default: false
+ *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         admin_recipients?: list<array{ // Default: []
+ *             email?: scalar|Param|null,
+ *             phone?: scalar|Param|null, // Default: ""
+ *         }>,
+ *     },
+ *     rate_limiter?: bool|array{ // Rate limiter configuration
+ *         enabled?: bool|Param, // Default: false
+ *         limiters?: array<string, array{ // Default: []
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|Param|null>,
+ *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
+ *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
+ *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
+ *             },
+ *         }>,
+ *     },
+ *     uid?: bool|array{ // Uid configuration
+ *         enabled?: bool|Param, // Default: true
+ *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
+ *         name_based_uuid_version?: 5|3|Param, // Default: 5
+ *         name_based_uuid_namespace?: scalar|Param|null,
+ *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
+ *         time_based_uuid_node?: scalar|Param|null,
+ *     },
+ *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
+ *         enabled?: bool|Param, // Default: false
+ *         sanitizers?: array<string, array{ // Default: []
+ *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
+ *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
+ *             allow_elements?: array<string, mixed>,
+ *             block_elements?: list<string|Param>,
+ *             drop_elements?: list<string|Param>,
+ *             allow_attributes?: array<string, mixed>,
+ *             drop_attributes?: array<string, mixed>,
+ *             force_attributes?: array<string, array<string, string|Param>>,
+ *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
+ *             allowed_link_schemes?: list<string|Param>,
+ *             allowed_link_hosts?: list<string|Param>|null,
+ *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
+ *             allowed_media_schemes?: list<string|Param>,
+ *             allowed_media_hosts?: list<string|Param>|null,
+ *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
+ *             with_attribute_sanitizers?: list<string|Param>,
+ *             without_attribute_sanitizers?: list<string|Param>,
+ *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
+ *         }>,
+ *     },
+ *     webhook?: bool|array{ // Webhook configuration
+ *         enabled?: bool|Param, // Default: false
+ *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         routing?: array<string, array{ // Default: []
+ *             service?: scalar|Param|null,
+ *             secret?: scalar|Param|null, // Default: ""
+ *         }>,
+ *     },
+ *     remote-event?: bool|array{ // RemoteEvent configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ *     json_streamer?: bool|array{ // JSON streamer configuration
+ *         enabled?: bool|Param, // Default: false
+ *     },
+ * }
+ * @psalm-type SecurityConfig = array{
+ *     access_denied_url?: scalar|Param|null, // Default: null
+ *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
+ *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
+ *     erase_credentials?: bool|Param, // Default: true
+ *     access_decision_manager?: array{
+ *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority"|Param,
+ *         service?: scalar|Param|null,
+ *         strategy_service?: scalar|Param|null,
+ *         allow_if_all_abstain?: bool|Param, // Default: false
+ *         allow_if_equal_granted_denied?: bool|Param, // Default: true
+ *     },
+ *     password_hashers?: array<string, string|array{ // Default: []
+ *         algorithm?: scalar|Param|null,
+ *         migrate_from?: list<scalar|Param|null>,
+ *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *         key_length?: scalar|Param|null, // Default: 40
+ *         ignore_case?: bool|Param, // Default: false
+ *         encode_as_base64?: bool|Param, // Default: true
+ *         iterations?: scalar|Param|null, // Default: 5000
+ *         cost?: int|Param, // Default: null
+ *         memory_cost?: scalar|Param|null, // Default: null
+ *         time_cost?: scalar|Param|null, // Default: null
+ *         id?: scalar|Param|null,
+ *     }>,
+ *     providers?: array<string, array{ // Default: []
+ *         id?: scalar|Param|null,
+ *         chain?: array{
+ *             providers?: list<scalar|Param|null>,
+ *         },
+ *         memory?: array{
+ *             users?: array<string, array{ // Default: []
+ *                 password?: scalar|Param|null, // Default: null
+ *                 roles?: list<scalar|Param|null>,
+ *             }>,
+ *         },
+ *         ldap?: array{
+ *             service?: scalar|Param|null,
+ *             base_dn?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: null
+ *             search_password?: scalar|Param|null, // Default: null
+ *             extra_fields?: list<scalar|Param|null>,
+ *             default_roles?: list<scalar|Param|null>,
+ *             role_fetcher?: scalar|Param|null, // Default: null
+ *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
+ *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
+ *             password_attribute?: scalar|Param|null, // Default: null
+ *         },
+ *         lexik_jwt?: array{
+ *             class?: scalar|Param|null, // Default: "Lexik\\Bundle\\JWTAuthenticationBundle\\Security\\User\\JWTUser"
+ *         },
+ *         entity?: array{
+ *             class?: scalar|Param|null, // The full entity class name of your user class.
+ *             property?: scalar|Param|null, // Default: null
+ *             manager_name?: scalar|Param|null, // Default: null
+ *         },
+ *     }>,
+ *     firewalls?: array<string, array{ // Default: []
+ *         pattern?: scalar|Param|null,
+ *         host?: scalar|Param|null,
+ *         methods?: list<scalar|Param|null>,
+ *         security?: bool|Param, // Default: true
+ *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *         request_matcher?: scalar|Param|null,
+ *         access_denied_url?: scalar|Param|null,
+ *         access_denied_handler?: scalar|Param|null,
+ *         entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
+ *         provider?: scalar|Param|null,
+ *         stateless?: bool|Param, // Default: false
+ *         lazy?: bool|Param, // Default: false
+ *         context?: scalar|Param|null,
+ *         logout?: array{
+ *             enable_csrf?: bool|Param|null, // Default: null
+ *             csrf_token_id?: scalar|Param|null, // Default: "logout"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_manager?: scalar|Param|null,
+ *             path?: scalar|Param|null, // Default: "/logout"
+ *             target?: scalar|Param|null, // Default: "/"
+ *             invalidate_session?: bool|Param, // Default: true
+ *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             delete_cookies?: array<string, array{ // Default: []
+ *                 path?: scalar|Param|null, // Default: null
+ *                 domain?: scalar|Param|null, // Default: null
+ *                 secure?: scalar|Param|null, // Default: false
+ *                 samesite?: scalar|Param|null, // Default: null
+ *                 partitioned?: scalar|Param|null, // Default: false
+ *             }>,
+ *         },
+ *         switch_user?: array{
+ *             provider?: scalar|Param|null,
+ *             parameter?: scalar|Param|null, // Default: "_switch_user"
+ *             role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *             target_route?: scalar|Param|null, // Default: null
+ *         },
+ *         required_badges?: list<scalar|Param|null>,
+ *         custom_authenticators?: list<scalar|Param|null>,
+ *         login_throttling?: array{
+ *             limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *             max_attempts?: int|Param, // Default: 5
+ *             interval?: scalar|Param|null, // Default: "1 minute"
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
+ *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
+ *         },
+ *         x509?: array{
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
+ *             credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
+ *             user_identifier?: scalar|Param|null, // Default: "emailAddress"
+ *         },
+ *         remote_user?: array{
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "REMOTE_USER"
+ *         },
+ *         jwt?: array{
+ *             provider?: scalar|Param|null, // Default: null
+ *             authenticator?: scalar|Param|null, // Default: "lexik_jwt_authentication.security.jwt_authenticator"
+ *         },
+ *         login_link?: array{
+ *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *             check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *             signature_properties?: list<scalar|Param|null>,
+ *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
+ *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
+ *             used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
+ *             success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *             failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *             provider?: scalar|Param|null, // The user provider to load users from.
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *         },
+ *         form_login?: array{
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *         },
+ *         form_login_ldap?: array{
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
+ *             enable_csrf?: bool|Param, // Default: false
+ *             post_only?: bool|Param, // Default: true
+ *             form_only?: bool|Param, // Default: false
+ *             always_use_default_target_path?: bool|Param, // Default: false
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
+ *             use_referer?: bool|Param, // Default: false
+ *             failure_path?: scalar|Param|null, // Default: null
+ *             failure_forward?: bool|Param, // Default: false
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
+ *         },
+ *         json_login?: array{
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
+ *         },
+ *         json_login_ldap?: array{
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
+ *             use_forward?: bool|Param, // Default: false
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
+ *         },
+ *         access_token?: array{
+ *             provider?: scalar|Param|null,
+ *             remember_me?: bool|Param, // Default: true
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: null
+ *             token_extractors?: list<scalar|Param|null>,
+ *             token_handler?: string|array{
+ *                 id?: scalar|Param|null,
+ *                 oidc_user_info?: string|array{
+ *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                     discovery?: array{ // Enable the OIDC discovery.
+ *                         cache?: array{
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                         },
+ *                     },
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                     client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
+ *                 },
+ *                 oidc?: array{
+ *                     discovery?: array{ // Enable the OIDC discovery.
+ *                         base_uri?: list<scalar|Param|null>,
+ *                         cache?: array{
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
+ *                         },
+ *                     },
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
+ *                     issuers?: list<scalar|Param|null>,
+ *                     algorithms?: list<scalar|Param|null>,
+ *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                     encryption?: bool|array{
+ *                         enabled?: bool|Param, // Default: false
+ *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
+ *                         algorithms?: list<scalar|Param|null>,
+ *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                     },
+ *                 },
+ *                 cas?: array{
+ *                     validation_url?: scalar|Param|null, // CAS server validation URL
+ *                     prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
+ *                     http_client?: scalar|Param|null, // HTTP Client service // Default: null
+ *                 },
+ *                 oauth2?: scalar|Param|null,
+ *             },
+ *         },
+ *         http_basic?: array{
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
+ *         },
+ *         http_basic_ldap?: array{
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
+ *         },
+ *         remember_me?: array{
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *             service?: scalar|Param|null,
+ *             user_providers?: list<scalar|Param|null>,
+ *             catch_exceptions?: bool|Param, // Default: true
+ *             signature_properties?: list<scalar|Param|null>,
+ *             token_provider?: string|array{
+ *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
+ *                 doctrine?: bool|array{
+ *                     enabled?: bool|Param, // Default: false
+ *                     connection?: scalar|Param|null, // Default: null
+ *                 },
+ *             },
+ *             token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
+ *             name?: scalar|Param|null, // Default: "REMEMBERME"
+ *             lifetime?: int|Param, // Default: 31536000
+ *             path?: scalar|Param|null, // Default: "/"
+ *             domain?: scalar|Param|null, // Default: null
+ *             secure?: true|false|"auto"|Param, // Default: false
+ *             httponly?: bool|Param, // Default: true
+ *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: null
+ *             always_remember_me?: bool|Param, // Default: false
+ *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
+ *         },
+ *     }>,
+ *     access_control?: list<array{ // Default: []
+ *         request_matcher?: scalar|Param|null, // Default: null
+ *         requires_channel?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
+ *         host?: scalar|Param|null, // Default: null
+ *         port?: int|Param, // Default: null
+ *         ips?: list<scalar|Param|null>,
+ *         attributes?: array<string, scalar|Param|null>,
+ *         route?: scalar|Param|null, // Default: null
+ *         methods?: list<scalar|Param|null>,
+ *         allow_if?: scalar|Param|null, // Default: null
+ *         roles?: list<scalar|Param|null>,
+ *     }>,
+ *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
+ * }
+ * @psalm-type LexikJwtAuthenticationConfig = array{
+ *     public_key?: scalar|Param|null, // The key used to sign tokens (useless for HMAC). If not set, the key will be automatically computed from the secret key. // Default: null
+ *     additional_public_keys?: list<scalar|Param|null>,
+ *     secret_key?: scalar|Param|null, // The key used to sign tokens. It can be a raw secret (for HMAC), a raw RSA/ECDSA key or the path to a file itself being plaintext or PEM. // Default: null
+ *     pass_phrase?: scalar|Param|null, // The key passphrase (useless for HMAC) // Default: ""
+ *     token_ttl?: scalar|Param|null, // Default: 3600
+ *     allow_no_expiration?: bool|Param, // Allow tokens without "exp" claim (i.e. indefinitely valid, no lifetime) to be considered valid. Caution: usage of this should be rare. // Default: false
+ *     clock_skew?: scalar|Param|null, // Default: 0
+ *     encoder?: array{
+ *         service?: scalar|Param|null, // Default: "lexik_jwt_authentication.encoder.lcobucci"
+ *         signature_algorithm?: scalar|Param|null, // Default: "RS256"
+ *     },
+ *     user_id_claim?: scalar|Param|null, // Default: "username"
+ *     token_extractors?: array{
+ *         authorization_header?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *             prefix?: scalar|Param|null, // Default: "Bearer"
+ *             name?: scalar|Param|null, // Default: "Authorization"
+ *         },
+ *         cookie?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             name?: scalar|Param|null, // Default: "BEARER"
+ *         },
+ *         query_parameter?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             name?: scalar|Param|null, // Default: "bearer"
+ *         },
+ *         split_cookie?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             cookies?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     remove_token_from_body_when_cookies_used?: scalar|Param|null, // Default: true
+ *     set_cookies?: array<string, array{ // Default: []
+ *         lifetime?: scalar|Param|null, // The cookie lifetime. If null, the "token_ttl" option value will be used // Default: null
+ *         samesite?: "none"|"lax"|"strict"|Param, // Default: "lax"
+ *         path?: scalar|Param|null, // Default: "/"
+ *         domain?: scalar|Param|null, // Default: null
+ *         secure?: scalar|Param|null, // Default: true
+ *         httpOnly?: scalar|Param|null, // Default: true
+ *         partitioned?: scalar|Param|null, // Default: false
+ *         split?: list<scalar|Param|null>,
+ *     }>,
+ *     api_platform?: bool|array{ // API Platform compatibility: add check_path in OpenAPI documentation.
+ *         enabled?: bool|Param, // Default: false
+ *         check_path?: scalar|Param|null, // The login check path to add in OpenAPI. // Default: null
+ *         username_path?: scalar|Param|null, // The path to the username in the JSON body. // Default: null
+ *         password_path?: scalar|Param|null, // The path to the password in the JSON body. // Default: null
+ *     },
+ *     access_token_issuance?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         signature?: array{
+ *             algorithm?: scalar|Param|null, // The algorithm use to sign the access tokens.
+ *             key?: scalar|Param|null, // The signature key. It shall be JWK encoded.
+ *         },
+ *         encryption?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             key_encryption_algorithm?: scalar|Param|null, // The key encryption algorithm is used to encrypt the token.
+ *             content_encryption_algorithm?: scalar|Param|null, // The key encryption algorithm is used to encrypt the token.
+ *             key?: scalar|Param|null, // The encryption key. It shall be JWK encoded.
+ *         },
+ *     },
+ *     access_token_verification?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         signature?: array{
+ *             header_checkers?: list<scalar|Param|null>,
+ *             claim_checkers?: list<scalar|Param|null>,
+ *             mandatory_claims?: list<scalar|Param|null>,
+ *             allowed_algorithms?: list<scalar|Param|null>,
+ *             keyset?: scalar|Param|null, // The signature keyset. It shall be JWKSet encoded.
+ *         },
+ *         encryption?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             continue_on_decryption_failure?: bool|Param, // If enable, non-encrypted tokens or tokens that failed during decryption or verification processes are accepted. // Default: false
+ *             header_checkers?: list<scalar|Param|null>,
+ *             allowed_key_encryption_algorithms?: list<scalar|Param|null>,
+ *             allowed_content_encryption_algorithms?: list<scalar|Param|null>,
+ *             keyset?: scalar|Param|null, // The encryption keyset. It shall be JWKSet encoded.
+ *         },
+ *     },
+ *     blocklist_token?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         cache?: scalar|Param|null, // Storage to track blocked tokens // Default: "cache.app"
+ *     },
+ * }
+ * @psalm-type NelmioCorsConfig = array{
+ *     defaults?: array{
+ *         allow_credentials?: bool|Param, // Default: false
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
+ *         allow_private_network?: bool|Param, // Default: false
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
+ *         origin_regex?: bool|Param, // Default: false
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
+ *         skip_same_as_origin?: bool|Param, // Default: true
+ *     },
+ *     paths?: array<string, array{ // Default: []
+ *         allow_credentials?: bool|Param,
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
+ *         allow_private_network?: bool|Param,
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
+ *         origin_regex?: bool|Param,
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
+ *         skip_same_as_origin?: bool|Param,
+ *     }>,
+ * }
+ * @psalm-type MakerConfig = array{
+ *     root_namespace?: scalar|Param|null, // Default: "App"
+ *     generate_final_classes?: bool|Param, // Default: true
+ *     generate_final_entities?: bool|Param, // Default: false
+ * }
+ * @psalm-type DoctrineConfig = array{
+ *     dbal?: array{
+ *         default_connection?: scalar|Param|null,
+ *         types?: array<string, string|array{ // Default: []
+ *             class?: scalar|Param|null,
+ *         }>,
+ *         driver_schemes?: array<string, scalar|Param|null>,
+ *         connections?: array<string, array{ // Default: []
+ *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *             dbname?: scalar|Param|null,
+ *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *             port?: scalar|Param|null, // Defaults to null at runtime.
+ *             user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *             password?: scalar|Param|null, // Defaults to null at runtime.
+ *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *             application_name?: scalar|Param|null,
+ *             charset?: scalar|Param|null,
+ *             path?: scalar|Param|null,
+ *             memory?: bool|Param,
+ *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             driver?: scalar|Param|null, // Default: "pdo_mysql"
+ *             auto_commit?: bool|Param,
+ *             schema_filter?: scalar|Param|null,
+ *             logging?: bool|Param, // Default: true
+ *             profiling?: bool|Param, // Default: true
+ *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
+ *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
+ *             server_version?: scalar|Param|null,
+ *             idle_connection_ttl?: int|Param, // Default: 600
+ *             driver_class?: scalar|Param|null,
+ *             wrapper_class?: scalar|Param|null,
+ *             keep_replica?: bool|Param,
+ *             options?: array<string, mixed>,
+ *             mapping_types?: array<string, scalar|Param|null>,
+ *             default_table_options?: array<string, scalar|Param|null>,
+ *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *             result_cache?: scalar|Param|null,
+ *             replicas?: array<string, array{ // Default: []
+ *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|Param|null,
+ *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|Param|null, // Defaults to null at runtime.
+ *                 user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                 password?: scalar|Param|null, // Defaults to null at runtime.
+ *                 dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|Param|null,
+ *                 charset?: scalar|Param|null,
+ *                 path?: scalar|Param|null,
+ *                 memory?: bool|Param,
+ *                 unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
+ *                 protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
+ *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
+ *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
+ *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             }>,
+ *         }>,
+ *     },
+ *     orm?: array{
+ *         default_entity_manager?: scalar|Param|null,
+ *         enable_native_lazy_objects?: bool|Param, // Deprecated: The "enable_native_lazy_objects" option is deprecated and will be removed in DoctrineBundle 4.0, as native lazy objects are now always enabled. // Default: true
+ *         controller_resolver?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *             auto_mapping?: bool|Param, // Deprecated: The "doctrine.orm.controller_resolver.auto_mapping.auto_mapping" option is deprecated and will be removed in DoctrineBundle 4.0, as it only accepts `false` since 3.0. // Set to true to enable using route placeholders as lookup criteria when the primary key doesn't match the argument name // Default: false
+ *             evict_cache?: bool|Param, // Set to true to fetch the entity from the database instead of using the cache, if any // Default: false
+ *         },
+ *         entity_managers?: array<string, array{ // Default: []
+ *             query_cache_driver?: string|array{
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
+ *             },
+ *             metadata_cache_driver?: string|array{
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
+ *             },
+ *             result_cache_driver?: string|array{
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
+ *             },
+ *             entity_listeners?: array{
+ *                 entities?: array<string, array{ // Default: []
+ *                     listeners?: array<string, array{ // Default: []
+ *                         events?: list<array{ // Default: []
+ *                             type?: scalar|Param|null,
+ *                             method?: scalar|Param|null, // Default: null
+ *                         }>,
+ *                     }>,
+ *                 }>,
+ *             },
+ *             connection?: scalar|Param|null,
+ *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
+ *             auto_mapping?: scalar|Param|null, // Default: false
+ *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
+ *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
+ *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
+ *             entity_listener_resolver?: scalar|Param|null, // Default: null
+ *             fetch_mode_subselect_batch_size?: scalar|Param|null,
+ *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
+ *             schema_ignore_classes?: list<scalar|Param|null>,
+ *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
+ *             second_level_cache?: array{
+ *                 region_cache_driver?: string|array{
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
+ *                 },
+ *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
+ *                 log_enabled?: bool|Param, // Default: true
+ *                 region_lifetime?: scalar|Param|null, // Default: 3600
+ *                 enabled?: bool|Param, // Default: true
+ *                 factory?: scalar|Param|null,
+ *                 regions?: array<string, array{ // Default: []
+ *                     cache_driver?: string|array{
+ *                         type?: scalar|Param|null, // Default: null
+ *                         id?: scalar|Param|null,
+ *                         pool?: scalar|Param|null,
+ *                     },
+ *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                     lock_lifetime?: scalar|Param|null, // Default: 60
+ *                     type?: scalar|Param|null, // Default: "default"
+ *                     lifetime?: scalar|Param|null, // Default: 0
+ *                     service?: scalar|Param|null,
+ *                     name?: scalar|Param|null,
+ *                 }>,
+ *                 loggers?: array<string, array{ // Default: []
+ *                     name?: scalar|Param|null,
+ *                     service?: scalar|Param|null,
+ *                 }>,
+ *             },
+ *             hydrators?: array<string, scalar|Param|null>,
+ *             mappings?: array<string, bool|string|array{ // Default: []
+ *                 mapping?: scalar|Param|null, // Default: true
+ *                 type?: scalar|Param|null,
+ *                 dir?: scalar|Param|null,
+ *                 alias?: scalar|Param|null,
+ *                 prefix?: scalar|Param|null,
+ *                 is_bundle?: bool|Param,
+ *             }>,
+ *             dql?: array{
+ *                 string_functions?: array<string, scalar|Param|null>,
+ *                 numeric_functions?: array<string, scalar|Param|null>,
+ *                 datetime_functions?: array<string, scalar|Param|null>,
+ *             },
+ *             filters?: array<string, string|array{ // Default: []
+ *                 class?: scalar|Param|null,
+ *                 enabled?: bool|Param, // Default: false
+ *                 parameters?: array<string, mixed>,
+ *             }>,
+ *             identity_generation_preferences?: array<string, scalar|Param|null>,
+ *         }>,
+ *         resolve_target_entities?: array<string, scalar|Param|null>,
+ *     },
+ * }
+ * @psalm-type DoctrineMigrationsConfig = array{
+ *     enable_service_migrations?: bool|Param, // Whether to enable fetching migrations from the service container. // Default: false
+ *     migrations_paths?: array<string, scalar|Param|null>,
+ *     services?: array<string, scalar|Param|null>,
+ *     factories?: array<string, scalar|Param|null>,
+ *     storage?: array{ // Storage to use for migration status metadata.
+ *         table_storage?: array{ // The default metadata storage, implemented as a table in the database.
+ *             table_name?: scalar|Param|null, // Default: null
+ *             version_column_name?: scalar|Param|null, // Default: null
+ *             version_column_length?: scalar|Param|null, // Default: null
+ *             executed_at_column_name?: scalar|Param|null, // Default: null
+ *             execution_time_column_name?: scalar|Param|null, // Default: null
+ *         },
+ *     },
+ *     migrations?: list<scalar|Param|null>,
+ *     connection?: scalar|Param|null, // Connection name to use for the migrations database. // Default: null
+ *     em?: scalar|Param|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
+ *     all_or_nothing?: scalar|Param|null, // Run all migrations in a transaction. // Default: false
+ *     check_database_platform?: scalar|Param|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
+ *     custom_template?: scalar|Param|null, // Custom template path for generated migration classes. // Default: null
+ *     organize_migrations?: scalar|Param|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
+ *     enable_profiler?: bool|Param, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
+ *     transactional?: bool|Param, // Whether or not to wrap migrations in a single transaction. // Default: true
+ * }
+ * @psalm-type ZenstruckMessengerMonitorConfig = array{
+ *     storage?: array{
+ *         exclude?: list<scalar|Param|null>,
+ *         orm?: array{
+ *             entity_class?: scalar|Param|null, // Your Doctrine entity class that extends "Zenstruck\Messenger\Monitor\History\Model\ProcessedMessage"
+ *         },
+ *     },
+ *     cache?: array{
+ *         pool?: scalar|Param|null, // Cache pool to use for worker cache. // Default: "cache.app"
+ *         expired_worker_ttl?: int|Param, // How long to keep expired workers in cache (in seconds). // Default: 3600
+ *     },
+ * }
+ * @psalm-type TwigConfig = array{
+ *     form_themes?: list<scalar|Param|null>,
+ *     globals?: array<string, array{ // Default: []
+ *         id?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         value?: mixed,
+ *     }>,
+ *     autoescape_service?: scalar|Param|null, // Default: null
+ *     autoescape_service_method?: scalar|Param|null, // Default: null
+ *     cache?: scalar|Param|null, // Default: true
+ *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
+ *     debug?: bool|Param, // Default: "%kernel.debug%"
+ *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
+ *     auto_reload?: scalar|Param|null,
+ *     optimizations?: int|Param,
+ *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: list<scalar|Param|null>,
+ *     paths?: array<string, mixed>,
+ *     date?: array{ // The default format options used by the date filter.
+ *         format?: scalar|Param|null, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|Param|null, // Default: "%d days"
+ *         timezone?: scalar|Param|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *     },
+ *     number_format?: array{ // The default format options for the number_format filter.
+ *         decimals?: int|Param, // Default: 0
+ *         decimal_point?: scalar|Param|null, // Default: "."
+ *         thousands_separator?: scalar|Param|null, // Default: ","
+ *     },
+ *     mailer?: array{
+ *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *     },
+ * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
+ * @psalm-type ConfigType = array{
+ *     imports?: ImportsConfig,
+ *     parameters?: ParametersConfig,
+ *     services?: ServicesConfig,
+ *     framework?: FrameworkConfig,
+ *     security?: SecurityConfig,
+ *     lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
+ *     nelmio_cors?: NelmioCorsConfig,
+ *     doctrine?: DoctrineConfig,
+ *     doctrine_migrations?: DoctrineMigrationsConfig,
+ *     zenstruck_messenger_monitor?: ZenstruckMessengerMonitorConfig,
+ *     twig?: TwigConfig,
+ *     "when@dev"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         security?: SecurityConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
+ *         nelmio_cors?: NelmioCorsConfig,
+ *         maker?: MakerConfig,
+ *         doctrine?: DoctrineConfig,
+ *         doctrine_migrations?: DoctrineMigrationsConfig,
+ *         zenstruck_messenger_monitor?: ZenstruckMessengerMonitorConfig,
+ *         twig?: TwigConfig,
+ *     },
+ *     "when@prod"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         security?: SecurityConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
+ *         nelmio_cors?: NelmioCorsConfig,
+ *         doctrine?: DoctrineConfig,
+ *         doctrine_migrations?: DoctrineMigrationsConfig,
+ *         zenstruck_messenger_monitor?: ZenstruckMessengerMonitorConfig,
+ *         twig?: TwigConfig,
+ *     },
+ *     "when@test"?: array{
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         framework?: FrameworkConfig,
+ *         security?: SecurityConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
+ *         nelmio_cors?: NelmioCorsConfig,
+ *         doctrine?: DoctrineConfig,
+ *         doctrine_migrations?: DoctrineMigrationsConfig,
+ *         zenstruck_messenger_monitor?: ZenstruckMessengerMonitorConfig,
+ *         twig?: TwigConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
+ *     },
+ *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
+ *         imports?: ImportsConfig,
+ *         parameters?: ParametersConfig,
+ *         services?: ServicesConfig,
+ *         ...<string, ExtensionType>,
+ *     }>
+ * }
+ */
+final class App
+{
+    /**
+     * @param ConfigType $config
+     *
+     * @psalm-return ConfigType
+     */
+    public static function config(array $config): array
+    {
+        /** @var ConfigType $config */
+        $config = AppReference::config($config);
+
+        return $config;
+    }
+}
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+/**
+ * This class provides array-shapes for configuring the routes of an application.
+ *
+ * Example:
+ *
+ *     ```php
+ *     // config/routes.php
+ *     namespace Symfony\Component\Routing\Loader\Configurator;
+ *
+ *     return Routes::config([
+ *         'controllers' => [
+ *             'resource' => 'routing.controllers',
+ *         ],
+ *     ]);
+ *     ```
+ *
+ * @psalm-type RouteConfig = array{
+ *     path: string|array<string,string>,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type ImportConfig = array{
+ *     resource: string,
+ *     type?: string,
+ *     exclude?: string|list<string>,
+ *     prefix?: string|array<string,string>,
+ *     name_prefix?: string,
+ *     trailing_slash_on_root?: bool,
+ *     controller?: string,
+ *     methods?: string|list<string>,
+ *     requirements?: array<string,string>,
+ *     defaults?: array<string,mixed>,
+ *     options?: array<string,mixed>,
+ *     host?: string|array<string,string>,
+ *     schemes?: string|list<string>,
+ *     condition?: string,
+ *     locale?: string,
+ *     format?: string,
+ *     utf8?: bool,
+ *     stateless?: bool,
+ * }
+ * @psalm-type AliasConfig = array{
+ *     alias: string,
+ *     deprecated?: array{package:string, version:string, message?:string},
+ * }
+ * @psalm-type RoutesConfig = array{
+ *     "when@dev"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     "when@prod"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     "when@test"?: array<string, RouteConfig|ImportConfig|AliasConfig>,
+ *     ...<string, RouteConfig|ImportConfig|AliasConfig>
+ * }
+ */
+final class Routes
+{
+    /**
+     * @param RoutesConfig $config
+     *
+     * @psalm-return RoutesConfig
+     */
+    public static function config(array $config): array
+    {
+        return $config;
+    }
+}

--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -26,6 +26,7 @@ services:
             - '../src/Shared/Domain/'
             - '../src/*/Shared/Event/'
             - '../src/Auth/Domain/ValueObject/'
+            - '../src/Manga/Infrastructure/ExternalApi/AbstractSruEditionDiscoveryClient.php'
 
     # Auth providers
     App\Auth\Infrastructure\Http\MonitorUserProvider:
@@ -136,6 +137,65 @@ services:
         tags:
             - { name: app.manga_cover_provider, priority: 10 }
 
+    # Edition discovery composite — used for discoverEditions endpoint
+    App\Manga\Domain\EditionDiscoveryInterface:
+        alias: App\Manga\Infrastructure\ExternalApi\CompositeEditionDiscoveryClient
+
+    App\Manga\Infrastructure\ExternalApi\CompositeEditionDiscoveryClient:
+        arguments:
+            $providers: !tagged_iterator { tag: app.edition_discovery_provider }
+
+    # National libraries — authoritative per country thanks to legal deposit.
+    # Highest priority so their records win on dedup over the generic providers.
+    # Each serves exactly one country and is a no-op (no HTTP) for the others.
+
+    # Bibliothèque nationale de France — authoritative for French editions.
+    App\Manga\Infrastructure\ExternalApi\BnfEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(BNF_SRU_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 150 }
+
+    # Deutsche Nationalbibliothek — authoritative for German editions.
+    App\Manga\Infrastructure\ExternalApi\DnbEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(DNB_SRU_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 150 }
+
+    # National Diet Library — authoritative for Japanese editions.
+    App\Manga\Infrastructure\ExternalApi\NdlEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(NDL_SRU_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 150 }
+
+    # Library of Congress — authoritative for US editions.
+    App\Manga\Infrastructure\ExternalApi\LocEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(LOC_SRU_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 150 }
+
+    # Biblioteca Nacional de España — authoritative for Spanish editions.
+    App\Manga\Infrastructure\ExternalApi\BneEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(BNE_SRU_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 150 }
+
+    App\Manga\Infrastructure\ExternalApi\GoogleBooksEditionDiscoveryClient:
+        arguments:
+            $apiKey: '%env(GOOGLE_BOOKS_API_KEY)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 100 }
+
+    App\Manga\Infrastructure\ExternalApi\OpenLibraryEditionDiscoveryClient:
+        arguments:
+            $baseUrl: '%env(OPEN_LIBRARY_BASE_URL)%'
+        tags:
+            - { name: app.edition_discovery_provider, priority: 50 }
+
     App\Collection\Domain\CollectionRepositoryInterface:
         alias: App\Collection\Infrastructure\Doctrine\DoctrineCollectionRepository
 
@@ -189,6 +249,23 @@ services:
     App\Stats\Domain\StatsRepositoryInterface:
         alias: App\Stats\Infrastructure\Doctrine\DoctrineStatsRepository
 
+    App\Manga\Domain\ScanSessionAuthorizerInterface:
+        alias: App\Manga\Infrastructure\Mercure\MercureScanSessionAuthorizer
+
+    App\Manga\Infrastructure\Mercure\MercureScanSessionAuthorizer:
+        arguments:
+            $subscriberJwtKey: '%env(MERCURE_SUBSCRIBER_JWT_KEY)%'
+            $publicHubUrlValue: '%env(MERCURE_PUBLIC_URL)%'
+
+    App\Manga\Domain\ScanSessionPublisherInterface:
+        alias: App\Manga\Infrastructure\Mercure\MercureScanSessionPublisher
+
+    App\Manga\Infrastructure\Mercure\MercureScanSessionPublisher:
+        arguments:
+            $hubUrl: '%env(MERCURE_URL)%'
+            $publisherJwtKey: '%env(MERCURE_PUBLISHER_JWT_KEY)%'
+            $logger: '@logger'
+
     App\Manga\Domain\CoverBatchProgressPublisherInterface:
         alias: App\Manga\Infrastructure\Mercure\MercureCoverBatchProgressPublisher
 
@@ -208,6 +285,8 @@ services:
 
 when@test:
     services:
+        App\Manga\Domain\EditionDiscoveryInterface:
+            alias: App\Manga\Infrastructure\ExternalApi\NullEditionDiscoveryClient
         App\Manga\Domain\ExternalApiClientInterface:
             alias: App\Manga\Infrastructure\ExternalApi\NullMangaApiClient
         App\Manga\Domain\MangaCoverProviderInterface:
@@ -227,4 +306,12 @@ when@test:
         App\Manga\Domain\CoverBatchSubscriberAuthorizerInterface:
             alias: App\Tests\Doubles\Manga\StubCoverBatchSubscriberAuthorizer
         App\Tests\Doubles\Manga\StubCoverBatchSubscriberAuthorizer:
+            public: true
+        App\Manga\Domain\ScanSessionAuthorizerInterface:
+            alias: App\Tests\Doubles\Manga\StubScanSessionAuthorizer
+        App\Tests\Doubles\Manga\StubScanSessionAuthorizer:
+            public: true
+        App\Manga\Domain\ScanSessionPublisherInterface:
+            alias: App\Tests\Doubles\Manga\InMemoryScanSessionPublisher
+        App\Tests\Doubles\Manga\InMemoryScanSessionPublisher:
             public: true

--- a/back/migrations/Version20260530000000.php
+++ b/back/migrations/Version20260530000000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260530000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add publisher, edition_year, external_work_id to mangas; backfill publisher from edition';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE mangas ADD COLUMN publisher VARCHAR(255) NULL');
+        $this->addSql('ALTER TABLE mangas ADD COLUMN edition_year INT NULL');
+        $this->addSql('ALTER TABLE mangas ADD COLUMN external_work_id VARCHAR(255) NULL');
+
+        // Backfill: existing edition values are publisher names; move them, clear edition
+        $this->addSql("UPDATE mangas SET publisher = edition, edition = NULL WHERE publisher IS NULL AND edition IS NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE mangas DROP COLUMN publisher');
+        $this->addSql('ALTER TABLE mangas DROP COLUMN edition_year');
+        $this->addSql('ALTER TABLE mangas DROP COLUMN external_work_id');
+    }
+}

--- a/back/src/Manga/Application/DiscoverEditions/DiscoverEditionsHandler.php
+++ b/back/src/Manga/Application/DiscoverEditions/DiscoverEditionsHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\DiscoverEditions;
+
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'query.bus')]
+final readonly class DiscoverEditionsHandler
+{
+    public function __construct(private EditionDiscoveryInterface $editionDiscovery)
+    {
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function __invoke(DiscoverEditionsQuery $query): array
+    {
+        $editions = $this->editionDiscovery->discoverEditions($query->title, $query->country);
+
+        return array_map(
+            fn (ExternalEditionDto $edition) => $edition->toArray(),
+            $editions,
+        );
+    }
+}

--- a/back/src/Manga/Application/DiscoverEditions/DiscoverEditionsQuery.php
+++ b/back/src/Manga/Application/DiscoverEditions/DiscoverEditionsQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\DiscoverEditions;
+
+use App\Manga\Domain\Country;
+
+final readonly class DiscoverEditionsQuery
+{
+    public function __construct(
+        public string $title,
+        public Country $country = Country::France,
+    ) {
+    }
+}

--- a/back/src/Manga/Application/Import/ImportMangaCommand.php
+++ b/back/src/Manga/Application/Import/ImportMangaCommand.php
@@ -16,6 +16,9 @@ final readonly class ImportMangaCommand
         public ?string $genre = null,
         public ?string $externalId = null,
         public ?int $totalVolumes = null,
+        public ?string $publisher = null,
+        public ?int $editionYear = null,
+        public ?string $externalWorkId = null,
     ) {
     }
 }

--- a/back/src/Manga/Application/Import/ImportMangaHandler.php
+++ b/back/src/Manga/Application/Import/ImportMangaHandler.php
@@ -41,6 +41,9 @@ final readonly class ImportMangaHandler
                 coverUrl: $command->coverUrl,
                 genre: $command->genre !== null ? GenreEnum::from($command->genre) : null,
                 externalId: $command->externalId,
+                publisher: $command->publisher,
+                editionYear: $command->editionYear,
+                externalWorkId: $command->externalWorkId,
             );
 
             // Auto-create volume placeholders when total is known from external API

--- a/back/src/Manga/Application/PublishScannedIsbn/PublishScannedIsbnCommand.php
+++ b/back/src/Manga/Application/PublishScannedIsbn/PublishScannedIsbnCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\PublishScannedIsbn;
+
+final readonly class PublishScannedIsbnCommand
+{
+    public function __construct(
+        public string $sessionId,
+        public string $isbn,
+    ) {
+    }
+}

--- a/back/src/Manga/Application/PublishScannedIsbn/PublishScannedIsbnHandler.php
+++ b/back/src/Manga/Application/PublishScannedIsbn/PublishScannedIsbnHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\PublishScannedIsbn;
+
+use App\Manga\Domain\Isbn;
+use App\Manga\Domain\ScanSessionPublisherInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'command.bus')]
+final readonly class PublishScannedIsbnHandler
+{
+    public function __construct(private ScanSessionPublisherInterface $scanSessionPublisher)
+    {
+    }
+
+    public function __invoke(PublishScannedIsbnCommand $command): void
+    {
+        $isbn = Isbn::fromString($command->isbn);
+        $this->scanSessionPublisher->publishIsbn($command->sessionId, $isbn->value);
+    }
+}

--- a/back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalHandler.php
+++ b/back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Manga\Application\SearchVolumeExternal;
 
+use App\Manga\Domain\EditionContext;
+use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
 use Psr\Container\ContainerInterface;
@@ -24,17 +26,32 @@ final readonly class SearchVolumeExternalHandler
         $provider = $this->resolveProvider($query->provider);
         $volumeNumber = $query->volumeNumber ?? 1;
 
-        $coverDto = $provider->findByContext(
+        if ($query->isbn !== null) {
+            $isbn = Isbn::tryFrom($query->isbn);
+            if ($isbn !== null) {
+                $coverDto = $provider->findByIsbn($isbn);
+                if ($coverDto !== null) {
+                    return [$this->mapDtoToArray($coverDto, $query->search, $volumeNumber, $query->language)];
+                }
+            }
+        }
+
+        $editionContext = new EditionContext(
             mangaTitle: $query->search,
-            edition: $query->edition,
-            volumeNumber: $volumeNumber,
+            publisher: $query->publisher,
+            editionLabel: $query->edition,
+            year: $query->year,
+            language: $query->language,
+            externalWorkId: $query->externalWorkId,
         );
+
+        $coverDto = $provider->findByContext($editionContext, $volumeNumber);
 
         if ($coverDto === null) {
             return [];
         }
 
-        return [$this->mapDtoToArray($coverDto, $query->search, $volumeNumber)];
+        return [$this->mapDtoToArray($coverDto, $query->search, $volumeNumber, $query->language)];
     }
 
     private function resolveProvider(string $key): MangaCoverProviderInterface
@@ -47,18 +64,18 @@ final readonly class SearchVolumeExternalHandler
     }
 
     /** @return array<string, mixed> */
-    private function mapDtoToArray(MangaVolumeCoverDto $dto, string $title, int $volumeNumber): array
+    private function mapDtoToArray(MangaVolumeCoverDto $dto, string $title, int $volumeNumber, string $language): array
     {
         return [
-            'externalId' => null,
-            'title' => $title,
-            'edition' => null,
-            'coverUrl' => $dto->coverUrl,
-            'spineUrl' => $dto->spineUrl,
-            'isbn' => $dto->isbn?->value,
-            'language' => 'fr',
+            'externalId'   => null,
+            'title'        => $title,
+            'edition'      => null,
+            'coverUrl'     => $dto->coverUrl,
+            'spineUrl'     => $dto->spineUrl,
+            'isbn'         => $dto->isbn?->value,
+            'language'     => $language,
             'totalVolumes' => null,
-            'source' => $dto->source,
+            'source'       => $dto->source,
         ];
     }
 }

--- a/back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalQuery.php
+++ b/back/src/Manga/Application/SearchVolumeExternal/SearchVolumeExternalQuery.php
@@ -12,6 +12,11 @@ final readonly class SearchVolumeExternalQuery
         public ?int $volumeNumber = null,
         public ?string $edition = null,
         public string $provider = 'composite',
+        public ?string $isbn = null,
+        public ?string $publisher = null,
+        public ?int $year = null,
+        public ?string $externalWorkId = null,
+        public string $language = 'fr',
     ) {
     }
 }

--- a/back/src/Manga/Application/StartScanSession/StartScanSessionCommand.php
+++ b/back/src/Manga/Application/StartScanSession/StartScanSessionCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\StartScanSession;
+
+final readonly class StartScanSessionCommand
+{
+}

--- a/back/src/Manga/Application/StartScanSession/StartScanSessionHandler.php
+++ b/back/src/Manga/Application/StartScanSession/StartScanSessionHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\StartScanSession;
+
+use App\Manga\Domain\ScanSessionAuthorizerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+#[AsMessageHandler(bus: 'command.bus')]
+final readonly class StartScanSessionHandler
+{
+    public function __construct(private ScanSessionAuthorizerInterface $scanSessionAuthorizer)
+    {
+    }
+
+    public function __invoke(StartScanSessionCommand $command): StartScanSessionResult
+    {
+        $sessionId = Uuid::v4()->toRfc4122();
+
+        $subscriberToken = $this->scanSessionAuthorizer->issueSubscriberToken($sessionId, ttlSeconds: 600);
+        $topic = $this->scanSessionAuthorizer->topicFor($sessionId);
+        $mercureUrl = $this->scanSessionAuthorizer->publicHubUrl();
+
+        return new StartScanSessionResult(
+            sessionId: $sessionId,
+            mercureUrl: $mercureUrl,
+            subscriberToken: $subscriberToken,
+            topic: $topic,
+        );
+    }
+}

--- a/back/src/Manga/Application/StartScanSession/StartScanSessionResult.php
+++ b/back/src/Manga/Application/StartScanSession/StartScanSessionResult.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\StartScanSession;
+
+final readonly class StartScanSessionResult
+{
+    public function __construct(
+        public string $sessionId,
+        public string $mercureUrl,
+        public string $subscriberToken,
+        public string $topic,
+    ) {
+    }
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return [
+            'sessionId'       => $this->sessionId,
+            'mercureUrl'      => $this->mercureUrl,
+            'subscriberToken' => $this->subscriberToken,
+            'topic'           => $this->topic,
+        ];
+    }
+}

--- a/back/src/Manga/Application/Update/UpdateMangaCommand.php
+++ b/back/src/Manga/Application/Update/UpdateMangaCommand.php
@@ -11,6 +11,8 @@ final readonly class UpdateMangaCommand
         public ?string $title = null,
         public ?string $edition = null,
         public ?string $coverUrl = null,
+        public ?string $publisher = null,
+        public ?int $editionYear = null,
     ) {
     }
 }

--- a/back/src/Manga/Application/Update/UpdateMangaHandler.php
+++ b/back/src/Manga/Application/Update/UpdateMangaHandler.php
@@ -41,6 +41,14 @@ final readonly class UpdateMangaHandler
                 $manga->coverUrl = $command->coverUrl === '' ? null : $command->coverUrl;
             }
 
+            if ($command->publisher !== null) {
+                $manga->publisher = $command->publisher === '' ? null : $command->publisher;
+            }
+
+            if ($command->editionYear !== null) {
+                $manga->editionYear = $command->editionYear;
+            }
+
             $this->mangaRepository->save($manga);
 
             $this->eventBus->publish(new UpdateMangaSucceededEvent(

--- a/back/src/Manga/Application/UpdateVolume/UpdateVolumeCommand.php
+++ b/back/src/Manga/Application/UpdateVolume/UpdateVolumeCommand.php
@@ -13,6 +13,7 @@ final readonly class UpdateVolumeCommand
         public ?string $releaseDate = null,
         public ?float $price = null,
         public ?string $spineUrl = null,
+        public ?string $isbn = null,
     ) {
     }
 }

--- a/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
+++ b/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Application\UpdateVolume;
 
+use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaRepositoryInterface;
 use App\Manga\Domain\Volume;
 use App\Manga\Shared\Event\UpdateVolumeSucceededEvent;
@@ -53,6 +54,10 @@ final readonly class UpdateVolumeHandler
 
             if ($command->spineUrl !== null) {
                 $volume->spineUrl = $command->spineUrl;
+            }
+
+            if ($command->isbn !== null) {
+                $volume->isbn = Isbn::fromString($command->isbn);
             }
 
             $this->mangaRepository->save($manga);

--- a/back/src/Manga/Domain/Country.php
+++ b/back/src/Manga/Domain/Country.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+/**
+ * Country whose book market editions are searched. The chosen country drives
+ * both the query language and which discovery providers are relevant (the BnF,
+ * for instance, only catalogs works deposited in France).
+ */
+enum Country: string
+{
+    case France = 'FR';
+    case Italy = 'IT';
+    case Spain = 'ES';
+    case Germany = 'DE';
+    case UnitedStates = 'US';
+    case Japan = 'JP';
+
+    /**
+     * ISO 639-1 language code used when querying external edition sources.
+     */
+    public function language(): string
+    {
+        return match ($this) {
+            self::France => 'fr',
+            self::Italy => 'it',
+            self::Spain => 'es',
+            self::Germany => 'de',
+            self::UnitedStates => 'en',
+            self::Japan => 'ja',
+        };
+    }
+
+    public static function default(): self
+    {
+        return self::France;
+    }
+
+    /**
+     * Resolves a country from an arbitrary code, falling back to the default
+     * when the code is null, empty or unknown.
+     */
+    public static function fromCode(?string $code): self
+    {
+        if ($code === null || trim($code) === '') {
+            return self::default();
+        }
+
+        return self::tryFrom(strtoupper(trim($code))) ?? self::default();
+    }
+}

--- a/back/src/Manga/Domain/EditionContext.php
+++ b/back/src/Manga/Domain/EditionContext.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+final readonly class EditionContext
+{
+    public function __construct(
+        public string $mangaTitle,
+        public ?string $publisher = null,
+        public ?string $editionLabel = null,
+        public ?int $year = null,
+        public string $language = 'fr',
+        public ?string $externalWorkId = null,
+    ) {
+    }
+}

--- a/back/src/Manga/Domain/EditionDiscoveryInterface.php
+++ b/back/src/Manga/Domain/EditionDiscoveryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+interface EditionDiscoveryInterface
+{
+    /**
+     * Discover all known editions for a given work title in the requested country's market.
+     *
+     * @return ExternalEditionDto[]
+     */
+    public function discoverEditions(string $workTitle, Country $country): array;
+}

--- a/back/src/Manga/Domain/ExternalEditionDto.php
+++ b/back/src/Manga/Domain/ExternalEditionDto.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+final readonly class ExternalEditionDto
+{
+    public function __construct(
+        public string $publisher,
+        public ?string $editionLabel,
+        public ?int $year,
+        public string $language,
+        public ?string $coverUrl,
+        public ?int $volumeCount,
+        public ?string $sampleIsbn,
+        public string $source,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'publisher'   => $this->publisher,
+            'editionLabel' => $this->editionLabel,
+            'year'        => $this->year,
+            'language'    => $this->language,
+            'coverUrl'    => $this->coverUrl,
+            'volumeCount' => $this->volumeCount,
+            'sampleIsbn'  => $this->sampleIsbn,
+            'source'      => $this->source,
+        ];
+    }
+}

--- a/back/src/Manga/Domain/Manga.php
+++ b/back/src/Manga/Domain/Manga.php
@@ -47,6 +47,12 @@ class Manga
         public ?GenreEnum $genre = null,
         #[ORM\Column(nullable: true)]
         public ?string $externalId = null,
+        #[ORM\Column(nullable: true)]
+        public ?string $publisher = null,
+        #[ORM\Column(nullable: true)]
+        public ?int $editionYear = null,
+        #[ORM\Column(nullable: true)]
+        public ?string $externalWorkId = null,
     ) {
         $this->volumes = new ArrayCollection();
         $this->createdAt = new DateTimeImmutable();
@@ -72,6 +78,9 @@ class Manga
             'coverUrl' => $this->coverUrl,
             'genre' => $this->genre?->value,
             'externalId' => $this->externalId,
+            'publisher' => $this->publisher,
+            'editionYear' => $this->editionYear,
+            'externalWorkId' => $this->externalWorkId,
             'totalVolumes' => $this->volumes->count(),
             'createdAt' => $this->createdAt->format(DateTimeInterface::ATOM),
         ];

--- a/back/src/Manga/Domain/MangaCoverProviderInterface.php
+++ b/back/src/Manga/Domain/MangaCoverProviderInterface.php
@@ -8,10 +8,5 @@ interface MangaCoverProviderInterface
 {
     public function findByIsbn(Isbn $isbn): ?MangaVolumeCoverDto;
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto;
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto;
 }

--- a/back/src/Manga/Domain/ScanSessionAuthorizerInterface.php
+++ b/back/src/Manga/Domain/ScanSessionAuthorizerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+interface ScanSessionAuthorizerInterface
+{
+    public function issueSubscriberToken(string $sessionId, int $ttlSeconds): string;
+
+    public function topicFor(string $sessionId): string;
+
+    public function publicHubUrl(): string;
+}

--- a/back/src/Manga/Domain/ScanSessionPublisherInterface.php
+++ b/back/src/Manga/Domain/ScanSessionPublisherInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+interface ScanSessionPublisherInterface
+{
+    public function publishIsbn(string $sessionId, string $isbn): void;
+}

--- a/back/src/Manga/Domain/Service/CoverBatchResolver.php
+++ b/back/src/Manga/Domain/Service/CoverBatchResolver.php
@@ -7,6 +7,7 @@ namespace App\Manga\Domain\Service;
 use App\Manga\Domain\CoverBatchProgressEvent;
 use App\Manga\Domain\CoverBatchProgressPublisherInterface;
 use App\Manga\Domain\CoverBatchResult;
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\Manga;
 use App\Manga\Domain\MangaCoverProviderInterface;
@@ -124,17 +125,23 @@ final readonly class CoverBatchResolver
 
     private function resolveCover(Manga $manga, Volume $volume): ?MangaVolumeCoverDto
     {
-        return $volume->isbn !== null
-            ? ($this->coverProvider->findByIsbn($volume->isbn) ?? $this->coverProvider->findByContext(
-                $manga->title,
-                $manga->edition,
-                $volume->number,
-            ))
-            : $this->coverProvider->findByContext(
-                $manga->title,
-                $manga->edition,
-                $volume->number,
-            );
+        $editionContext = new EditionContext(
+            mangaTitle: $manga->title,
+            publisher: $manga->publisher,
+            editionLabel: $manga->edition,
+            year: $manga->editionYear,
+            language: $manga->language,
+            externalWorkId: $manga->externalWorkId,
+        );
+
+        if ($volume->isbn !== null) {
+            $coverByIsbn = $this->coverProvider->findByIsbn($volume->isbn);
+            if ($coverByIsbn !== null) {
+                return $coverByIsbn;
+            }
+        }
+
+        return $this->coverProvider->findByContext($editionContext, $volume->number);
     }
 
     private function applyCovers(Volume $volume, string $coverUrl, ?string $spineUrl, ?Isbn $isbn): void

--- a/back/src/Manga/Domain/Service/EditionGrouper.php
+++ b/back/src/Manga/Domain/Service/EditionGrouper.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain\Service;
+
+use App\Manga\Domain\ExternalEditionDto;
+
+/**
+ * @phpstan-type RawVolume array{
+ *     publisher: string|null,
+ *     year: int|null,
+ *     volumeNumber: int|null,
+ *     title: string,
+ *     coverUrl: string|null,
+ *     isbn: string|null
+ * }
+ * @phpstan-type GroupedVolume array{
+ *     publisher: string,
+ *     year: int|null,
+ *     volumeNumber: int|null,
+ *     title: string,
+ *     coverUrl: string|null,
+ *     isbn: string|null
+ * }
+ */
+final readonly class EditionGrouper
+{
+    private const array VARIANT_KEYWORDS = [
+        'perfect', 'deluxe', 'originale', 'double', 'collector', 'ultimate',
+    ];
+
+    /**
+     * Groups raw volume data by publisher into ExternalEditionDto instances.
+     *
+     * @param array<int, RawVolume> $rawVolumes
+     * @return ExternalEditionDto[]
+     */
+    public function group(array $rawVolumes, string $language, string $source = 'grouped'): array
+    {
+        /** @var array<string, array<int, GroupedVolume>> $byPublisher */
+        $byPublisher = [];
+
+        foreach ($rawVolumes as $rawVolume) {
+            if (empty($rawVolume['publisher'])) {
+                continue;
+            }
+
+            $normalizedPublisher = trim((string) $rawVolume['publisher']);
+            if ($normalizedPublisher === '') {
+                continue;
+            }
+
+            $groupKey = strtolower($normalizedPublisher);
+            $byPublisher[$groupKey][] = array_merge($rawVolume, ['publisher' => $normalizedPublisher]);
+        }
+
+        $editions = [];
+
+        foreach ($byPublisher as $groupKey => $volumeItems) {
+            $publisherName = $volumeItems[0]['publisher'];
+
+            $year = $this->resolveMinYear($volumeItems);
+            $coverUrl = $this->resolveCoverUrl($volumeItems);
+            $volumeCount = $this->resolveVolumeCount($volumeItems);
+            $sampleIsbn = $this->resolveSampleIsbn($volumeItems);
+            $editionLabel = $this->resolveEditionLabel($volumeItems);
+
+            $editions[] = new ExternalEditionDto(
+                publisher: $publisherName,
+                editionLabel: $editionLabel,
+                year: $year,
+                language: $language,
+                coverUrl: $coverUrl,
+                volumeCount: $volumeCount,
+                sampleIsbn: $sampleIsbn,
+                source: $source,
+            );
+        }
+
+        return $editions;
+    }
+
+    /**
+     * @param array<int, GroupedVolume> $volumeItems
+     */
+    private function resolveMinYear(array $volumeItems): ?int
+    {
+        $years = array_filter(array_column($volumeItems, 'year'));
+
+        if (empty($years)) {
+            return null;
+        }
+
+        return (int) min($years);
+    }
+
+    /**
+     * @param array<int, GroupedVolume> $volumeItems
+     */
+    private function resolveCoverUrl(array $volumeItems): ?string
+    {
+        // Prefer cover from volume number 1
+        foreach ($volumeItems as $volumeItem) {
+            if ($volumeItem['volumeNumber'] === 1 && $volumeItem['coverUrl'] !== null) {
+                return $volumeItem['coverUrl'];
+            }
+        }
+
+        // Fall back to smallest volume number with a cover
+        $sortedByNumber = $volumeItems;
+        usort($sortedByNumber, static function (array $firstItem, array $secondItem): int {
+            $firstNumber  = $firstItem['volumeNumber'] ?? PHP_INT_MAX;
+            $secondNumber = $secondItem['volumeNumber'] ?? PHP_INT_MAX;
+            return $firstNumber <=> $secondNumber;
+        });
+
+        foreach ($sortedByNumber as $volumeItem) {
+            if ($volumeItem['coverUrl'] !== null) {
+                return $volumeItem['coverUrl'];
+            }
+        }
+
+        // Fall back to any item with a cover
+        foreach ($volumeItems as $volumeItem) {
+            if ($volumeItem['coverUrl'] !== null) {
+                return $volumeItem['coverUrl'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, GroupedVolume> $volumeItems
+     */
+    private function resolveVolumeCount(array $volumeItems): int
+    {
+        $volumeNumbers = array_filter(array_column($volumeItems, 'volumeNumber'));
+
+        if (!empty($volumeNumbers)) {
+            return (int) max($volumeNumbers);
+        }
+
+        return count($volumeItems);
+    }
+
+    /**
+     * @param array<int, GroupedVolume> $volumeItems
+     */
+    private function resolveSampleIsbn(array $volumeItems): ?string
+    {
+        foreach ($volumeItems as $volumeItem) {
+            if ($volumeItem['isbn'] !== null && $volumeItem['isbn'] !== '') {
+                return $volumeItem['isbn'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, GroupedVolume> $volumeItems
+     */
+    private function resolveEditionLabel(array $volumeItems): ?string
+    {
+        foreach ($volumeItems as $volumeItem) {
+            $titleLower = strtolower($volumeItem['title']);
+            foreach (self::VARIANT_KEYWORDS as $keyword) {
+                if (str_contains($titleLower, $keyword)) {
+                    return $keyword;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/AbstractSruEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/AbstractSruEditionDiscoveryClient.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use App\Manga\Domain\Service\EditionGrouper;
+use Psr\Log\LoggerInterface;
+use SimpleXMLElement;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+
+/**
+ * Shared logic for discovering editions from a national library's SRU API
+ * using Dublin Core (or Dublin-Core-compatible) record schemas.
+ *
+ * Thanks to the legal deposit (dépôt légal / Pflichtexemplar / 法定納本),
+ * national libraries catalogue every work published in their country, making
+ * them the authoritative source for that market's editions. Each concrete
+ * client therefore serves exactly one {@see Country} and short-circuits for
+ * any other without an HTTP call.
+ *
+ * @phpstan-import-type RawVolume from EditionGrouper
+ */
+abstract readonly class AbstractSruEditionDiscoveryClient implements EditionDiscoveryInterface
+{
+    private const string SRW_NAMESPACE = 'http://www.loc.gov/zing/srw/';
+    private const string DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
+    private const string DCTERMS_NAMESPACE = 'http://purl.org/dc/terms/';
+    private const string DCNDL_NAMESPACE = 'http://ndl.go.jp/dcndl/terms/';
+    private const string COVERS_BASE_URL = 'https://covers.openlibrary.org';
+
+    /**
+     * ISO 639-1 request language → record language codes accepted as a match.
+     * National libraries label languages with MARC/ISO 639-2 codes (fre, ger,
+     * jpn…); we accept both the 639-2/B and 639-2/T variants plus the bare
+     * 639-1 code so co-edition filtering is tolerant across catalogues.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array LANGUAGE_CODES = [
+        'fr' => ['fre', 'fra', 'fr'],
+        'en' => ['eng', 'en'],
+        'ja' => ['jpn', 'ja'],
+        'de' => ['ger', 'deu', 'de'],
+        'es' => ['spa', 'es'],
+        'it' => ['ita', 'it'],
+    ];
+
+    public function __construct(
+        protected HttpClientInterface $httpClient,
+        protected string $baseUrl,
+        protected EditionGrouper $editionGrouper,
+        protected LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * The single country whose editions this catalogue is authoritative for.
+     */
+    abstract protected function country(): Country;
+
+    /**
+     * Short identifier tagged on every edition produced (e.g. 'bnf', 'dnb').
+     */
+    abstract protected function source(): string;
+
+    abstract protected function sruVersion(): string;
+
+    abstract protected function recordSchema(): string;
+
+    /**
+     * Builds the catalogue-specific CQL query for a title search.
+     */
+    abstract protected function buildQuery(string $workTitle): string;
+
+    /**
+     * Maximum number of records to request per call.
+     * Each catalogue enforces its own server-side cap; override accordingly.
+     */
+    abstract protected function maximumRecords(): int;
+
+    /**
+     * @return ExternalEditionDto[]
+     */
+    final public function discoverEditions(string $workTitle, Country $country): array
+    {
+        if ($country !== $this->country()) {
+            return [];
+        }
+
+        $body = $this->fetch($workTitle);
+        if ($body === null) {
+            return [];
+        }
+
+        $rawVolumes = $this->parseRecords($body, $country->language());
+
+        $this->logger->info($this->logPrefix() . 'raw volumes parsed.', [
+            'title' => $workTitle,
+            'count' => count($rawVolumes),
+        ]);
+
+        return $this->editionGrouper->group($rawVolumes, $country->language(), $this->source());
+    }
+
+    private function logPrefix(): string
+    {
+        return strtoupper($this->source()) . '_EDITIONS : ';
+    }
+
+    private function fetch(string $workTitle): ?string
+    {
+        try {
+            $response = $this->httpClient->request('GET', $this->baseUrl, [
+                'query' => [
+                    'version'        => $this->sruVersion(),
+                    'operation'      => 'searchRetrieve',
+                    'query'          => $this->buildQuery($workTitle),
+                    'recordSchema'   => $this->recordSchema(),
+                    'maximumRecords' => $this->maximumRecords(),
+                ],
+            ]);
+
+            return $response->getContent();
+        } catch (Throwable $exception) {
+            $this->logger->warning($this->logPrefix() . 'fetch failed.', [
+                'message' => $exception->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * @return array<int, RawVolume>
+     */
+    private function parseRecords(string $body, string $language): array
+    {
+        $previousUseInternalErrors = libxml_use_internal_errors(true);
+        $document = simplexml_load_string($body);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousUseInternalErrors);
+
+        if ($document === false) {
+            $this->logger->warning($this->logPrefix() . 'XML parse failed.');
+            return [];
+        }
+
+        $document->registerXPathNamespace('srw', self::SRW_NAMESPACE);
+        $recordNodes = $document->xpath('//srw:recordData/*') ?: [];
+
+        $rawVolumes = [];
+
+        foreach ($recordNodes as $recordNode) {
+            $rawVolume = $this->normalizeRecord($recordNode, $language);
+            if ($rawVolume !== null) {
+                $rawVolumes[] = $rawVolume;
+            }
+        }
+
+        return $rawVolumes;
+    }
+
+    /**
+     * @return RawVolume|null
+     */
+    private function normalizeRecord(SimpleXMLElement $recordNode, string $language): ?array
+    {
+        $recordNode->registerXPathNamespace('dc', self::DC_NAMESPACE);
+        $recordNode->registerXPathNamespace('dcterms', self::DCTERMS_NAMESPACE);
+        $recordNode->registerXPathNamespace('dcndl', self::DCNDL_NAMESPACE);
+
+        $title = $this->firstValue($recordNode, ['.//dc:title', './/dcterms:title']);
+        if ($title === null) {
+            return null;
+        }
+
+        // Catalogues are dominated by their own country's language, but
+        // co-editions in other languages are listed too; keep only records
+        // whose declared language matches the requested one.
+        $recordLanguage = $this->firstValue($recordNode, ['.//dc:language', './/dcterms:language']);
+        if ($recordLanguage !== null && !$this->matchesLanguage($recordLanguage, $language)) {
+            return null;
+        }
+
+        $isbn = $this->extractIsbn($recordNode);
+
+        return [
+            'publisher'    => $this->normalizePublisher(
+                $this->firstValue($recordNode, ['.//dc:publisher', './/dcterms:publisher']),
+            ),
+            'year'         => $this->extractYear($recordNode),
+            'volumeNumber' => $this->extractVolumeNumber($title),
+            'title'        => $title,
+            'coverUrl'     => $isbn !== null ? $this->buildCoverUrl($isbn) : null,
+            'isbn'         => $isbn,
+        ];
+    }
+
+    /**
+     * Returns the first non-empty value found across the candidate xpaths.
+     *
+     * @param list<string> $xpaths
+     */
+    private function firstValue(SimpleXMLElement $recordNode, array $xpaths): ?string
+    {
+        foreach ($xpaths as $xpath) {
+            $nodes = $recordNode->xpath($xpath) ?: [];
+            if ($nodes === []) {
+                continue;
+            }
+
+            $value = trim((string) $nodes[0]);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Publisher entries frequently append the city in parentheses, e.g.
+     * "Glénat (Grenoble)" or "Carlsen (Hamburg)". Strip that suffix so grouping
+     * and deduplication work across differently-formatted records.
+     */
+    private function normalizePublisher(?string $publisher): ?string
+    {
+        if ($publisher === null) {
+            return null;
+        }
+
+        $normalized = trim((string) preg_replace('/\s*\([^)]+\)\s*$/', '', $publisher));
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function matchesLanguage(string $recordLanguage, string $language): bool
+    {
+        $acceptable = self::LANGUAGE_CODES[$language] ?? [$language];
+
+        return in_array(strtolower(trim($recordLanguage)), $acceptable, true);
+    }
+
+    private function extractYear(SimpleXMLElement $recordNode): ?int
+    {
+        $date = $this->firstValue($recordNode, ['.//dc:date', './/dcterms:date', './/dcterms:issued']);
+        if ($date === null) {
+            return null;
+        }
+
+        // Dates come in many shapes: "1993", "DL 1994", "cop. 2013", "2010-2015".
+        if (preg_match('/(\d{4})/', $date, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    private function extractVolumeNumber(string $title): ?int
+    {
+        // Latin numbering: "Tome 3", "Tomo 3", "Band 3", "Vol. 3", "T03".
+        if (preg_match('/\b(?:tome|tomo|band|vol(?:ume)?|t)[\s.]*(\d+)/i', $title, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        // Japanese numbering: "第3巻" or a trailing "3巻".
+        if (preg_match('/(\d+)\s*巻/u', $title, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        // Fallback for "Dragon Ball. 3" / "Dragon Ball, 3" / "Dragon Ball 3".
+        if (preg_match('/[.,\s](\d{1,3})\s*$/u', $title, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    private function extractIsbn(SimpleXMLElement $recordNode): ?string
+    {
+        $identifierNodes = array_merge(
+            $recordNode->xpath('.//dc:identifier') ?: [],
+            $recordNode->xpath('.//dcndl:ISBN') ?: [],
+        );
+
+        foreach ($identifierNodes as $identifierNode) {
+            $candidate = $this->normalizeIsbnCandidate((string) $identifierNode);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Identifiers can be ARK URIs, "ISBN 978-2-344-02081-4", or a bare ISBN.
+     * Only return a value when it genuinely looks like an ISBN so ARK URIs
+     * (which also contain long digit runs) are never mistaken for one.
+     */
+    private function normalizeIsbnCandidate(string $rawIdentifier): ?string
+    {
+        if (preg_match('/\b(97[89](?:[\s-]?\d){10})\b/', $rawIdentifier, $matches) === 1) {
+            return (string) preg_replace('/\D/', '', $matches[1]);
+        }
+
+        if (stripos($rawIdentifier, 'ISBN') !== false) {
+            $digits = (string) preg_replace('/[^0-9X]/i', '', strtoupper($rawIdentifier));
+            if (strlen($digits) === 13 || strlen($digits) === 10) {
+                return $digits;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildCoverUrl(string $isbn): string
+    {
+        return sprintf('%s/b/isbn/%s-L.jpg', self::COVERS_BASE_URL, $isbn);
+    }
+
+    protected function escapeCqlValue(string $value): string
+    {
+        return str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/BneEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/BneEditionDiscoveryClient.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+
+/**
+ * Discovers Spanish editions from the Biblioteca Nacional de España (BNE) via
+ * its SRU API, using the Dublin Core record schema. The legal deposit
+ * (depósito legal) makes the BNE authoritative for works published in Spain.
+ */
+final readonly class BneEditionDiscoveryClient extends AbstractSruEditionDiscoveryClient
+{
+    protected function country(): Country
+    {
+        return Country::Spain;
+    }
+
+    protected function source(): string
+    {
+        return 'bne';
+    }
+
+    protected function sruVersion(): string
+    {
+        return '1.1';
+    }
+
+    protected function recordSchema(): string
+    {
+        return 'dc';
+    }
+
+    protected function buildQuery(string $workTitle): string
+    {
+        return sprintf('dc.title all "%s"', $this->escapeCqlValue($workTitle));
+    }
+
+    protected function maximumRecords(): int
+    {
+        return 100;
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/BnfEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/BnfEditionDiscoveryClient.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+
+/**
+ * Discovers French editions from the Bibliothèque nationale de France (BnF)
+ * via its SRU API, using the Dublin Core record schema. The legal deposit
+ * (dépôt légal) makes the BnF authoritative for works published in France.
+ */
+final readonly class BnfEditionDiscoveryClient extends AbstractSruEditionDiscoveryClient
+{
+    protected function country(): Country
+    {
+        return Country::France;
+    }
+
+    protected function source(): string
+    {
+        return 'bnf';
+    }
+
+    protected function sruVersion(): string
+    {
+        return '1.2';
+    }
+
+    protected function recordSchema(): string
+    {
+        return 'dublincore';
+    }
+
+    protected function buildQuery(string $workTitle): string
+    {
+        return sprintf('bib.title all "%s"', $this->escapeCqlValue($workTitle));
+    }
+
+    protected function maximumRecords(): int
+    {
+        return 500; // BnF supports up to 1000; 500 gives full coverage without over-fetching.
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/CompositeEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/CompositeEditionDiscoveryClient.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use Psr\Log\LoggerInterface;
+
+final readonly class CompositeEditionDiscoveryClient implements EditionDiscoveryInterface
+{
+    /**
+     * @param iterable<EditionDiscoveryInterface> $providers ordered by priority (highest first)
+     */
+    public function __construct(
+        private iterable $providers,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return ExternalEditionDto[]
+     */
+    public function discoverEditions(string $workTitle, Country $country): array
+    {
+        /** @var array<string, ExternalEditionDto> $seenByKey */
+        $seenByKey = [];
+        $allEditions = [];
+
+        foreach ($this->providers as $provider) {
+            $editions = $provider->discoverEditions($workTitle, $country);
+
+            $this->logger->info('COMPOSITE_EDITIONS : provider returned editions.', [
+                'provider' => $provider::class,
+                'count'    => count($editions),
+            ]);
+
+            foreach ($editions as $edition) {
+                $deduplicationKey = strtolower($edition->publisher) . '|' . ($edition->year ?? '');
+
+                if (isset($seenByKey[$deduplicationKey])) {
+                    continue;
+                }
+
+                $seenByKey[$deduplicationKey] = $edition;
+                $allEditions[] = $edition;
+            }
+        }
+
+        usort(
+            $allEditions,
+            static function (ExternalEditionDto $firstEdition, ExternalEditionDto $secondEdition): int {
+                return ($secondEdition->volumeCount ?? 0) <=> ($firstEdition->volumeCount ?? 0);
+            },
+        );
+
+        return $allEditions;
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/CompositeMangaCoverApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/CompositeMangaCoverApiClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\ExternalApi;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
@@ -44,25 +45,21 @@ final readonly class CompositeMangaCoverApiClient implements MangaCoverProviderI
         return null;
     }
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto {
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
+    {
         foreach ($this->providers as $provider) {
             $providerClass = $provider::class;
             $this->logger->info('COMPOSITE : trying findByContext.', [
                 'provider' => $providerClass,
-                'title' => $mangaTitle,
-                'volume' => $volumeNumber,
+                'title'    => $context->mangaTitle,
+                'volume'   => $volumeNumber,
             ]);
 
-            $result = $provider->findByContext($mangaTitle, $edition, $volumeNumber, $language);
+            $result = $provider->findByContext($context, $volumeNumber);
 
             $this->logger->info('COMPOSITE : findByContext result.', [
                 'provider' => $providerClass,
-                'match' => $result !== null,
+                'match'    => $result !== null,
             ]);
 
             if ($result !== null) {

--- a/back/src/Manga/Infrastructure/ExternalApi/DnbEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/DnbEditionDiscoveryClient.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+
+/**
+ * Discovers German editions from the Deutsche Nationalbibliothek (DNB) via its
+ * SRU API, using the Dublin Core (oai_dc) record schema. The legal deposit
+ * (Pflichtexemplar) makes the DNB authoritative for works published in Germany.
+ */
+final readonly class DnbEditionDiscoveryClient extends AbstractSruEditionDiscoveryClient
+{
+    protected function country(): Country
+    {
+        return Country::Germany;
+    }
+
+    protected function source(): string
+    {
+        return 'dnb';
+    }
+
+    protected function sruVersion(): string
+    {
+        return '1.1';
+    }
+
+    protected function recordSchema(): string
+    {
+        return 'oai_dc';
+    }
+
+    protected function buildQuery(string $workTitle): string
+    {
+        // WOE = "Wörter aus dem Titel" (words from the title).
+        return sprintf('WOE all "%s"', $this->escapeCqlValue($workTitle));
+    }
+
+    protected function maximumRecords(): int
+    {
+        return 100; // DNB server-side cap is 100.
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksEditionDiscoveryClient.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use App\Manga\Domain\Service\EditionGrouper;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+
+/**
+ * @phpstan-import-type RawVolume from EditionGrouper
+ */
+final readonly class GoogleBooksEditionDiscoveryClient implements EditionDiscoveryInterface
+{
+    private const string BASE_URL = 'https://www.googleapis.com/books/v1';
+    private const string PREFIX_LOGGER = 'GOOGLE_BOOKS_EDITIONS : ';
+    private const int MAX_PAGES = 2;
+    private const int PAGE_SIZE = 20;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $apiKey,
+        private EditionGrouper $editionGrouper,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return ExternalEditionDto[]
+     */
+    public function discoverEditions(string $workTitle, Country $country): array
+    {
+        $language = $country->language();
+
+        $this->logger->info(self::PREFIX_LOGGER . 'discoverEditions; BEGIN.', [
+            'title'    => $workTitle,
+            'language' => $language,
+        ]);
+
+        $rawVolumes = [];
+
+        for ($pageIndex = 0; $pageIndex < self::MAX_PAGES; $pageIndex++) {
+            $pageItems = $this->fetchPage($workTitle, $language, $pageIndex);
+            $rawVolumes = array_merge($rawVolumes, $pageItems);
+        }
+
+        $this->logger->info(self::PREFIX_LOGGER . 'discoverEditions; raw volumes fetched.', [
+            'count' => count($rawVolumes),
+        ]);
+
+        return $this->editionGrouper->group($rawVolumes, $language, 'google_books');
+    }
+
+    /**
+     * @return array<int, RawVolume>
+     */
+    private function fetchPage(string $workTitle, string $language, int $pageIndex): array
+    {
+        try {
+            $response = $this->httpClient->request('GET', self::BASE_URL . '/volumes', [
+                'query' => [
+                    'q'            => $workTitle . '+manga',
+                    'printType'    => 'books',
+                    'langRestrict' => $language,
+                    'maxResults'   => self::PAGE_SIZE,
+                    'startIndex'   => $pageIndex * self::PAGE_SIZE,
+                    'orderBy'      => 'relevance',
+                    'key'          => $this->apiKey,
+                ],
+            ]);
+
+            $data = $response->toArray();
+        } catch (Throwable $exception) {
+            $this->logger->warning(self::PREFIX_LOGGER . 'fetchPage failed.', [
+                'page'    => $pageIndex,
+                'message' => $exception->getMessage(),
+            ]);
+            return [];
+        }
+
+        if (empty($data['items'])) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            fn (array $item) => $this->normalizeItem($item, $language),
+            $data['items'],
+        )));
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     * @return RawVolume|null
+     */
+    private function normalizeItem(array $item, string $language): ?array
+    {
+        $volumeInfo = $item['volumeInfo'] ?? [];
+        $title = $volumeInfo['title'] ?? null;
+
+        if ($title === null) {
+            return null;
+        }
+
+        // langRestrict is loosely enforced for manga; drop items whose declared
+        // language disagrees with the requested one. Items without a language
+        // tag are kept (the metadata is simply missing).
+        $itemLanguage = $volumeInfo['language'] ?? null;
+        if ($itemLanguage !== null && $itemLanguage !== $language) {
+            return null;
+        }
+
+        $publisher = $volumeInfo['publisher'] ?? null;
+        $year = $this->extractYear($volumeInfo['publishedDate'] ?? null);
+        $volumeNumber = $this->extractVolumeNumber($volumeInfo);
+        $coverUrl = $this->extractCoverUrl($volumeInfo);
+        $isbn = $this->extractIsbn($volumeInfo);
+
+        return [
+            'publisher'    => $publisher,
+            'year'         => $year,
+            'volumeNumber' => $volumeNumber,
+            'title'        => $title,
+            'coverUrl'     => $coverUrl,
+            'isbn'         => $isbn,
+        ];
+    }
+
+    private function extractYear(?string $publishedDate): ?int
+    {
+        if ($publishedDate === null) {
+            return null;
+        }
+
+        $year = (int) substr($publishedDate, 0, 4);
+
+        return $year > 0 ? $year : null;
+    }
+
+    /** @param array<string, mixed> $volumeInfo */
+    private function extractVolumeNumber(array $volumeInfo): ?int
+    {
+        if (!empty($volumeInfo['seriesInfo']['bookDisplayNumber'])) {
+            $number = filter_var($volumeInfo['seriesInfo']['bookDisplayNumber'], FILTER_VALIDATE_INT);
+            if ($number !== false) {
+                return $number;
+            }
+        }
+
+        // Try to extract from title (e.g. "Berserk Tome 1", "Berserk T03")
+        $title = $volumeInfo['title'] ?? '';
+        if (preg_match('/\b(?:tome|vol(?:ume)?|t)[\s.]?(\d+)/i', $title, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $volumeInfo */
+    private function extractCoverUrl(array $volumeInfo): ?string
+    {
+        $imageLinks = $volumeInfo['imageLinks'] ?? [];
+
+        $url = $imageLinks['extraLarge']
+            ?? $imageLinks['large']
+            ?? $imageLinks['medium']
+            ?? $imageLinks['thumbnail']
+            ?? $imageLinks['smallThumbnail']
+            ?? null;
+
+        if ($url === null) {
+            return null;
+        }
+
+        $url = str_replace('http://', 'https://', $url);
+        return implode('', explode('&edge=curl', $url));
+    }
+
+    /** @param array<string, mixed> $volumeInfo */
+    private function extractIsbn(array $volumeInfo): ?string
+    {
+        foreach ($volumeInfo['industryIdentifiers'] ?? [] as $identifier) {
+            if (($identifier['type'] ?? '') === 'ISBN_13') {
+                return $identifier['identifier'] ?? null;
+            }
+        }
+
+        foreach ($volumeInfo['industryIdentifiers'] ?? [] as $identifier) {
+            if (($identifier['type'] ?? '') === 'ISBN_10') {
+                return $identifier['identifier'] ?? null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksMangaApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksMangaApiClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\ExternalApi;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\ExternalApiClientInterface;
 use App\Manga\Domain\ExternalMangaDto;
 use App\Manga\Domain\Isbn;
@@ -139,22 +140,44 @@ final readonly class GoogleBooksMangaApiClient implements ExternalApiClientInter
         }
     }
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto {
-        $query = sprintf('%s tome %d%s', $mangaTitle, $volumeNumber, $edition ? ' ' . $edition : '');
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
+    {
+        $publisherSuffix = $context->publisher !== null ? ' ' . $context->publisher : '';
+        $query = sprintf('%s tome %d%s', $context->mangaTitle, $volumeNumber, $publisherSuffix);
         $this->logger->info(self::PREFIX_LOGGER . 'find by context; BEGIN.', ['query' => $query]);
 
         try {
-            $results = $this->searchByTitle($query, page: 1);
+            $response = $this->httpClient->request('GET', self::BASE_URL . '/volumes', [
+                'query' => [
+                    'q'            => $query . '+manga',
+                    'printType'    => 'books',
+                    'langRestrict' => $context->language,
+                    'maxResults'   => 10,
+                    'orderBy'      => 'relevance',
+                    'key'          => $this->apiKey,
+                ],
+            ]);
 
-            foreach ($results as $dto) {
-                if ($dto->coverUrl !== null) {
+            $data = $response->toArray();
+
+            if (empty($data['items'])) {
+                return null;
+            }
+
+            foreach ($data['items'] as $item) {
+                $volumeInfo = $item['volumeInfo'] ?? [];
+
+                if ($context->publisher !== null) {
+                    $itemPublisher = strtolower($volumeInfo['publisher'] ?? '');
+                    if (!str_contains($itemPublisher, strtolower($context->publisher))) {
+                        continue;
+                    }
+                }
+
+                $coverUrl = $this->extractCoverUrl($volumeInfo);
+                if ($coverUrl !== null) {
                     return new MangaVolumeCoverDto(
-                        coverUrl: $dto->coverUrl,
+                        coverUrl: $coverUrl,
                         spineUrl: null,
                         isbn: null,
                         source: 'google_books',

--- a/back/src/Manga/Infrastructure/ExternalApi/LocEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/LocEditionDiscoveryClient.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+
+/**
+ * Discovers US editions from the Library of Congress (LOC) via its SRU API,
+ * using the Dublin Core record schema. LOC is the authoritative bibliographic
+ * source for works published or registered in the United States.
+ */
+final readonly class LocEditionDiscoveryClient extends AbstractSruEditionDiscoveryClient
+{
+    protected function country(): Country
+    {
+        return Country::UnitedStates;
+    }
+
+    protected function source(): string
+    {
+        return 'loc';
+    }
+
+    protected function sruVersion(): string
+    {
+        return '1.1';
+    }
+
+    protected function recordSchema(): string
+    {
+        return 'dc';
+    }
+
+    protected function buildQuery(string $workTitle): string
+    {
+        // "dc.title" is the standard CQL index for the LOC catalog.
+        return sprintf('dc.title all "%s"', $this->escapeCqlValue($workTitle));
+    }
+
+    protected function maximumRecords(): int
+    {
+        return 100; // LOC SRU server cap is 100.
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\ExternalApi;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
@@ -29,32 +30,30 @@ final readonly class MangaDexMangaApiClient implements MangaCoverProviderInterfa
         return null;
     }
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto {
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
+    {
         $this->logger->info(self::PREFIX_LOGGER . 'find by context; BEGIN.', [
-            'title' => $mangaTitle,
-            'edition' => $edition,
-            'volume' => $volumeNumber,
-            'language' => $language,
+            'title'    => $context->mangaTitle,
+            'volume'   => $volumeNumber,
+            'language' => $context->language,
         ]);
 
         try {
-            $mangaId = $this->searchMangaId($mangaTitle, $language);
+            $mangaId = $this->searchMangaId($context->mangaTitle, $context->language);
 
             if ($mangaId === null) {
-                $this->logger->info(self::PREFIX_LOGGER . 'find by context; NO MANGA FOUND.', ['title' => $mangaTitle]);
+                $this->logger->info(
+                    self::PREFIX_LOGGER . 'find by context; NO MANGA FOUND.',
+                    ['title' => $context->mangaTitle],
+                );
                 return null;
             }
 
-            $coverDto = $this->findVolumeCover($mangaId, $volumeNumber, $language);
+            $coverDto = $this->findVolumeCover($mangaId, $volumeNumber, $context->language);
 
             if ($coverDto === null) {
                 $this->logger->info(self::PREFIX_LOGGER . 'find by context; NO COVER FOUND.', [
-                    'title' => $mangaTitle,
+                    'title' => $context->mangaTitle,
                     'manga_id' => $mangaId,
                     'volume' => $volumeNumber,
                 ]);
@@ -63,7 +62,7 @@ final readonly class MangaDexMangaApiClient implements MangaCoverProviderInterfa
             return $coverDto;
         } catch (Throwable $exception) {
             $this->logger->info(self::PREFIX_LOGGER . 'find by context; ERROR.', [
-                'title' => $mangaTitle,
+                'title' => $context->mangaTitle,
                 'error' => $exception->getMessage(),
             ]);
             return null;

--- a/back/src/Manga/Infrastructure/ExternalApi/NdlEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/NdlEditionDiscoveryClient.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+
+/**
+ * Discovers Japanese editions from the National Diet Library (NDL) via its SRU
+ * API, using the simplified DC-NDL record schema. The legal deposit (法定納本)
+ * makes the NDL authoritative for works published in Japan.
+ *
+ * NDL records primarily carry Japanese-script titles; popular series also
+ * index a romanized alternate title. Both fields are queried so that a
+ * Latin-script search ("Dragon Ball") and a kana search ("ドラゴンボール") both
+ * resolve to the same set of records.
+ */
+final readonly class NdlEditionDiscoveryClient extends AbstractSruEditionDiscoveryClient
+{
+    protected function country(): Country
+    {
+        return Country::Japan;
+    }
+
+    protected function source(): string
+    {
+        return 'ndl';
+    }
+
+    protected function sruVersion(): string
+    {
+        return '1.2';
+    }
+
+    protected function recordSchema(): string
+    {
+        return 'dcndl_simple';
+    }
+
+    protected function buildQuery(string $workTitle): string
+    {
+        // Search title AND alternative (romanized/English) title so that both
+        // Latin-script ("Dragon Ball") and kana queries ("ドラゴンボール") find results.
+        $escaped = $this->escapeCqlValue($workTitle);
+        return sprintf('title="%s" OR alternative="%s"', $escaped, $escaped);
+    }
+
+    protected function maximumRecords(): int
+    {
+        return 200; // NDL server cap is 200.
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/NullEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/NullEditionDiscoveryClient.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+
+final readonly class NullEditionDiscoveryClient implements EditionDiscoveryInterface
+{
+    /**
+     * @return ExternalEditionDto[]
+     */
+    public function discoverEditions(string $workTitle, Country $country): array
+    {
+        return [];
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/NullMangaCoverApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/NullMangaCoverApiClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\ExternalApi;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
@@ -15,12 +16,8 @@ final readonly class NullMangaCoverApiClient implements MangaCoverProviderInterf
         return null;
     }
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto {
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
+    {
         return null;
     }
 }

--- a/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryCoversApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryCoversApiClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\ExternalApi;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
@@ -67,12 +68,8 @@ final readonly class OpenLibraryCoversApiClient implements MangaCoverProviderInt
         }
     }
 
-    public function findByContext(
-        string $mangaTitle,
-        ?string $edition,
-        int $volumeNumber,
-        string $language = 'fr',
-    ): ?MangaVolumeCoverDto {
+    public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
+    {
         // Open Library does not support title-based cover search in this context
         return null;
     }

--- a/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryEditionDiscoveryClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryEditionDiscoveryClient.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\ExternalApi;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+
+final readonly class OpenLibraryEditionDiscoveryClient implements EditionDiscoveryInterface
+{
+    private const string PREFIX_LOGGER = 'OPEN_LIBRARY_EDITIONS : ';
+    private const string COVERS_BASE_URL = 'https://covers.openlibrary.org';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $baseUrl,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @return ExternalEditionDto[]
+     */
+    public function discoverEditions(string $workTitle, Country $country): array
+    {
+        $language = $country->language();
+
+        $this->logger->info(self::PREFIX_LOGGER . 'discoverEditions; BEGIN.', [
+            'title'    => $workTitle,
+            'language' => $language,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('GET', $this->baseUrl . '/search.json', [
+                'query' => [
+                    'q'      => $workTitle . ' manga',
+                    'fields' => 'key,title,publisher,first_publish_year,number_of_pages_median,isbn,language',
+                    'limit'  => 20,
+                ],
+            ]);
+
+            $data = $response->toArray();
+        } catch (Throwable $exception) {
+            $this->logger->warning(self::PREFIX_LOGGER . 'discoverEditions failed.', [
+                'message' => $exception->getMessage(),
+            ]);
+            return [];
+        }
+
+        $docs = $data['docs'] ?? [];
+
+        if (empty($docs)) {
+            return [];
+        }
+
+        /** @var array<string, ExternalEditionDto> $grouped */
+        $grouped = [];
+
+        foreach ($docs as $doc) {
+            $docLanguages = $doc['language'] ?? [];
+
+            // Filter by language (Open Library uses language codes: 'fre' for French, 'eng' for English)
+            $targetCode = $this->toOpenLibraryLanguageCode($language);
+            if (!empty($docLanguages) && !in_array($targetCode, $docLanguages, true)) {
+                continue;
+            }
+
+            $publishers = $doc['publisher'] ?? [];
+            if (empty($publishers)) {
+                continue;
+            }
+
+            $publisher = (string) ($publishers[0] ?? '');
+            if ($publisher === '') {
+                continue;
+            }
+
+            $groupKey = strtolower($publisher);
+
+            if (isset($grouped[$groupKey])) {
+                continue;
+            }
+
+            $year = isset($doc['first_publish_year']) ? (int) $doc['first_publish_year'] : null;
+            $isbns = $doc['isbn'] ?? [];
+            $sampleIsbn = !empty($isbns) ? (string) $isbns[0] : null;
+            $coverUrl = $sampleIsbn !== null ? $this->buildCoverUrl($sampleIsbn) : null;
+
+            $grouped[$groupKey] = new ExternalEditionDto(
+                publisher: $publisher,
+                editionLabel: null,
+                year: $year,
+                language: $language,
+                coverUrl: $coverUrl,
+                volumeCount: null,
+                sampleIsbn: $sampleIsbn,
+                source: 'open_library',
+            );
+        }
+
+        return array_values($grouped);
+    }
+
+    private function buildCoverUrl(string $isbn): string
+    {
+        return sprintf('%s/b/isbn/%s-L.jpg', self::COVERS_BASE_URL, $isbn);
+    }
+
+    private function toOpenLibraryLanguageCode(string $languageCode): string
+    {
+        return match ($languageCode) {
+            'fr' => 'fre',
+            'en' => 'eng',
+            'de' => 'ger',
+            'es' => 'spa',
+            'ja' => 'jpn',
+            default => $languageCode,
+        };
+    }
+}

--- a/back/src/Manga/Infrastructure/Http/ImportMangaRequest.php
+++ b/back/src/Manga/Infrastructure/Http/ImportMangaRequest.php
@@ -24,6 +24,11 @@ final readonly class ImportMangaRequest
         public ?string $externalId = null,
         #[Assert\PositiveOrZero]
         public ?int $totalVolumes = null,
+        #[Assert\Length(max: 255)]
+        public ?string $publisher = null,
+        #[Assert\Range(min: 1900, max: 2100)]
+        public ?int $editionYear = null,
+        public ?string $externalWorkId = null,
     ) {
     }
 }

--- a/back/src/Manga/Infrastructure/Http/MangaController.php
+++ b/back/src/Manga/Infrastructure/Http/MangaController.php
@@ -6,13 +6,17 @@ namespace App\Manga\Infrastructure\Http;
 
 use App\Manga\Application\AddVolume\AddVolumeCommand;
 use App\Manga\Application\AutoCovers\StartCoverBatchCommand;
+use App\Manga\Application\DiscoverEditions\DiscoverEditionsQuery;
 use App\Manga\Application\Get\GetMangaQuery;
 use App\Manga\Application\Import\ImportMangaCommand;
+use App\Manga\Application\PublishScannedIsbn\PublishScannedIsbnCommand;
 use App\Manga\Application\Search\SearchMangaQuery;
 use App\Manga\Application\SearchExternal\SearchExternalMangaQuery;
 use App\Manga\Application\SearchVolumeExternal\SearchVolumeExternalQuery;
+use App\Manga\Application\StartScanSession\StartScanSessionCommand;
 use App\Manga\Application\Update\UpdateMangaCommand;
 use App\Manga\Application\UpdateVolume\UpdateVolumeCommand;
+use App\Manga\Domain\Country;
 use App\Shared\Application\Bus\CommandBusInterface;
 use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -48,25 +52,65 @@ final readonly class MangaController
         return new JsonResponse($this->queryBus->ask(new SearchExternalMangaQuery($query, $type, $page)));
     }
 
+    #[Route('/editions', methods: ['GET'])]
+    public function discoverEditions(Request $request): JsonResponse
+    {
+        $title   = $request->query->get('title', '');
+        $country = Country::fromCode($request->query->get('country'));
+
+        return new JsonResponse($this->queryBus->ask(new DiscoverEditionsQuery($title, $country)));
+    }
+
     /** Composite cover search for individual volume covers/metadata */
     #[Route('/volume-search', methods: ['GET'])]
     public function searchVolumeExternal(Request $request): JsonResponse
     {
-        $query        = $request->query->get('q', '');
+        $search       = $request->query->get('q', '');
         $page         = max(1, (int) $request->query->get('page', 1));
         $volumeNumber = $request->query->get('volumeNumber') !== null
             ? (int) $request->query->get('volumeNumber')
             : null;
         $edition      = $request->query->get('edition');
         $provider     = $request->query->get('provider', 'composite');
+        $isbn         = $request->query->get('isbn');
+        $publisher    = $request->query->get('publisher');
+        $year         = $request->query->get('year') !== null
+            ? (int) $request->query->get('year')
+            : null;
+        $language     = $request->query->get('language', 'fr');
 
         return new JsonResponse($this->queryBus->ask(new SearchVolumeExternalQuery(
-            search: $query,
+            search: $search,
             page: $page,
             volumeNumber: $volumeNumber,
             edition: $edition,
             provider: $provider,
+            isbn: $isbn,
+            publisher: $publisher,
+            year: $year,
+            language: $language,
         )));
+    }
+
+    #[Route('/scan-session', methods: ['POST'])]
+    public function startScanSession(): JsonResponse
+    {
+        $result = $this->commandBus->dispatch(new StartScanSessionCommand());
+
+        return new JsonResponse($result->toArray(), Response::HTTP_ACCEPTED);
+    }
+
+    #[Route('/scan-session/{sessionId}/isbn', methods: ['POST'])]
+    public function publishScannedIsbn(
+        string $sessionId,
+        #[MapRequestPayload] ScanIsbnRequest $request,
+    ): JsonResponse {
+        $this->commandBus->dispatch(new PublishScannedIsbnCommand(
+            sessionId: $sessionId,
+            isbn: $request->isbn,
+        ));
+
+        return new JsonResponse(null, Response::HTTP_ACCEPTED);
     }
 
     #[Route('/{id}', methods: ['GET'])]
@@ -88,6 +132,9 @@ final readonly class MangaController
             genre: $request->genre,
             externalId: $request->externalId,
             totalVolumes: $request->totalVolumes,
+            publisher: $request->publisher,
+            editionYear: $request->editionYear,
+            externalWorkId: $request->externalWorkId,
         ));
 
         return new JsonResponse(['id' => $id], Response::HTTP_CREATED);
@@ -101,6 +148,8 @@ final readonly class MangaController
             title: $request->title,
             edition: $request->edition,
             coverUrl: $request->coverUrl,
+            publisher: $request->publisher,
+            editionYear: $request->editionYear,
         ));
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
@@ -132,6 +181,7 @@ final readonly class MangaController
             releaseDate: $request->releaseDate,
             price: $request->price,
             spineUrl: $request->spineUrl,
+            isbn: $request->isbn,
         ));
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/back/src/Manga/Infrastructure/Http/ScanIsbnRequest.php
+++ b/back/src/Manga/Infrastructure/Http/ScanIsbnRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Http;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class ScanIsbnRequest
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        public string $isbn,
+    ) {
+    }
+}

--- a/back/src/Manga/Infrastructure/Http/UpdateMangaRequest.php
+++ b/back/src/Manga/Infrastructure/Http/UpdateMangaRequest.php
@@ -10,6 +10,8 @@ final readonly class UpdateMangaRequest
         public ?string $title = null,
         public ?string $edition = null,
         public ?string $coverUrl = null,
+        public ?string $publisher = null,
+        public ?int $editionYear = null,
     ) {
     }
 }

--- a/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
+++ b/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
@@ -14,6 +14,7 @@ final readonly class UpdateVolumeRequest
         #[Assert\PositiveOrZero]
         public ?float $price = null,
         public ?string $spineUrl = null,
+        public ?string $isbn = null,
     ) {
     }
 }

--- a/back/src/Manga/Infrastructure/Mercure/MercureScanSessionAuthorizer.php
+++ b/back/src/Manga/Infrastructure/Mercure/MercureScanSessionAuthorizer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Mercure;
+
+use App\Manga\Domain\ScanSessionAuthorizerInterface;
+use DateTimeImmutable;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use RuntimeException;
+
+final readonly class MercureScanSessionAuthorizer implements ScanSessionAuthorizerInterface
+{
+    public function __construct(
+        private string $subscriberJwtKey,
+        private string $publicHubUrlValue,
+    ) {
+    }
+
+    public function issueSubscriberToken(string $sessionId, int $ttlSeconds): string
+    {
+        if (strlen($this->subscriberJwtKey) < 32) {
+            throw new RuntimeException(
+                sprintf(
+                    'MERCURE_SUBSCRIBER_JWT_KEY must be at least 32 characters (256 bits), %d given.',
+                    strlen($this->subscriberJwtKey)
+                )
+            );
+        }
+
+        $config = Configuration::forSymmetricSigner(
+            new Sha256(),
+            InMemory::plainText($this->subscriberJwtKey),
+        );
+
+        $now = new DateTimeImmutable();
+
+        $token = $config->builder()
+            ->issuedAt($now)
+            ->expiresAt($now->modify(sprintf('+%d seconds', $ttlSeconds)))
+            ->withClaim('mercure', ['subscribe' => [$this->topicFor($sessionId)]])
+            ->getToken($config->signer(), $config->signingKey());
+
+        return $token->toString();
+    }
+
+    public function topicFor(string $sessionId): string
+    {
+        return sprintf('https://ziggytheque.app/scan-session/%s', $sessionId);
+    }
+
+    public function publicHubUrl(): string
+    {
+        return $this->publicHubUrlValue;
+    }
+}

--- a/back/src/Manga/Infrastructure/Mercure/MercureScanSessionPublisher.php
+++ b/back/src/Manga/Infrastructure/Mercure/MercureScanSessionPublisher.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Mercure;
+
+use App\Manga\Domain\ScanSessionPublisherInterface;
+use DateTimeImmutable;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+
+final readonly class MercureScanSessionPublisher implements ScanSessionPublisherInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $hubUrl,
+        private string $publisherJwtKey,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function publishIsbn(string $sessionId, string $isbn): void
+    {
+        $topic = sprintf('https://ziggytheque.app/scan-session/%s', $sessionId);
+        $payload = (string) json_encode([
+            'type'      => 'isbn_scanned',
+            'sessionId' => $sessionId,
+            'isbn'      => $isbn,
+        ]);
+
+        try {
+            $response = $this->httpClient->request('POST', $this->hubUrl, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $this->mintPublisherJwt(),
+                    'Content-Type'  => 'application/x-www-form-urlencoded',
+                ],
+                'body' => http_build_query([
+                    'topic'   => $topic,
+                    'data'    => $payload,
+                    'private' => '1',
+                ]),
+            ]);
+            $response->getStatusCode();
+        } catch (Throwable $throwable) {
+            $this->logger->warning('Mercure scan publish failed for session {sessionId}: {message}', [
+                'sessionId' => $sessionId,
+                'message'   => $throwable->getMessage(),
+            ]);
+        }
+    }
+
+    private function mintPublisherJwt(): string
+    {
+        if (strlen($this->publisherJwtKey) < 32) {
+            throw new RuntimeException(
+                sprintf(
+                    'MERCURE_PUBLISHER_JWT_KEY must be at least 32 characters (256 bits), %d given.',
+                    strlen($this->publisherJwtKey)
+                )
+            );
+        }
+
+        $config = Configuration::forSymmetricSigner(
+            new Sha256(),
+            InMemory::plainText($this->publisherJwtKey),
+        );
+
+        $now = new DateTimeImmutable();
+
+        $token = $config->builder()
+            ->issuedAt($now)
+            ->expiresAt($now->modify('+1 hour'))
+            ->withClaim('mercure', ['publish' => ['*']])
+            ->getToken($config->signer(), $config->signingKey());
+
+        return $token->toString();
+    }
+}

--- a/back/tests/Doubles/Manga/InMemoryScanSessionPublisher.php
+++ b/back/tests/Doubles/Manga/InMemoryScanSessionPublisher.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Doubles\Manga;
+
+use App\Manga\Domain\ScanSessionPublisherInterface;
+
+final class InMemoryScanSessionPublisher implements ScanSessionPublisherInterface
+{
+    /** @var array<int, array{sessionId: string, isbn: string}> */
+    public array $published = [];
+
+    public function publishIsbn(string $sessionId, string $isbn): void
+    {
+        $this->published[] = ['sessionId' => $sessionId, 'isbn' => $isbn];
+    }
+}

--- a/back/tests/Doubles/Manga/StubScanSessionAuthorizer.php
+++ b/back/tests/Doubles/Manga/StubScanSessionAuthorizer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Doubles\Manga;
+
+use App\Manga\Domain\ScanSessionAuthorizerInterface;
+
+final class StubScanSessionAuthorizer implements ScanSessionAuthorizerInterface
+{
+    public function issueSubscriberToken(string $sessionId, int $ttlSeconds): string
+    {
+        return 'stub-scan-subscriber-token-' . $sessionId;
+    }
+
+    public function topicFor(string $sessionId): string
+    {
+        return 'https://ziggytheque.app/scan-session/' . $sessionId;
+    }
+
+    public function publicHubUrl(): string
+    {
+        return 'http://localhost:8000/.well-known/mercure';
+    }
+}

--- a/back/tests/Functional/Manga/MangaControllerTest.php
+++ b/back/tests/Functional/Manga/MangaControllerTest.php
@@ -92,6 +92,22 @@ final class MangaControllerTest extends AbstractApiTestCase
         $this->assertIsString($data['id']);
     }
 
+    public function testImportMangaWithPublisherAndEditionYear(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/manga', [
+            'title'       => 'Berserk',
+            'language'    => 'fr',
+            'publisher'   => 'Glénat',
+            'editionYear' => 2019,
+        ]);
+        $data = $this->assertJsonStatus(201, $response);
+        $id   = $data['id'];
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $id));
+        $this->assertSame('Glénat', $detail['publisher']);
+        $this->assertSame(2019, $detail['editionYear']);
+    }
+
     public function testImportMangaWithVolumes(): void
     {
         $response = $this->jsonRequest('POST', '/api/manga', [
@@ -188,6 +204,62 @@ final class MangaControllerTest extends AbstractApiTestCase
         $this->assertJsonStatus(404, $response);
     }
 
+    public function testUpdateVolumeWithValidIsbn(): void
+    {
+        $mangaId = $this->importManga();
+
+        $volData  = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga/' . $mangaId . '/volumes',
+            ['number' => 1],
+        ));
+        $volumeId = $volData['id'];
+
+        $response = $this->jsonRequest(
+            'PATCH',
+            '/api/manga/' . $mangaId . '/volumes/' . $volumeId,
+            ['isbn' => '9782344020814'],
+        );
+        $this->assertSame(204, $response->getStatusCode());
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
+        $this->assertSame('9782344020814', $detail['volumes'][0]['isbn']);
+    }
+
+    public function testUpdateVolumeWithInvalidIsbnReturns422(): void
+    {
+        $mangaId = $this->importManga();
+
+        $volData  = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga/' . $mangaId . '/volumes',
+            ['number' => 1],
+        ));
+        $volumeId = $volData['id'];
+
+        $response = $this->jsonRequest(
+            'PATCH',
+            '/api/manga/' . $mangaId . '/volumes/' . $volumeId,
+            ['isbn' => '123'],
+        );
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    // ── GET /api/manga/editions ──────────────────────────────────────────────
+
+    public function testDiscoverEditionsReturnsEmpty(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/manga/editions?title=Berserk&country=FR');
+        $data     = $this->assertJsonStatus(200, $response);
+        $this->assertSame([], $data);
+    }
+
+    public function testDiscoverEditionsRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/manga/editions?title=Berserk', auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
     // ── GET /api/manga/external ───────────────────────────────────────────────
 
     public function testSearchExternalReturnsEmpty(): void
@@ -209,6 +281,13 @@ final class MangaControllerTest extends AbstractApiTestCase
     {
         // NullMangaCoverApiClient is active in test env — always returns []
         $response = $this->jsonRequest('GET', '/api/manga/volume-search?q=test');
+        $data     = $this->assertJsonStatus(200, $response);
+        $this->assertSame([], $data);
+    }
+
+    public function testVolumeSearchWithIsbnParamReturnsEmpty(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/manga/volume-search?q=test&isbn=9782344020814');
         $data     = $this->assertJsonStatus(200, $response);
         $this->assertSame([], $data);
     }

--- a/back/tests/Functional/Manga/ScanSessionControllerTest.php
+++ b/back/tests/Functional/Manga/ScanSessionControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Manga;
+
+use App\Tests\Doubles\Manga\InMemoryScanSessionPublisher;
+use App\Tests\Functional\AbstractApiTestCase;
+
+final class ScanSessionControllerTest extends AbstractApiTestCase
+{
+    // ── POST /api/manga/scan-session ─────────────────────────────────────────
+
+    public function testStartScanSessionReturns202WithSessionData(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/manga/scan-session');
+        $data     = $this->assertJsonStatus(202, $response);
+
+        $this->assertArrayHasKey('sessionId', $data);
+        $this->assertArrayHasKey('mercureUrl', $data);
+        $this->assertArrayHasKey('subscriberToken', $data);
+        $this->assertArrayHasKey('topic', $data);
+        $this->assertIsString($data['sessionId']);
+        $this->assertStringContainsString($data['sessionId'], $data['topic']);
+    }
+
+    public function testStartScanSessionRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/manga/scan-session', auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    // ── POST /api/manga/scan-session/{sessionId}/isbn ─────────────────────────
+
+    public function testPublishScannedIsbnReturns202(): void
+    {
+        $sessionData = $this->assertJsonStatus(202, $this->jsonRequest('POST', '/api/manga/scan-session'));
+        $sessionId   = $sessionData['sessionId'];
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/manga/scan-session/' . $sessionId . '/isbn',
+            ['isbn' => '9782344020814'],
+        );
+        $this->assertSame(202, $response->getStatusCode());
+
+        /** @var InMemoryScanSessionPublisher $publisher */
+        $publisher = static::getContainer()->get(InMemoryScanSessionPublisher::class);
+        $this->assertCount(1, $publisher->published);
+        $this->assertSame($sessionId, $publisher->published[0]['sessionId']);
+        $this->assertSame('9782344020814', $publisher->published[0]['isbn']);
+    }
+
+    public function testPublishScannedIsbnWithInvalidIsbnReturns422(): void
+    {
+        $sessionData = $this->assertJsonStatus(202, $this->jsonRequest('POST', '/api/manga/scan-session'));
+        $sessionId   = $sessionData['sessionId'];
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/manga/scan-session/' . $sessionId . '/isbn',
+            ['isbn' => '123'],
+        );
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testPublishScannedIsbnRequiresAuth(): void
+    {
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/manga/scan-session/some-session-id/isbn',
+            ['isbn' => '9782344020814'],
+            auth: false,
+        );
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}

--- a/back/tests/Unit/Manga/Application/PublishScannedIsbnHandlerTest.php
+++ b/back/tests/Unit/Manga/Application/PublishScannedIsbnHandlerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Application;
+
+use App\Manga\Application\PublishScannedIsbn\PublishScannedIsbnCommand;
+use App\Manga\Application\PublishScannedIsbn\PublishScannedIsbnHandler;
+use App\Manga\Domain\Exception\InvalidIsbnException;
+use App\Tests\Doubles\Manga\InMemoryScanSessionPublisher;
+use PHPUnit\Framework\TestCase;
+
+final class PublishScannedIsbnHandlerTest extends TestCase
+{
+    private InMemoryScanSessionPublisher $publisher;
+    private PublishScannedIsbnHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->publisher = new InMemoryScanSessionPublisher();
+        $this->handler   = new PublishScannedIsbnHandler($this->publisher);
+    }
+
+    public function testPublishesCanonicalIsbnToSession(): void
+    {
+        ($this->handler)(new PublishScannedIsbnCommand(
+            sessionId: 'session-abc',
+            isbn: '9782344020814',
+        ));
+
+        $this->assertCount(1, $this->publisher->published);
+        $this->assertSame('session-abc', $this->publisher->published[0]['sessionId']);
+        $this->assertSame('9782344020814', $this->publisher->published[0]['isbn']);
+    }
+
+    public function testThrowsOnInvalidIsbn(): void
+    {
+        $this->expectException(InvalidIsbnException::class);
+
+        ($this->handler)(new PublishScannedIsbnCommand(
+            sessionId: 'session-abc',
+            isbn: '123-invalid',
+        ));
+    }
+
+    public function testNothingPublishedOnInvalidIsbn(): void
+    {
+        try {
+            ($this->handler)(new PublishScannedIsbnCommand(
+                sessionId: 'session-abc',
+                isbn: '000',
+            ));
+        } catch (InvalidIsbnException) {
+        }
+
+        $this->assertCount(0, $this->publisher->published);
+    }
+}

--- a/back/tests/Unit/Manga/Domain/CountryTest.php
+++ b/back/tests/Unit/Manga/Domain/CountryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain;
+
+use App\Manga\Domain\Country;
+use PHPUnit\Framework\TestCase;
+
+final class CountryTest extends TestCase
+{
+    public function testLanguageForFrance(): void
+    {
+        $this->assertSame('fr', Country::France->language());
+    }
+
+    public function testLanguageForUnitedStates(): void
+    {
+        $this->assertSame('en', Country::UnitedStates->language());
+    }
+
+    public function testLanguageForItaly(): void
+    {
+        $this->assertSame('it', Country::Italy->language());
+    }
+
+    public function testLanguageForSpain(): void
+    {
+        $this->assertSame('es', Country::Spain->language());
+    }
+
+    public function testLanguageForGermany(): void
+    {
+        $this->assertSame('de', Country::Germany->language());
+    }
+
+    public function testLanguageForJapan(): void
+    {
+        $this->assertSame('ja', Country::Japan->language());
+    }
+
+    public function testDefaultIsFrance(): void
+    {
+        $this->assertSame(Country::France, Country::default());
+    }
+
+    public function testFromCodeResolvesKnownCountry(): void
+    {
+        $this->assertSame(Country::UnitedStates, Country::fromCode('US'));
+    }
+
+    public function testFromCodeResolvesItaly(): void
+    {
+        $this->assertSame(Country::Italy, Country::fromCode('IT'));
+    }
+
+    public function testFromCodeResolvesSpain(): void
+    {
+        $this->assertSame(Country::Spain, Country::fromCode('ES'));
+    }
+
+    public function testFromCodeResolvesGermany(): void
+    {
+        $this->assertSame(Country::Germany, Country::fromCode('DE'));
+    }
+
+    public function testFromCodeIsCaseInsensitive(): void
+    {
+        $this->assertSame(Country::Japan, Country::fromCode('jp'));
+    }
+
+    public function testFromCodeTrimsWhitespace(): void
+    {
+        $this->assertSame(Country::France, Country::fromCode('  FR  '));
+    }
+
+    public function testFromCodeFallsBackToDefaultOnUnknownCode(): void
+    {
+        $this->assertSame(Country::France, Country::fromCode('XX'));
+    }
+
+    public function testFromCodeFallsBackToDefaultOnNull(): void
+    {
+        $this->assertSame(Country::France, Country::fromCode(null));
+    }
+
+    public function testFromCodeFallsBackToDefaultOnEmptyString(): void
+    {
+        $this->assertSame(Country::France, Country::fromCode(''));
+    }
+}

--- a/back/tests/Unit/Manga/Domain/ExternalEditionDtoTest.php
+++ b/back/tests/Unit/Manga/Domain/ExternalEditionDtoTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain;
+
+use App\Manga\Domain\ExternalEditionDto;
+use PHPUnit\Framework\TestCase;
+
+final class ExternalEditionDtoTest extends TestCase
+{
+    public function testConstructionAndToArray(): void
+    {
+        $dto = new ExternalEditionDto(
+            publisher: 'Glénat',
+            editionLabel: 'deluxe',
+            year: 2019,
+            language: 'fr',
+            coverUrl: 'https://example.com/cover.jpg',
+            volumeCount: 40,
+            sampleIsbn: '9782344020814',
+            source: 'google_books',
+        );
+
+        $this->assertSame('Glénat', $dto->publisher);
+        $this->assertSame('deluxe', $dto->editionLabel);
+        $this->assertSame(2019, $dto->year);
+        $this->assertSame('fr', $dto->language);
+        $this->assertSame('https://example.com/cover.jpg', $dto->coverUrl);
+        $this->assertSame(40, $dto->volumeCount);
+        $this->assertSame('9782344020814', $dto->sampleIsbn);
+        $this->assertSame('google_books', $dto->source);
+
+        $array = $dto->toArray();
+        $this->assertSame('Glénat', $array['publisher']);
+        $this->assertSame('deluxe', $array['editionLabel']);
+        $this->assertSame(2019, $array['year']);
+        $this->assertSame('fr', $array['language']);
+        $this->assertSame('https://example.com/cover.jpg', $array['coverUrl']);
+        $this->assertSame(40, $array['volumeCount']);
+        $this->assertSame('9782344020814', $array['sampleIsbn']);
+        $this->assertSame('google_books', $array['source']);
+    }
+
+    public function testNullableFields(): void
+    {
+        $dto = new ExternalEditionDto(
+            publisher: 'Ki-oon',
+            editionLabel: null,
+            year: null,
+            language: 'fr',
+            coverUrl: null,
+            volumeCount: null,
+            sampleIsbn: null,
+            source: 'open_library',
+        );
+
+        $array = $dto->toArray();
+        $this->assertNull($array['editionLabel']);
+        $this->assertNull($array['year']);
+        $this->assertNull($array['coverUrl']);
+        $this->assertNull($array['volumeCount']);
+        $this->assertNull($array['sampleIsbn']);
+    }
+}

--- a/back/tests/Unit/Manga/Domain/MangaTest.php
+++ b/back/tests/Unit/Manga/Domain/MangaTest.php
@@ -23,6 +23,9 @@ final class MangaTest extends TestCase
             coverUrl: 'https://example.com/cover.jpg',
             genre: GenreEnum::Shonen,
             externalId: 'ext-123',
+            publisher: 'Glénat',
+            editionYear: 2019,
+            externalWorkId: 'mal-42',
         );
     }
 
@@ -40,6 +43,9 @@ final class MangaTest extends TestCase
         $this->assertSame('ext-123', $arr['externalId']);
         $this->assertSame(0, $arr['totalVolumes']);
         $this->assertArrayHasKey('createdAt', $arr);
+        $this->assertSame('Glénat', $arr['publisher']);
+        $this->assertSame(2019, $arr['editionYear']);
+        $this->assertSame('mal-42', $arr['externalWorkId']);
     }
 
     public function testToArrayNullableFields(): void
@@ -52,6 +58,9 @@ final class MangaTest extends TestCase
         $this->assertNull($arr['coverUrl']);
         $this->assertNull($arr['genre']);
         $this->assertNull($arr['externalId']);
+        $this->assertNull($arr['publisher']);
+        $this->assertNull($arr['editionYear']);
+        $this->assertNull($arr['externalWorkId']);
     }
 
     public function testAddVolume(): void

--- a/back/tests/Unit/Manga/Domain/Service/CoverBatchResolverTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/CoverBatchResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Domain\Service;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\Manga;
 use App\Manga\Domain\MangaCoverProviderInterface;
@@ -41,7 +42,7 @@ final class CoverBatchResolverTest extends TestCase
                 return $this->dto;
             }
 
-            public function findByContext(string $mangaTitle, ?string $edition, int $volumeNumber, string $language = 'fr'): ?MangaVolumeCoverDto
+            public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
             {
                 return $this->dto;
             }
@@ -138,7 +139,7 @@ final class CoverBatchResolverTest extends TestCase
                 return $this->dto;
             }
 
-            public function findByContext(string $mangaTitle, ?string $edition, int $volumeNumber, string $language = 'fr'): ?MangaVolumeCoverDto
+            public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
             {
                 $this->log[] = 'findByContext';
                 return $this->dto;
@@ -174,7 +175,7 @@ final class CoverBatchResolverTest extends TestCase
                 return null;
             }
 
-            public function findByContext(string $mangaTitle, ?string $edition, int $volumeNumber, string $language = 'fr'): ?MangaVolumeCoverDto
+            public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
             {
                 $this->log[] = 'findByContext';
                 return $this->dto;
@@ -212,7 +213,7 @@ final class CoverBatchResolverTest extends TestCase
                 return null;
             }
 
-            public function findByContext(string $mangaTitle, ?string $edition, int $volumeNumber, string $language = 'fr'): ?MangaVolumeCoverDto
+            public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
             {
                 $this->count++;
                 return $this->count === 1 ? $this->dto : null;

--- a/back/tests/Unit/Manga/Domain/Service/EditionGrouperTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/EditionGrouperTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain\Service;
+
+use App\Manga\Domain\Service\EditionGrouper;
+use PHPUnit\Framework\TestCase;
+
+final class EditionGrouperTest extends TestCase
+{
+    private EditionGrouper $grouper;
+
+    protected function setUp(): void
+    {
+        $this->grouper = new EditionGrouper();
+    }
+
+    public function testGroupsThreeVolumesFromSamePublisher(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2021, 'volumeNumber' => 3, 'title' => 'Berserk T03', 'coverUrl' => 'https://cover3.jpg', 'isbn' => null],
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Berserk T01', 'coverUrl' => 'https://cover1.jpg', 'isbn' => '9782344020814'],
+            ['publisher' => 'Glénat', 'year' => 2020, 'volumeNumber' => 2, 'title' => 'Berserk T02', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('Glénat', $editions[0]->publisher);
+        $this->assertSame(2019, $editions[0]->year);
+        $this->assertSame(3, $editions[0]->volumeCount);
+        $this->assertSame('https://cover1.jpg', $editions[0]->coverUrl);
+        $this->assertSame('9782344020814', $editions[0]->sampleIsbn);
+    }
+
+    public function testGroupsTwoDistinctPublishers(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Berserk T01', 'coverUrl' => 'https://glenat.jpg', 'isbn' => null],
+            ['publisher' => 'Panini', 'year' => 2020, 'volumeNumber' => 1, 'title' => 'Berserk Vol.1', 'coverUrl' => 'https://panini.jpg', 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertCount(2, $editions);
+        $publishers = array_map(fn ($edition) => $edition->publisher, $editions);
+        $this->assertContains('Glénat', $publishers);
+        $this->assertContains('Panini', $publishers);
+    }
+
+    public function testDetectsPerfectEditionLabel(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2022, 'volumeNumber' => 1, 'title' => 'Berserk Perfect Edition T01', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('perfect', $editions[0]->editionLabel);
+    }
+
+    public function testDetectsDeluxeLabel(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Ki-oon', 'year' => 2021, 'volumeNumber' => 1, 'title' => 'Chainsaw Man Deluxe', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertSame('deluxe', $editions[0]->editionLabel);
+    }
+
+    public function testIgnoresItemsWithoutPublisher(): void
+    {
+        $rawVolumes = [
+            ['publisher' => null, 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Unknown', 'coverUrl' => null, 'isbn' => null],
+            ['publisher' => '', 'year' => 2020, 'volumeNumber' => 2, 'title' => 'Empty', 'coverUrl' => null, 'isbn' => null],
+            ['publisher' => 'Glénat', 'year' => 2021, 'volumeNumber' => 1, 'title' => 'Berserk', 'coverUrl' => 'https://cover.jpg', 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('Glénat', $editions[0]->publisher);
+    }
+
+    public function testEmptyInputReturnsEmptyArray(): void
+    {
+        $editions = $this->grouper->group([], 'fr');
+
+        $this->assertSame([], $editions);
+    }
+
+    public function testCoverPrioritizesVolumeOne(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2021, 'volumeNumber' => 3, 'title' => 'T03', 'coverUrl' => 'https://cover3.jpg', 'isbn' => null],
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'T01', 'coverUrl' => 'https://cover1.jpg', 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertSame('https://cover1.jpg', $editions[0]->coverUrl);
+    }
+
+    public function testNoEditionLabelForStandardTitle(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Berserk T01', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertNull($editions[0]->editionLabel);
+    }
+
+    public function testSourceDefaultsToGrouped(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Berserk T01', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr');
+
+        $this->assertSame('grouped', $editions[0]->source);
+    }
+
+    public function testSourceIsTaggedOnEachEdition(): void
+    {
+        $rawVolumes = [
+            ['publisher' => 'Glénat', 'year' => 2019, 'volumeNumber' => 1, 'title' => 'Berserk T01', 'coverUrl' => null, 'isbn' => null],
+        ];
+
+        $editions = $this->grouper->group($rawVolumes, 'fr', 'bnf');
+
+        $this->assertSame('bnf', $editions[0]->source);
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/BneEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/BneEditionDiscoveryClientTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\BneEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class BneEditionDiscoveryClientTest extends TestCase
+{
+    private const string BASE_URL = 'https://www.bne.es/SRUBib';
+
+    private function makeClient(MockHttpClient $httpClient): BneEditionDiscoveryClient
+    {
+        return new BneEditionDiscoveryClient(
+            $httpClient,
+            self::BASE_URL,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * SRU oai_dc response with two Spanish Planeta volumes and one English VIZ
+     * volume; the English record must be filtered out.
+     */
+    private function sruResponse(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:version>1.1</srw:version>
+          <srw:numberOfRecords>3</srw:numberOfRecords>
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Vol. 1</dc:title>
+                  <dc:creator>Toriyama, Akira</dc:creator>
+                  <dc:publisher>Planeta (Barcelona)</dc:publisher>
+                  <dc:date>2002</dc:date>
+                  <dc:language>spa</dc:language>
+                  <dc:identifier>ISBN 978-84-9787-001-0</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Vol. 2</dc:title>
+                  <dc:publisher>Planeta</dc:publisher>
+                  <dc:date>2002</dc:date>
+                  <dc:language>spa</dc:language>
+                  <dc:identifier>ISBN 9788497870027</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball, Vol. 1</dc:title>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dc:date>2003</dc:date>
+                  <dc:language>eng</dc:language>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+    }
+
+    public function testDiscoverEditionsGroupsSpanishVolumesByPublisher(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Dragon Ball', Country::Spain);
+
+        // The English VIZ record is filtered out, and the city suffix is stripped
+        // from the first Planeta record, so both volumes merge into one edition.
+        $this->assertCount(1, $editions);
+        $this->assertSame('Planeta', $editions[0]->publisher);
+        $this->assertSame('bne', $editions[0]->source);
+        $this->assertSame('es', $editions[0]->language);
+        $this->assertSame(2002, $editions[0]->year);
+        $this->assertSame(2, $editions[0]->volumeCount);
+    }
+
+    public function testReturnsEmptyForNonSpainWithoutHttpCall(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::Spain));
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/BnfEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/BnfEditionDiscoveryClientTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\BnfEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class BnfEditionDiscoveryClientTest extends TestCase
+{
+    private const string BASE_URL = 'https://catalogue.bnf.fr/api/SRU';
+
+    private function makeClient(MockHttpClient $httpClient): BnfEditionDiscoveryClient
+    {
+        return new BnfEditionDiscoveryClient(
+            $httpClient,
+            self::BASE_URL,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * SRU response with two French Glénat volumes (the first carrying both a
+     * city suffix on its publisher and an ARK URI alongside its ISBN) and one
+     * English VIZ Media volume.
+     */
+    private function sruResponse(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:version>1.2</srw:version>
+          <srw:numberOfRecords>3</srw:numberOfRecords>
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Tome 1</dc:title>
+                  <dc:creator>Toriyama, Akira</dc:creator>
+                  <dc:publisher>Glénat (Grenoble)</dc:publisher>
+                  <dc:date>1993</dc:date>
+                  <dc:language>fre</dc:language>
+                  <dc:identifier>http://catalogue.bnf.fr/ark:/12148/cb39476789p</dc:identifier>
+                  <dc:identifier>ISBN 978-2-344-02081-4</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Tome 2</dc:title>
+                  <dc:publisher>Glénat</dc:publisher>
+                  <dc:date>DL 1994</dc:date>
+                  <dc:language>fre</dc:language>
+                  <dc:identifier>ISBN 9782344020822</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball, Vol. 1</dc:title>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dc:date>2003</dc:date>
+                  <dc:language>eng</dc:language>
+                  <dc:identifier>ISBN 978-1-56931-920-1</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+    }
+
+    public function testDiscoverEditionsGroupsFrenchVolumesByPublisher(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Dragon Ball', Country::France);
+
+        // The English VIZ Media record is filtered out, and the two French
+        // records merge into one edition once the "(Grenoble)" city suffix is
+        // stripped from the first publisher.
+        $this->assertCount(1, $editions);
+        $this->assertSame('Glénat', $editions[0]->publisher);
+        $this->assertSame('bnf', $editions[0]->source);
+        $this->assertSame(1993, $editions[0]->year);
+        $this->assertSame(2, $editions[0]->volumeCount);
+    }
+
+    public function testDiscoverEditionsPicksIsbnOverArkIdentifier(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Dragon Ball', Country::France);
+
+        $this->assertSame('9782344020814', $editions[0]->sampleIsbn);
+        $this->assertStringContainsString('covers.openlibrary.org', (string) $editions[0]->coverUrl);
+        $this->assertStringContainsString('9782344020814', (string) $editions[0]->coverUrl);
+    }
+
+    public function testReturnsEmptyForNonFranceWithoutHttpCall(): void
+    {
+        // No mock responses: any HTTP call would raise, proving the country guard
+        // short-circuits before reaching the network.
+        $httpClient = new MockHttpClient([]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::Japan));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+    }
+
+    public function testReturnsEmptyOnMalformedXml(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse('this is not xml')]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+    }
+
+    public function testReturnsEmptyWhenNoRecordsMatchLanguage(): void
+    {
+        $englishOnly = <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball, Vol. 1</dc:title>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dc:language>eng</dc:language>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+
+        $httpClient = new MockHttpClient([new MockResponse($englishOnly)]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/CompositeEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/CompositeEditionDiscoveryClientTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\EditionDiscoveryInterface;
+use App\Manga\Domain\ExternalEditionDto;
+use App\Manga\Infrastructure\ExternalApi\CompositeEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class CompositeEditionDiscoveryClientTest extends TestCase
+{
+    private function makeEdition(
+        string $publisher,
+        ?int $year,
+        string $source,
+        ?int $volumeCount = null,
+    ): ExternalEditionDto {
+        return new ExternalEditionDto(
+            publisher: $publisher,
+            editionLabel: null,
+            year: $year,
+            language: 'fr',
+            coverUrl: null,
+            volumeCount: $volumeCount,
+            sampleIsbn: null,
+            source: $source,
+        );
+    }
+
+    public function testDeduplicatesEditionsByPublisherAndYear(): void
+    {
+        $googleEdition = $this->makeEdition('Glénat', 2019, 'google_books');
+        $openLibEdition = $this->makeEdition('Glénat', 2019, 'open_library');
+
+        $googleProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $googleProvider->method('discoverEditions')->willReturn([$googleEdition]);
+
+        $openLibProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $openLibProvider->method('discoverEditions')->willReturn([$openLibEdition]);
+
+        $composite = new CompositeEditionDiscoveryClient(
+            [$googleProvider, $openLibProvider],
+            new NullLogger(),
+        );
+
+        $editions = $composite->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('google_books', $editions[0]->source);
+    }
+
+    public function testMergesUniqueEditionsFromBothProviders(): void
+    {
+        $googleEdition = $this->makeEdition('Glénat', 2019, 'google_books');
+        $openLibEdition = $this->makeEdition('Panini', 2020, 'open_library');
+
+        $googleProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $googleProvider->method('discoverEditions')->willReturn([$googleEdition]);
+
+        $openLibProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $openLibProvider->method('discoverEditions')->willReturn([$openLibEdition]);
+
+        $composite = new CompositeEditionDiscoveryClient(
+            [$googleProvider, $openLibProvider],
+            new NullLogger(),
+        );
+
+        $editions = $composite->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(2, $editions);
+    }
+
+    public function testReturnsEmptyWhenNoProviders(): void
+    {
+        $composite = new CompositeEditionDiscoveryClient([], new NullLogger());
+        $editions = $composite->discoverEditions('Berserk', Country::France);
+
+        $this->assertSame([], $editions);
+    }
+
+    public function testSortsEditionsByVolumeCountDescending(): void
+    {
+        $singleVolume = $this->makeEdition('Hachette', 2008, 'bnf', 1);
+        $manyVolumes = $this->makeEdition('Glénat', 1993, 'bnf', 21);
+        $someVolumes = $this->makeEdition('Panini', 2020, 'google_books', 8);
+
+        $firstProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $firstProvider->method('discoverEditions')->willReturn([$singleVolume, $manyVolumes]);
+
+        $secondProvider = $this->createStub(EditionDiscoveryInterface::class);
+        $secondProvider->method('discoverEditions')->willReturn([$someVolumes]);
+
+        $composite = new CompositeEditionDiscoveryClient(
+            [$firstProvider, $secondProvider],
+            new NullLogger(),
+        );
+
+        $editions = $composite->discoverEditions('Dragon Ball', Country::France);
+
+        $volumeCounts = array_map(static fn (ExternalEditionDto $edition): ?int => $edition->volumeCount, $editions);
+        $this->assertSame([21, 8, 1], $volumeCounts);
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/CompositeMangaCoverApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/CompositeMangaCoverApiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Infrastructure;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaCoverProviderInterface;
 use App\Manga\Domain\MangaVolumeCoverDto;
@@ -23,7 +24,7 @@ final class CompositeMangaCoverApiClientTest extends TestCase
                 return $this->dto;
             }
 
-            public function findByContext(string $mangaTitle, ?string $edition, int $volumeNumber, string $language = 'fr'): ?MangaVolumeCoverDto
+            public function findByContext(EditionContext $context, int $volumeNumber): ?MangaVolumeCoverDto
             {
                 return $this->dto;
             }
@@ -103,7 +104,8 @@ final class CompositeMangaCoverApiClientTest extends TestCase
             new NullLogger(),
         );
 
-        $result = $composite->findByContext('One Piece', null, 1);
+        $context = new EditionContext(mangaTitle: 'One Piece');
+        $result = $composite->findByContext($context, 1);
 
         $this->assertSame($dto, $result);
     }
@@ -115,7 +117,8 @@ final class CompositeMangaCoverApiClientTest extends TestCase
             new NullLogger(),
         );
 
-        $result = $composite->findByContext('Unknown Manga', null, 99);
+        $context = new EditionContext(mangaTitle: 'Unknown Manga');
+        $result = $composite->findByContext($context, 99);
 
         $this->assertNull($result);
     }

--- a/back/tests/Unit/Manga/Infrastructure/DnbEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/DnbEditionDiscoveryClientTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\DnbEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class DnbEditionDiscoveryClientTest extends TestCase
+{
+    private const string BASE_URL = 'https://services.dnb.de/sru/dnb';
+
+    private function makeClient(MockHttpClient $httpClient): DnbEditionDiscoveryClient
+    {
+        return new DnbEditionDiscoveryClient(
+            $httpClient,
+            self::BASE_URL,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * SRU oai_dc response with two German Carlsen volumes (the first carrying a
+     * city suffix on its publisher) and one French Glénat volume.
+     */
+    private function sruResponse(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:version>1.1</srw:version>
+          <srw:numberOfRecords>3</srw:numberOfRecords>
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Band 1</dc:title>
+                  <dc:creator>Toriyama, Akira</dc:creator>
+                  <dc:publisher>Carlsen (Hamburg)</dc:publisher>
+                  <dc:date>2001</dc:date>
+                  <dc:language>ger</dc:language>
+                  <dc:identifier>ISBN 978-3-551-74201-0</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Band 2</dc:title>
+                  <dc:publisher>Carlsen</dc:publisher>
+                  <dc:date>2001</dc:date>
+                  <dc:language>ger</dc:language>
+                  <dc:identifier>ISBN 9783551742027</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Tome 1</dc:title>
+                  <dc:publisher>Glénat</dc:publisher>
+                  <dc:date>1993</dc:date>
+                  <dc:language>fre</dc:language>
+                  <dc:identifier>ISBN 978-2-344-02081-4</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+    }
+
+    public function testDiscoverEditionsGroupsGermanVolumesByPublisher(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Dragon Ball', Country::Germany);
+
+        // The French Glénat record is filtered out, and the two German records
+        // merge into one edition once the "(Hamburg)" city suffix is stripped.
+        $this->assertCount(1, $editions);
+        $this->assertSame('Carlsen', $editions[0]->publisher);
+        $this->assertSame('dnb', $editions[0]->source);
+        $this->assertSame('de', $editions[0]->language);
+        $this->assertSame(2001, $editions[0]->year);
+        $this->assertSame(2, $editions[0]->volumeCount);
+        $this->assertSame('9783551742010', $editions[0]->sampleIsbn);
+    }
+
+    public function testReturnsEmptyForNonGermanyWithoutHttpCall(): void
+    {
+        // No mock responses: any HTTP call would raise, proving the country
+        // guard short-circuits before reaching the network.
+        $httpClient = new MockHttpClient([]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::Germany));
+    }
+
+    public function testReturnsEmptyOnMalformedXml(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse('this is not xml')]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::Germany));
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/GoogleBooksEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/GoogleBooksEditionDiscoveryClientTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\GoogleBooksEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class GoogleBooksEditionDiscoveryClientTest extends TestCase
+{
+    private const string API_KEY = 'test-api-key';
+
+    private function makeClient(MockHttpClient $httpClient): GoogleBooksEditionDiscoveryClient
+    {
+        return new GoogleBooksEditionDiscoveryClient(
+            $httpClient,
+            self::API_KEY,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    private function makeVolumeItem(string $publisher, int $volumeNumber, string $title = 'Berserk'): array
+    {
+        return [
+            'id' => 'vol-' . $volumeNumber,
+            'volumeInfo' => [
+                'title'         => $title . ' T0' . $volumeNumber,
+                'publisher'     => $publisher,
+                'publishedDate' => '2019-0' . $volumeNumber . '-01',
+                'language'      => 'fr',
+                'imageLinks'    => [
+                    'thumbnail' => 'https://books.google.com/cover' . $volumeNumber . '.jpg',
+                ],
+                'industryIdentifiers' => [
+                    ['type' => 'ISBN_13', 'identifier' => '978234402081' . $volumeNumber],
+                ],
+                'seriesInfo' => [
+                    'bookDisplayNumber' => (string) $volumeNumber,
+                ],
+            ],
+        ];
+    }
+
+    public function testDiscoverEditionsReturnsTwoEditionsForTwoPublishers(): void
+    {
+        $glennatItems = [
+            $this->makeVolumeItem('Glénat', 1),
+            $this->makeVolumeItem('Glénat', 2),
+            $this->makeVolumeItem('Glénat', 3),
+        ];
+        $paniniItems = [
+            $this->makeVolumeItem('Panini', 1, 'Berserk Panini'),
+        ];
+
+        $allItems = array_merge($glennatItems, $paniniItems);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['items' => $allItems])),
+            new MockResponse((string) json_encode([])),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(2, $editions);
+        $publishers = array_map(fn ($edition) => $edition->publisher, $editions);
+        $this->assertContains('Glénat', $publishers);
+        $this->assertContains('Panini', $publishers);
+        $this->assertSame('google_books', $editions[0]->source);
+    }
+
+    public function testDiscoverEditionsFiltersOutMismatchedLanguageItems(): void
+    {
+        $frenchItem = $this->makeVolumeItem('Glénat', 1);
+        $englishItem = [
+            'id' => 'vol-en',
+            'volumeInfo' => [
+                'title'     => 'Berserk Vol.1',
+                'publisher' => 'Dark Horse',
+                'language'  => 'en',
+                'industryIdentifiers' => [
+                    ['type' => 'ISBN_13', 'identifier' => '9781506711980'],
+                ],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['items' => [$frenchItem, $englishItem]])),
+            new MockResponse((string) json_encode([])),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('Glénat', $editions[0]->publisher);
+    }
+
+    public function testDiscoverEditionsReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertSame([], $editions);
+    }
+
+    public function testDiscoverEditionsIgnoresItemsWithoutPublisher(): void
+    {
+        $itemWithoutPublisher = [
+            'id' => 'vol-no-pub',
+            'volumeInfo' => [
+                'title'    => 'Berserk T01',
+                'language' => 'fr',
+                'imageLinks' => ['thumbnail' => 'https://cover.jpg'],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['items' => [$itemWithoutPublisher]])),
+            new MockResponse((string) json_encode([])),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertSame([], $editions);
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/GoogleBooksMangaApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/GoogleBooksMangaApiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Infrastructure;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaVolumeCoverDto;
 use App\Manga\Infrastructure\ExternalApi\GoogleBooksMangaApiClient;
@@ -26,25 +27,31 @@ final class GoogleBooksMangaApiClientTest extends TestCase
         return Isbn::fromString('9782123456780');
     }
 
-    private function volumeItemWithCover(string $coverUrl = 'https://books.google.com/cover.jpg'): array
+    private function volumeItemWithCover(string $coverUrl = 'https://books.google.com/cover.jpg', ?string $publisher = null): array
     {
-        return [
-            'id' => 'google-vol-1',
-            'volumeInfo' => [
-                'title' => 'One Piece T.1',
-                'categories' => ['Comics & Graphic Novels / Manga'],
-                'imageLinks' => [
-                    'thumbnail' => str_replace('https://', 'http://', $coverUrl) . '&edge=curl',
-                ],
-                'language' => 'fr',
+        $volumeInfo = [
+            'title'      => 'One Piece T.1',
+            'categories' => ['Comics & Graphic Novels / Manga'],
+            'imageLinks' => [
+                'thumbnail' => str_replace('https://', 'http://', $coverUrl) . '&edge=curl',
             ],
+            'language' => 'fr',
+        ];
+
+        if ($publisher !== null) {
+            $volumeInfo['publisher'] = $publisher;
+        }
+
+        return [
+            'id'         => 'google-vol-1',
+            'volumeInfo' => $volumeInfo,
         ];
     }
 
     public function testFindByIsbnReturnsDtoWhenCoverFound(): void
     {
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['items' => [$this->volumeItemWithCover()]])),
+            new MockResponse((string) json_encode(['items' => [$this->volumeItemWithCover()]])),
         ]);
 
         $isbn = $this->makeIsbn();
@@ -60,7 +67,7 @@ final class GoogleBooksMangaApiClientTest extends TestCase
     public function testFindByIsbnReturnsNullWhenNoItems(): void
     {
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['totalItems' => 0])),
+            new MockResponse((string) json_encode(['totalItems' => 0])),
         ]);
 
         $result = $this->makeClient($httpClient)->findByIsbn($this->makeIsbn());
@@ -82,16 +89,16 @@ final class GoogleBooksMangaApiClientTest extends TestCase
     public function testFindByIsbnReturnsNullWhenItemHasNoCover(): void
     {
         $item = [
-            'id' => 'google-vol-2',
+            'id'         => 'google-vol-2',
             'volumeInfo' => [
-                'title' => 'No Cover Book',
+                'title'      => 'No Cover Book',
                 'categories' => ['Comics & Graphic Novels / Manga'],
-                'language' => 'fr',
+                'language'   => 'fr',
             ],
         ];
 
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['items' => [$item]])),
+            new MockResponse((string) json_encode(['items' => [$item]])),
         ]);
 
         $result = $this->makeClient($httpClient)->findByIsbn($this->makeIsbn());
@@ -102,10 +109,11 @@ final class GoogleBooksMangaApiClientTest extends TestCase
     public function testFindByContextReturnsDtoWhenCoverFound(): void
     {
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['items' => [$this->volumeItemWithCover()]])),
+            new MockResponse((string) json_encode(['items' => [$this->volumeItemWithCover()]])),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('One Piece', null, 1);
+        $context = new EditionContext(mangaTitle: 'One Piece');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
 
         $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
         $this->assertSame('google_books', $result->source);
@@ -115,11 +123,28 @@ final class GoogleBooksMangaApiClientTest extends TestCase
     public function testFindByContextReturnsNullWhenNoResults(): void
     {
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['totalItems' => 0])),
+            new MockResponse((string) json_encode(['totalItems' => 0])),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('Unknown Manga', null, 42);
+        $context = new EditionContext(mangaTitle: 'Unknown Manga');
+        $result = $this->makeClient($httpClient)->findByContext($context, 42);
 
         $this->assertNull($result);
+    }
+
+    public function testFindByContextFiltersOnPublisherWhenProvided(): void
+    {
+        $matchingItem = $this->volumeItemWithCover('https://books.google.com/cover.jpg', 'Glénat');
+        $nonMatchingItem = $this->volumeItemWithCover('https://books.google.com/other.jpg', 'Panini');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['items' => [$nonMatchingItem, $matchingItem]])),
+        ]);
+
+        $context = new EditionContext(mangaTitle: 'Berserk', publisher: 'Glénat');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
+
+        $this->assertNotNull($result);
+        $this->assertStringContainsString('cover.jpg', $result->coverUrl);
     }
 }

--- a/back/tests/Unit/Manga/Infrastructure/LocEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/LocEditionDiscoveryClientTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\LocEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class LocEditionDiscoveryClientTest extends TestCase
+{
+    private const string BASE_URL = 'https://www.loc.gov/sru';
+
+    private function makeClient(MockHttpClient $httpClient): LocEditionDiscoveryClient
+    {
+        return new LocEditionDiscoveryClient(
+            $httpClient,
+            self::BASE_URL,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * SRU oai_dc response with two English VIZ Media volumes and one French
+     * Glénat volume; the French record must be filtered out.
+     */
+    private function sruResponse(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:version>1.1</srw:version>
+          <srw:numberOfRecords>3</srw:numberOfRecords>
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Vol. 1</dc:title>
+                  <dc:creator>Toriyama, Akira</dc:creator>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dc:date>2003</dc:date>
+                  <dc:language>eng</dc:language>
+                  <dc:identifier>ISBN 978-1-56931-920-1</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Vol. 2</dc:title>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dc:date>2003</dc:date>
+                  <dc:language>eng</dc:language>
+                  <dc:identifier>ISBN 9781569319208</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/">
+                  <dc:title>Dragon Ball. Tome 1</dc:title>
+                  <dc:publisher>Glénat</dc:publisher>
+                  <dc:date>1993</dc:date>
+                  <dc:language>fre</dc:language>
+                  <dc:identifier>ISBN 978-2-344-02081-4</dc:identifier>
+                </oai_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+    }
+
+    public function testDiscoverEditionsGroupsEnglishVolumesByPublisher(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Dragon Ball', Country::UnitedStates);
+
+        // The French Glénat record is filtered out, leaving one VIZ Media edition.
+        $this->assertCount(1, $editions);
+        $this->assertSame('VIZ Media', $editions[0]->publisher);
+        $this->assertSame('loc', $editions[0]->source);
+        $this->assertSame('en', $editions[0]->language);
+        $this->assertSame(2003, $editions[0]->year);
+        $this->assertSame(2, $editions[0]->volumeCount);
+    }
+
+    public function testReturnsEmptyForNonUsWithoutHttpCall(): void
+    {
+        $httpClient = new MockHttpClient([]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::France));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('Dragon Ball', Country::UnitedStates));
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/MangaDexMangaApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/MangaDexMangaApiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Infrastructure;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaVolumeCoverDto;
 use App\Manga\Infrastructure\ExternalApi\MangaDexMangaApiClient;
@@ -24,7 +25,7 @@ final class MangaDexMangaApiClientTest extends TestCase
 
     private function mangaSearchResponse(string $mangaId): MockResponse
     {
-        return new MockResponse(json_encode([
+        return new MockResponse((string) json_encode([
             'data' => [
                 ['id' => $mangaId, 'attributes' => ['title' => ['fr' => 'Test Manga']]],
             ],
@@ -33,12 +34,12 @@ final class MangaDexMangaApiClientTest extends TestCase
 
     private function coverListResponse(string $mangaId, int $volumeNumber, string $fileName): MockResponse
     {
-        return new MockResponse(json_encode([
+        return new MockResponse((string) json_encode([
             'data' => [
                 [
-                    'id' => 'cover-id-1',
+                    'id'         => 'cover-id-1',
                     'attributes' => [
-                        'volume' => (string) $volumeNumber,
+                        'volume'   => (string) $volumeNumber,
                         'fileName' => $fileName,
                     ],
                 ],
@@ -61,7 +62,8 @@ final class MangaDexMangaApiClientTest extends TestCase
             $this->coverListResponse(self::MANGA_ID, 1, 'cover.jpg'),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('Test Manga', null, 1);
+        $context = new EditionContext(mangaTitle: 'Test Manga');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
 
         $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
         $this->assertSame('mangadex', $result->source);
@@ -73,10 +75,11 @@ final class MangaDexMangaApiClientTest extends TestCase
     public function testFindByContextReturnsNullWhenNoMangaFound(): void
     {
         $httpClient = new MockHttpClient([
-            new MockResponse(json_encode(['data' => []]), ['response_headers' => ['Content-Type' => 'application/json']]),
+            new MockResponse((string) json_encode(['data' => []]), ['response_headers' => ['Content-Type' => 'application/json']]),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('Unknown Manga', null, 1);
+        $context = new EditionContext(mangaTitle: 'Unknown Manga');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
 
         $this->assertNull($result);
     }
@@ -85,11 +88,11 @@ final class MangaDexMangaApiClientTest extends TestCase
     {
         $httpClient = new MockHttpClient([
             $this->mangaSearchResponse(self::MANGA_ID),
-            // Cover list has volume 5, not the requested volume 1
             $this->coverListResponse(self::MANGA_ID, 5, 'cover5.jpg'),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('Test Manga', null, 1);
+        $context = new EditionContext(mangaTitle: 'Test Manga');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
 
         $this->assertNull($result);
     }
@@ -100,7 +103,8 @@ final class MangaDexMangaApiClientTest extends TestCase
             new MockResponse('Internal Server Error', ['http_code' => 500]),
         ]);
 
-        $result = $this->makeClient($httpClient)->findByContext('Test Manga', null, 1);
+        $context = new EditionContext(mangaTitle: 'Test Manga');
+        $result = $this->makeClient($httpClient)->findByContext($context, 1);
 
         $this->assertNull($result);
     }

--- a/back/tests/Unit/Manga/Infrastructure/NdlEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/NdlEditionDiscoveryClientTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Domain\Service\EditionGrouper;
+use App\Manga\Infrastructure\ExternalApi\NdlEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class NdlEditionDiscoveryClientTest extends TestCase
+{
+    private const string BASE_URL = 'https://ndlsearch.ndl.go.jp/api/sru';
+
+    private function makeClient(MockHttpClient $httpClient): NdlEditionDiscoveryClient
+    {
+        return new NdlEditionDiscoveryClient(
+            $httpClient,
+            self::BASE_URL,
+            new EditionGrouper(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * SRU dcndl_simple response with two Japanese Shueisha volumes (dates in
+     * dcterms:date, ISBN in dcndl:ISBN) and one English VIZ Media volume.
+     */
+    private function sruResponse(): string
+    {
+        return <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <srw:searchRetrieveResponse xmlns:srw="http://www.loc.gov/zing/srw/">
+          <srw:version>1.2</srw:version>
+          <srw:numberOfRecords>3</srw:numberOfRecords>
+          <srw:records>
+            <srw:record>
+              <srw:recordData>
+                <srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-v1.1"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:dcterms="http://purl.org/dc/terms/"
+                           xmlns:dcndl="http://ndl.go.jp/dcndl/terms/">
+                  <dc:title>ドラゴンボール 1</dc:title>
+                  <dc:creator>鳥山, 明</dc:creator>
+                  <dc:publisher>集英社</dc:publisher>
+                  <dcterms:date>1985</dcterms:date>
+                  <dc:language>jpn</dc:language>
+                  <dcndl:ISBN>978-4-08-851831-5</dcndl:ISBN>
+                </srw_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-v1.1"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:dcterms="http://purl.org/dc/terms/"
+                           xmlns:dcndl="http://ndl.go.jp/dcndl/terms/">
+                  <dc:title>ドラゴンボール 2</dc:title>
+                  <dc:publisher>集英社</dc:publisher>
+                  <dcterms:date>1986</dcterms:date>
+                  <dc:language>jpn</dc:language>
+                  <dcndl:ISBN>978-4-08-851832-2</dcndl:ISBN>
+                </srw_dc:dc>
+              </srw:recordData>
+            </srw:record>
+            <srw:record>
+              <srw:recordData>
+                <srw_dc:dc xmlns:srw_dc="info:srw/schema/1/dc-v1.1"
+                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:dcterms="http://purl.org/dc/terms/">
+                  <dc:title>Dragon Ball, Vol. 1</dc:title>
+                  <dc:publisher>VIZ Media</dc:publisher>
+                  <dcterms:date>2003</dcterms:date>
+                  <dc:language>eng</dc:language>
+                </srw_dc:dc>
+              </srw:recordData>
+            </srw:record>
+          </srw:records>
+        </srw:searchRetrieveResponse>
+        XML;
+    }
+
+    public function testDiscoverEditionsGroupsJapaneseVolumesByPublisher(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('ドラゴンボール', Country::Japan);
+
+        // The English VIZ Media record is filtered out, leaving one Shueisha
+        // edition spanning the two Japanese volumes.
+        $this->assertCount(1, $editions);
+        $this->assertSame('集英社', $editions[0]->publisher);
+        $this->assertSame('ndl', $editions[0]->source);
+        $this->assertSame('ja', $editions[0]->language);
+        $this->assertSame(1985, $editions[0]->year);
+        $this->assertSame(2, $editions[0]->volumeCount);
+    }
+
+    public function testParsesIsbnFromDcndlElement(): void
+    {
+        $httpClient = new MockHttpClient([new MockResponse($this->sruResponse())]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('ドラゴンボール', Country::Japan);
+
+        $this->assertSame('9784088518315', $editions[0]->sampleIsbn);
+        $this->assertStringContainsString('9784088518315', (string) $editions[0]->coverUrl);
+    }
+
+    public function testReturnsEmptyForNonJapanWithoutHttpCall(): void
+    {
+        // No mock responses: any HTTP call would raise, proving the country
+        // guard short-circuits before reaching the network.
+        $httpClient = new MockHttpClient([]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('ドラゴンボール', Country::France));
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Service Unavailable', ['http_code' => 503]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+
+        $this->assertSame([], $client->discoverEditions('ドラゴンボール', Country::Japan));
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/OpenLibraryCoversApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/OpenLibraryCoversApiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Infrastructure;
 
+use App\Manga\Domain\EditionContext;
 use App\Manga\Domain\Isbn;
 use App\Manga\Domain\MangaVolumeCoverDto;
 use App\Manga\Infrastructure\ExternalApi\OpenLibraryCoversApiClient;
@@ -103,7 +104,8 @@ final class OpenLibraryCoversApiClientTest extends TestCase
     {
         $client = $this->makeClient(new MockHttpClient([]));
 
-        $result = $client->findByContext('One Piece', null, 1);
+        $context = new EditionContext(mangaTitle: 'One Piece');
+        $result = $client->findByContext($context, 1);
 
         $this->assertNull($result);
     }

--- a/back/tests/Unit/Manga/Infrastructure/OpenLibraryEditionDiscoveryClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/OpenLibraryEditionDiscoveryClientTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Domain\Country;
+use App\Manga\Infrastructure\ExternalApi\OpenLibraryEditionDiscoveryClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class OpenLibraryEditionDiscoveryClientTest extends TestCase
+{
+    private function makeClient(MockHttpClient $httpClient): OpenLibraryEditionDiscoveryClient
+    {
+        return new OpenLibraryEditionDiscoveryClient(
+            $httpClient,
+            'https://openlibrary.org',
+            new NullLogger(),
+        );
+    }
+
+    public function testDiscoverEditionsFiltersByLanguage(): void
+    {
+        $docs = [
+            [
+                'title'               => 'Berserk T01',
+                'publisher'           => ['Glénat'],
+                'first_publish_year'  => 2019,
+                'isbn'                => ['9782344020814'],
+                'language'            => ['fre'],
+            ],
+            [
+                'title'               => 'Berserk Vol.1',
+                'publisher'           => ['Dark Horse'],
+                'first_publish_year'  => 2018,
+                'isbn'                => ['9781506711980'],
+                'language'            => ['eng'],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['docs' => $docs])),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(1, $editions);
+        $this->assertSame('Glénat', $editions[0]->publisher);
+        $this->assertSame('open_library', $editions[0]->source);
+    }
+
+    public function testDiscoverEditionsReturnsEmptyOnHttpError(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse('Error', ['http_code' => 500]),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertSame([], $editions);
+    }
+
+    public function testDiscoverEditionsDeduplicatesPublishers(): void
+    {
+        $docs = [
+            [
+                'title'              => 'Berserk T01',
+                'publisher'          => ['Glénat'],
+                'first_publish_year' => 2019,
+                'isbn'               => ['9782344020814'],
+                'language'           => ['fre'],
+            ],
+            [
+                'title'              => 'Berserk T02',
+                'publisher'          => ['Glénat'],
+                'first_publish_year' => 2019,
+                'isbn'               => ['9782344020813'],
+                'language'           => ['fre'],
+            ],
+        ];
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['docs' => $docs])),
+        ]);
+
+        $client = $this->makeClient($httpClient);
+        $editions = $client->discoverEditions('Berserk', Country::France);
+
+        $this->assertCount(1, $editions);
+    }
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@tanstack/vue-query": "^5.99.0",
         "axios": "^1.16.0",
+        "barcode-detector": "^3.0.0",
         "chart.js": "^4.5.1",
         "lucide-vue-next": "^1.0.0",
         "pinia": "^3.0.4",
+        "qrcode": "^1.5.4",
         "three": "^0.184.0",
         "vue": "^3.5.32",
         "vue-chartjs": "^5.3.3",
@@ -23,6 +25,7 @@
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^24.12.2",
+        "@types/qrcode": "^1.5.5",
         "@types/three": "^0.184.0",
         "@vitejs/plugin-vue": "^6.0.5",
         "@vue/test-utils": "^2.4.6",
@@ -1355,6 +1358,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1384,6 +1393,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stats.js": {
@@ -2110,6 +2129,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/barcode-detector": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.1.3.tgz",
+      "integrity": "sha512-omL3/x26oU9jlR0gUQcGdXIjQtMlrUGKF7xRFO1RwrQkRkRU7WLz0mgQEsdUtYBm2uX3JH+HQLrKlyTS/BxZRw==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.0.3"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2162,6 +2190,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2184,11 +2221,91 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2201,7 +2318,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2349,6 +2465,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2381,6 +2506,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2943,6 +3074,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3166,7 +3306,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3875,6 +4014,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3919,7 +4067,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4021,6 +4168,15 @@
         "@vue/devtools-kit": "^7.7.9"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -4115,11 +4271,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/remove-accents": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
       "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -4130,6 +4312,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -4203,6 +4391,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4402,6 +4596,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -4551,6 +4757,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4990,6 +5211,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5132,6 +5359,140 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5143,6 +5504,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.3.tgz",
+      "integrity": "sha512-DdOn/G5F+qvZELWeO5ZFFwcN611TfMybxPV0LUUoutUmiH2t47MZSB7gLV9O9YLhvudBdnzQNAoFOu4Xz8eOrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.6.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
       }
     }
   }

--- a/front/package.json
+++ b/front/package.json
@@ -18,9 +18,11 @@
   "dependencies": {
     "@tanstack/vue-query": "^5.99.0",
     "axios": "^1.16.0",
+    "barcode-detector": "^3.0.0",
     "chart.js": "^4.5.1",
     "lucide-vue-next": "^1.0.0",
     "pinia": "^3.0.4",
+    "qrcode": "^1.5.4",
     "three": "^0.184.0",
     "vue": "^3.5.32",
     "vue-chartjs": "^5.3.3",
@@ -29,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/qrcode": "^1.5.5",
     "@types/three": "^0.184.0",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^24.12.2",

--- a/front/src/api/manga.ts
+++ b/front/src/api/manga.ts
@@ -21,6 +21,9 @@ export async function importManga(payload: {
   genre?: string
   externalId?: string
   totalVolumes?: number
+  publisher?: string
+  editionYear?: number
+  externalWorkId?: string
 }): Promise<{ id: string }> {
   const res = await client.post('/manga', payload)
   return res.data
@@ -34,6 +37,10 @@ export async function searchVolumeExternal(
   volumeNumber?: number | null,
   edition?: string | null,
   provider: CoverProvider = 'composite',
+  isbn?: string | null,
+  publisher?: string | null,
+  year?: number | null,
+  language = 'fr',
 ): Promise<{
   externalId: string | null
   title: string
@@ -45,16 +52,51 @@ export async function searchVolumeExternal(
   totalVolumes: number | null
   source: string | null
 }[]> {
-  const params: Record<string, string | number> = { q, page, provider }
+  const params: Record<string, string | number> = { q, page, provider, language }
   if (volumeNumber != null) params.volumeNumber = volumeNumber
   if (edition != null) params.edition = edition
+  if (isbn != null) params.isbn = isbn
+  if (publisher != null) params.publisher = publisher
+  if (year != null) params.year = year
   const res = await client.get('/manga/volume-search', { params })
   return res.data
 }
 
+export interface DiscoveredEdition {
+  publisher: string
+  editionLabel: string | null
+  year: number | null
+  language: string
+  coverUrl: string | null
+  volumeCount: number | null
+  sampleIsbn: string | null
+  source: string
+}
+
+export async function discoverEditions(title: string, country = 'FR'): Promise<DiscoveredEdition[]> {
+  const res = await client.get('/manga/editions', { params: { title, country } })
+  return res.data
+}
+
+export interface ScanSessionStartResponse {
+  sessionId: string
+  mercureUrl: string
+  subscriberToken: string
+  topic: string
+}
+
+export async function startScanSession(): Promise<ScanSessionStartResponse> {
+  const res = await client.post('/manga/scan-session')
+  return res.data
+}
+
+export async function postScannedIsbn(sessionId: string, isbn: string): Promise<void> {
+  await client.post(`/manga/scan-session/${sessionId}/isbn`, { isbn })
+}
+
 export async function updateManga(
   id: string,
-  payload: { title?: string; edition?: string; coverUrl?: string },
+  payload: { title?: string; edition?: string; coverUrl?: string; publisher?: string; editionYear?: number },
 ): Promise<void> {
   await client.patch(`/manga/${id}`, payload)
 }
@@ -62,7 +104,7 @@ export async function updateManga(
 export async function updateVolume(
   mangaId: string,
   volumeId: string,
-  payload: { coverUrl?: string; releaseDate?: string; price?: number | null; spineUrl?: string },
+  payload: { coverUrl?: string; releaseDate?: string; price?: number | null; spineUrl?: string; isbn?: string },
 ): Promise<void> {
   await client.patch(`/manga/${mangaId}/volumes/${volumeId}`, payload)
 }

--- a/front/src/components/molecules/EditionCard.vue
+++ b/front/src/components/molecules/EditionCard.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { Book } from 'lucide-vue-next'
+import type { DiscoveredEdition } from '@/api/manga'
+import { coverUrl } from '@/utils/coverUrl'
+
+const props = defineProps<{
+  edition: DiscoveredEdition
+}>()
+
+const emit = defineEmits<{
+  select: []
+}>()
+</script>
+
+<template>
+  <button
+    class="group flex flex-col items-center gap-2 text-left w-full focus:outline-none"
+    @click="emit('select')"
+  >
+    <div
+      class="w-full aspect-[2/3] relative rounded-xl overflow-hidden bg-base-200 shadow group-hover:shadow-lg group-hover:scale-105 transition-all duration-150 ring-2 ring-transparent group-hover:ring-primary"
+    >
+      <img
+        v-if="props.edition.coverUrl"
+        :src="coverUrl(props.edition.coverUrl)!"
+        :alt="props.edition.publisher"
+        class="w-full h-full object-cover"
+      />
+      <div
+        v-else
+        class="w-full h-full flex items-center justify-center opacity-30 text-base-content"
+      >
+        <Book class="h-10 w-10" stroke-width="1.5" />
+      </div>
+      <div
+        v-if="props.edition.volumeCount"
+        class="absolute bottom-1 right-1 bg-black/70 text-white text-[9px] font-bold px-1.5 py-0.5 rounded-full leading-none"
+      >
+        {{ props.edition.volumeCount }}T
+      </div>
+    </div>
+    <div class="w-full px-0.5 space-y-0.5">
+      <p class="text-xs font-semibold leading-tight line-clamp-2">{{ props.edition.publisher }}</p>
+      <p v-if="props.edition.editionLabel" class="text-[10px] text-base-content/60 truncate">
+        {{ props.edition.editionLabel }}
+      </p>
+      <p class="text-[10px] text-base-content/40 truncate">
+        <span v-if="props.edition.year">{{ props.edition.year }}</span>
+        <span v-if="props.edition.year && props.edition.source"> · </span>
+        <span>{{ props.edition.source }}</span>
+      </p>
+    </div>
+  </button>
+</template>

--- a/front/src/components/molecules/IsbnScanner.vue
+++ b/front/src/components/molecules/IsbnScanner.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useBarcodeScanner } from '@/composables/useBarcodeScanner'
+
+const emit = defineEmits<{
+  detected: [isbn: string]
+}>()
+
+const { t } = useI18n()
+
+const videoRef = ref<HTMLVideoElement | null>(null)
+const { isSupported, isScanning, error, start, stop, onDetected } = useBarcodeScanner(videoRef)
+
+onDetected((isbn) => {
+  emit('detected', isbn)
+})
+
+async function handleStart() {
+  await start()
+}
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2">
+    <div v-if="error && !isSupported" class="alert alert-warning text-sm">
+      {{ t('scan.cameraUnavailable') }}
+    </div>
+
+    <video
+      v-show="isScanning"
+      ref="videoRef"
+      class="rounded-lg w-full max-w-xs"
+      autoplay
+      playsinline
+      muted
+    />
+
+    <div class="flex gap-2">
+      <button v-if="!isScanning" class="btn btn-primary btn-sm" @click="handleStart">
+        {{ t('scan.title') }}
+      </button>
+      <button v-else class="btn btn-ghost btn-sm" @click="stop">
+        {{ t('common.cancel', 'Annuler') }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/front/src/components/molecules/ScanViaPhone.vue
+++ b/front/src/components/molecules/ScanViaPhone.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useScanSession } from '@/composables/useScanSession'
+
+const emit = defineEmits<{
+  isbn: [isbn: string]
+}>()
+
+const { t } = useI18n()
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+const { pairingUrl, start } = useScanSession()
+const isLoading = ref(false)
+
+async function generateQr(url: string) {
+  try {
+    const QRCode = await import('qrcode')
+    const canvas = canvasRef.value
+    if (canvas) {
+      await QRCode.default.toCanvas(canvas, url, { width: 200 })
+    }
+  } catch {
+    // QR generation is best-effort
+  }
+}
+
+onMounted(async () => {
+  isLoading.value = true
+  try {
+    await start({
+      onIsbn: (isbn) => {
+        emit('isbn', isbn)
+      },
+    })
+
+    if (pairingUrl.value) {
+      await generateQr(pairingUrl.value)
+    }
+  } finally {
+    isLoading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-3">
+    <p class="text-sm text-base-content/70">{{ t('scan.scanWithPhone') }}</p>
+
+    <div v-if="isLoading" class="loading loading-spinner" />
+
+    <canvas v-show="!isLoading" ref="canvasRef" class="rounded-lg" />
+
+    <p v-if="pairingUrl" class="text-xs text-base-content/50 break-all max-w-xs text-center">
+      {{ pairingUrl }}
+    </p>
+  </div>
+</template>

--- a/front/src/components/molecules/__tests__/IsbnScanner.spec.ts
+++ b/front/src/components/molecules/__tests__/IsbnScanner.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import IsbnScanner from '../IsbnScanner.vue'
+
+// Mock the composable
+const mockOnDetected = vi.fn()
+const mockStart = vi.fn()
+const mockStop = vi.fn()
+const mockIsSupported = ref(true)
+const mockIsScanning = ref(false)
+const mockError = ref<string | null>(null)
+
+vi.mock('@/composables/useBarcodeScanner', () => ({
+  useBarcodeScanner: () => ({
+    isSupported: mockIsSupported,
+    isScanning: mockIsScanning,
+    error: mockError,
+    start: mockStart,
+    stop: mockStop,
+    onDetected: mockOnDetected,
+  }),
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      scan: {
+        title: 'Scan ISBN',
+        cameraUnavailable: 'Camera not available',
+      },
+      common: { cancel: 'Cancel' },
+    },
+  },
+})
+
+describe('IsbnScanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsSupported.value = true
+    mockIsScanning.value = false
+    mockError.value = null
+  })
+
+  it('renders start button when not scanning', () => {
+    const wrapper = mount(IsbnScanner, { global: { plugins: [i18n] } })
+    expect(wrapper.find('button').text()).toContain('Scan ISBN')
+  })
+
+  it('calls onDetected callback with isbn on register', () => {
+    mount(IsbnScanner, { global: { plugins: [i18n] } })
+    expect(mockOnDetected).toHaveBeenCalledOnce()
+  })
+
+  it('shows camera unavailable message when not supported', async () => {
+    mockIsSupported.value = false
+    mockError.value = 'Camera not available'
+
+    const wrapper = mount(IsbnScanner, { global: { plugins: [i18n] } })
+    expect(wrapper.text()).toContain('Camera not available')
+  })
+
+  it('emits detected event when onDetected callback is triggered', async () => {
+    let capturedCallback: ((isbn: string) => void) | undefined
+
+    vi.mocked(mockOnDetected).mockImplementation((cb: (isbn: string) => void) => {
+      capturedCallback = cb
+    })
+
+    const wrapper = mount(IsbnScanner, { global: { plugins: [i18n] } })
+
+    capturedCallback?.('9782344020812')
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('detected')).toBeTruthy()
+    expect(wrapper.emitted('detected')![0]).toEqual(['9782344020812'])
+  })
+})

--- a/front/src/components/molecules/__tests__/ScanViaPhone.spec.ts
+++ b/front/src/components/molecules/__tests__/ScanViaPhone.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import ScanViaPhone from '../ScanViaPhone.vue'
+
+const mockPairingUrl = ref<string | null>(null)
+const mockStart = vi.fn()
+
+vi.mock('@/composables/useScanSession', () => ({
+  useScanSession: () => ({
+    sessionId: ref<string | null>(null),
+    pairingUrl: mockPairingUrl,
+    start: mockStart,
+    close: vi.fn(),
+  }),
+}))
+
+vi.mock('qrcode', () => ({
+  default: {
+    toCanvas: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      scan: {
+        scanWithPhone: 'Scan with phone',
+      },
+    },
+  },
+})
+
+describe('ScanViaPhone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPairingUrl.value = null
+    mockStart.mockImplementation(async () => {
+      mockPairingUrl.value = 'http://localhost:5173/scan/test-session-123'
+    })
+  })
+
+  it('renders and calls start on mount', async () => {
+    const wrapper = mount(ScanViaPhone, { global: { plugins: [i18n] } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockStart).toHaveBeenCalledOnce()
+    wrapper.unmount()
+  })
+
+  it('renders a canvas element for QR code', () => {
+    const wrapper = mount(ScanViaPhone, { global: { plugins: [i18n] } })
+    expect(wrapper.find('canvas').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('emits isbn event when onIsbn callback is triggered', async () => {
+    let capturedCallback: ((isbn: string) => void) | undefined
+
+    mockStart.mockImplementation(async ({ onIsbn }: { onIsbn: (isbn: string) => void }) => {
+      capturedCallback = onIsbn
+      mockPairingUrl.value = 'http://localhost:5173/scan/test-session-123'
+    })
+
+    const wrapper = mount(ScanViaPhone, { global: { plugins: [i18n] } })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    capturedCallback?.('9782344020812')
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('isbn')).toBeTruthy()
+    expect(wrapper.emitted('isbn')![0]).toEqual(['9782344020812'])
+
+    wrapper.unmount()
+  })
+})

--- a/front/src/components/organisms/EditionPicker.vue
+++ b/front/src/components/organisms/EditionPicker.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { discoverEditions } from '@/api/manga'
+import type { DiscoveredEdition } from '@/api/manga'
+import EditionCard from '@/components/molecules/EditionCard.vue'
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    initialCountry?: string
+  }>(),
+  { initialCountry: 'FR' },
+)
+
+const emit = defineEmits<{
+  select: [edition: DiscoveredEdition]
+  skip: []
+}>()
+
+const { t } = useI18n()
+
+const COUNTRIES = [
+  { code: 'FR', flag: '🇫🇷' },
+  { code: 'IT', flag: '🇮🇹' },
+  { code: 'ES', flag: '🇪🇸' },
+  { code: 'DE', flag: '🇩🇪' },
+  { code: 'US', flag: '🇺🇸' },
+  { code: 'JP', flag: '🇯🇵' },
+] as const
+
+const country = ref(props.initialCountry)
+const isLoading = ref(false)
+const editions = ref<DiscoveredEdition[]>([])
+
+async function load(): Promise<void> {
+  isLoading.value = true
+  try {
+    editions.value = await discoverEditions(props.title, country.value)
+  } catch {
+    editions.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function selectCountry(code: string): void {
+  if (code === country.value) return
+  country.value = code
+  load()
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-sm text-base-content/60">
+      {{ t('add.editionsFor') }} <strong>{{ title }}</strong>
+    </p>
+
+    <!-- Country chooser — drives which market's editions are discovered -->
+    <div class="flex flex-wrap gap-2">
+      <button
+        v-for="c in COUNTRIES"
+        :key="c.code"
+        type="button"
+        :data-test="`country-${c.code}`"
+        class="btn btn-sm gap-1.5"
+        :class="c.code === country ? 'btn-primary' : 'btn-outline'"
+        @click="selectCountry(c.code)"
+      >
+        <span>{{ c.flag }}</span>
+        <span>{{ t(`country.${c.code.toLowerCase()}`) }}</span>
+      </button>
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-8">
+      <span class="loading loading-spinner loading-md" />
+    </div>
+
+    <template v-else>
+      <div v-if="editions.length" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+        <EditionCard
+          v-for="(edition, index) in editions"
+          :key="`${edition.publisher}-${index}`"
+          :edition="edition"
+          @select="emit('select', edition)"
+        />
+      </div>
+
+      <p v-else class="text-sm text-center text-base-content/40 py-4">
+        {{ t('add.noEditionsFound') }}
+      </p>
+
+      <div class="divider text-xs text-base-content/40">{{ t('common.or') }}</div>
+      <button data-test="fill-manually" class="btn btn-outline btn-sm w-full" @click="emit('skip')">
+        {{ t('add.fillManually') }}
+      </button>
+    </template>
+  </div>
+</template>

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -14,6 +14,8 @@ const props = defineProps<{
   mangaId: string
   mangaTitle: string
   mangaEdition: string | null
+  mangaPublisher: string | null
+  mangaEditionYear: number | null
   volume: VolumeEntry | null
 }>()
 
@@ -104,7 +106,7 @@ async function runSearch(q: string) {
   currentPage = 1
   isSearching.value = true
   try {
-    const data = await searchVolumeExternal(lastQuery, 1, lastVolumeNumber, lastEdition, provider.value)
+    const data = await searchVolumeExternal(lastQuery, 1, lastVolumeNumber, lastEdition, provider.value, null, props.mangaPublisher, props.mangaEditionYear)
     searchResults.value = data
     hasMore.value = data.length >= PAGE_SIZE
   } catch {

--- a/front/src/components/organisms/__tests__/EditionPicker.spec.ts
+++ b/front/src/components/organisms/__tests__/EditionPicker.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import EditionPicker from '../EditionPicker.vue'
+import type { DiscoveredEdition } from '@/api/manga'
+
+const mockDiscoverEditions = vi.fn()
+
+vi.mock('@/api/manga', () => ({
+  discoverEditions: (...args: unknown[]) => mockDiscoverEditions(...args),
+}))
+
+vi.mock('@/components/molecules/EditionCard.vue', () => ({
+  default: {
+    name: 'EditionCard',
+    props: ['edition'],
+    emits: ['select'],
+    template: '<button data-test="edition-card" @click="$emit(\'select\')">{{ edition.publisher }}</button>',
+  },
+}))
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      add: {
+        editionsFor: 'Available editions for',
+        noEditionsFound: 'No editions found — fill in manually',
+        fillManually: 'Fill manually',
+      },
+      common: { or: 'or' },
+      country: { fr: 'France', it: 'Italy', es: 'Spain', de: 'Germany', us: 'United States', jp: 'Japan' },
+    },
+  },
+})
+
+const sampleEdition: DiscoveredEdition = {
+  publisher: 'Glénat',
+  editionLabel: 'Grand Format',
+  year: 2020,
+  language: 'fr',
+  coverUrl: null,
+  volumeCount: 12,
+  sampleIsbn: '9782344020814',
+  source: 'bnf',
+}
+
+const flushTimers = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('EditionPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading spinner while fetching', async () => {
+    mockDiscoverEditions.mockReturnValue(new Promise(() => {}))
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.loading').exists()).toBe(true)
+  })
+
+  it('shows edition cards when editions are loaded', async () => {
+    mockDiscoverEditions.mockResolvedValue([sampleEdition])
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await flushTimers()
+
+    expect(wrapper.findAll('[data-test="edition-card"]').length).toBe(1)
+    expect(wrapper.text()).toContain('Glénat')
+  })
+
+  it('emits select with the edition when a card is clicked', async () => {
+    mockDiscoverEditions.mockResolvedValue([sampleEdition])
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await flushTimers()
+
+    await wrapper.find('[data-test="edition-card"]').trigger('click')
+
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')![0]).toEqual([sampleEdition])
+  })
+
+  it('emits skip when fill manually button is clicked', async () => {
+    mockDiscoverEditions.mockResolvedValue([])
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await flushTimers()
+
+    await wrapper.find('[data-test="fill-manually"]').trigger('click')
+
+    expect(wrapper.emitted('skip')).toBeTruthy()
+  })
+
+  it('shows no editions found message when the list is empty', async () => {
+    mockDiscoverEditions.mockResolvedValue([])
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await flushTimers()
+
+    expect(wrapper.text()).toContain('No editions found')
+  })
+
+  it('defaults to France and calls discoverEditions with the FR country code', async () => {
+    mockDiscoverEditions.mockResolvedValue([])
+
+    mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'One Piece' },
+    })
+
+    await flushTimers()
+
+    expect(mockDiscoverEditions).toHaveBeenCalledWith('One Piece', 'FR')
+  })
+
+  it('honours the initialCountry prop', async () => {
+    mockDiscoverEditions.mockResolvedValue([])
+
+    mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'One Piece', initialCountry: 'US' },
+    })
+
+    await flushTimers()
+
+    expect(mockDiscoverEditions).toHaveBeenCalledWith('One Piece', 'US')
+  })
+
+  it('re-fetches editions when a different country is selected', async () => {
+    mockDiscoverEditions.mockResolvedValue([])
+
+    const wrapper = mount(EditionPicker, {
+      global: { plugins: [i18n] },
+      props: { title: 'Berserk' },
+    })
+
+    await flushTimers()
+    expect(mockDiscoverEditions).toHaveBeenLastCalledWith('Berserk', 'FR')
+
+    await wrapper.find('[data-test="country-JP"]').trigger('click')
+    await flushTimers()
+
+    expect(mockDiscoverEditions).toHaveBeenLastCalledWith('Berserk', 'JP')
+    expect(mockDiscoverEditions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/front/src/composables/__tests__/useBarcodeScanner.spec.ts
+++ b/front/src/composables/__tests__/useBarcodeScanner.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { effectScope, ref } from 'vue'
+import { useBarcodeScanner } from '../useBarcodeScanner'
+
+interface MockTrack {
+  stop: ReturnType<typeof vi.fn>
+}
+
+function makeTrack(): MockTrack {
+  return { stop: vi.fn() }
+}
+
+function makeStream(tracks: MockTrack[]) {
+  return {
+    getTracks: () => tracks,
+  } as unknown as MediaStream
+}
+
+describe('useBarcodeScanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Remove BarcodeDetector from global scope
+    delete (globalThis as Record<string, unknown>).BarcodeDetector
+    // Reset mediaDevices
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sets isSupported=false and error when getUserMedia is not available', async () => {
+    const videoRef = ref<HTMLVideoElement | null>(null)
+    const scope = effectScope()
+
+    let scanner: ReturnType<typeof useBarcodeScanner> | undefined
+
+    scope.run(() => {
+      scanner = useBarcodeScanner(videoRef)
+    })
+
+    await scanner!.start()
+
+    expect(scanner!.isSupported.value).toBe(false)
+    expect(scanner!.error.value).toBeTruthy()
+
+    scope.stop()
+  })
+
+  it('sets isSupported=false when barcode detection is unavailable', async () => {
+    const track = makeTrack()
+    const stream = makeStream([track])
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    // Mock import of barcode-detector/ponyfill to fail
+    vi.doMock('barcode-detector/ponyfill', () => {
+      throw new Error('Not available')
+    })
+
+    const videoRef = ref<HTMLVideoElement | null>(null)
+    const scope = effectScope()
+    let scanner: ReturnType<typeof useBarcodeScanner> | undefined
+
+    scope.run(() => {
+      scanner = useBarcodeScanner(videoRef)
+    })
+
+    await scanner!.start()
+
+    expect(scanner!.isSupported.value).toBe(false)
+
+    scope.stop()
+  })
+
+  it('calls onDetected with isbn and stops when ean_13 barcode detected', async () => {
+    const mockIsbn = '9782344020812'
+    const track = makeTrack()
+    const stream = makeStream([track])
+
+    const mockDetector = {
+      detect: vi.fn().mockResolvedValue([{ rawValue: mockIsbn, format: 'ean_13' }]),
+    }
+
+    ;(globalThis as Record<string, unknown>).BarcodeDetector = vi
+      .fn()
+      .mockImplementation(function () { return mockDetector })
+
+    const mockVideo = {
+      srcObject: null as MediaStream | null,
+      play: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HTMLVideoElement
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    // Mock requestAnimationFrame to execute synchronously
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) => {
+        callback(0)
+        return 0
+      },
+    )
+
+    const videoRef = ref<HTMLVideoElement | null>(mockVideo)
+    const scope = effectScope()
+    let scanner: ReturnType<typeof useBarcodeScanner> | undefined
+
+    const onDetectedCallback = vi.fn()
+
+    scope.run(() => {
+      scanner = useBarcodeScanner(videoRef)
+      scanner.onDetected(onDetectedCallback)
+    })
+
+    await scanner!.start()
+
+    expect(onDetectedCallback).toHaveBeenCalledWith(mockIsbn)
+    expect(scanner!.isScanning.value).toBe(false)
+    expect(track.stop).toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('stops scanning and releases tracks on scope dispose', async () => {
+    const track = makeTrack()
+    const stream = makeStream([track])
+
+    ;(globalThis as Record<string, unknown>).BarcodeDetector = vi.fn().mockImplementation(function () {
+      return { detect: vi.fn().mockResolvedValue([]) }
+    })
+
+    const mockVideo = {
+      srcObject: null as MediaStream | null,
+      play: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HTMLVideoElement
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue(stream),
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(0))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const videoRef = ref<HTMLVideoElement | null>(mockVideo)
+    const scope = effectScope()
+    let scanner: ReturnType<typeof useBarcodeScanner> | undefined
+
+    scope.run(() => {
+      scanner = useBarcodeScanner(videoRef)
+    })
+
+    await scanner!.start()
+    scope.stop()
+
+    expect(track.stop).toHaveBeenCalled()
+  })
+})

--- a/front/src/composables/__tests__/useScanSession.spec.ts
+++ b/front/src/composables/__tests__/useScanSession.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { effectScope } from 'vue'
+
+// Mock the API before importing the composable
+vi.mock('@/api/manga', () => ({
+  startScanSession: vi.fn().mockResolvedValue({
+    sessionId: 'test-session-123',
+    mercureUrl: 'http://localhost:8000/.well-known/mercure',
+    subscriberToken: 'stub-subscriber-token',
+    topic: 'https://ziggytheque.app/scan-session/test-session-123',
+  }),
+}))
+
+import { useScanSession } from '../useScanSession'
+
+interface MockEventSourceInstance {
+  onmessage: ((event: MessageEvent) => void) | null
+  onerror: (() => void) | null
+  close: ReturnType<typeof vi.fn>
+  url: string
+}
+
+const instances: MockEventSourceInstance[] = []
+
+class MockEventSource {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn()
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    instances.push(this)
+  }
+}
+
+vi.stubGlobal('EventSource', MockEventSource)
+
+describe('useScanSession', () => {
+  beforeEach(() => {
+    instances.length = 0
+    // Clear call history only — keeps the implementation set in the vi.mock factory
+    vi.clearAllMocks()
+  })
+
+  it('calls onIsbn when isbn_scanned event is received', async () => {
+    const scope = effectScope()
+    const onIsbn = vi.fn()
+
+    let scanner: ReturnType<typeof useScanSession> | undefined
+
+    await scope.run(async () => {
+      scanner = useScanSession()
+      await scanner.start({ onIsbn })
+    })
+
+    expect(instances).toHaveLength(1)
+    const source = instances[0]
+
+    source.onmessage!(
+      new MessageEvent('message', {
+        data: JSON.stringify({ type: 'isbn_scanned', isbn: '9782344020812' }),
+      }),
+    )
+
+    expect(onIsbn).toHaveBeenCalledWith('9782344020812')
+
+    scope.stop()
+  })
+
+  it('sets sessionId and pairingUrl after start', async () => {
+    const scope = effectScope()
+    let scanner: ReturnType<typeof useScanSession> | undefined
+
+    await scope.run(async () => {
+      scanner = useScanSession()
+      await scanner.start({ onIsbn: vi.fn() })
+    })
+
+    expect(scanner!.sessionId.value).toBe('test-session-123')
+    expect(scanner!.pairingUrl.value).toContain('test-session-123')
+
+    scope.stop()
+  })
+
+  it('closes EventSource when scope is disposed', async () => {
+    const scope = effectScope()
+
+    await scope.run(async () => {
+      const scanner = useScanSession()
+      await scanner.start({ onIsbn: vi.fn() })
+    })
+
+    const source = instances[0]
+    expect(source.close).not.toHaveBeenCalled()
+    scope.stop()
+    expect(source.close).toHaveBeenCalledOnce()
+  })
+
+  it('EventSource URL contains topic and authorization', async () => {
+    const scope = effectScope()
+
+    await scope.run(async () => {
+      const scanner = useScanSession()
+      await scanner.start({ onIsbn: vi.fn() })
+    })
+
+    const capturedUrl = instances[0].url
+    expect(capturedUrl).toContain('topic=')
+    expect(capturedUrl).toContain('authorization=stub-subscriber-token')
+    expect(capturedUrl).toContain('scan-session')
+
+    scope.stop()
+  })
+})

--- a/front/src/composables/useBarcodeScanner.ts
+++ b/front/src/composables/useBarcodeScanner.ts
@@ -1,0 +1,145 @@
+import { ref, onScopeDispose, toValue } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
+
+type DetectedCallback = (isbn: string) => void
+
+interface BarcodeScannerComposable {
+  isSupported: ReturnType<typeof ref<boolean>>
+  isScanning: ReturnType<typeof ref<boolean>>
+  error: ReturnType<typeof ref<string | null>>
+  start: () => Promise<void>
+  stop: () => void
+  onDetected: (callback: DetectedCallback) => void
+}
+
+interface BarcodeDetectorLike {
+  detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue: string; format: string }>>
+}
+
+interface BarcodeDetectorConstructor {
+  new (options: { formats: string[] }): BarcodeDetectorLike
+  getSupportedFormats?: () => Promise<string[]>
+}
+
+export function useBarcodeScanner(
+  videoRef: MaybeRefOrGetter<HTMLVideoElement | null>,
+): BarcodeScannerComposable {
+  const isSupported = ref(false)
+  const isScanning = ref(false)
+  const error = ref<string | null>(null)
+
+  let detector: BarcodeDetectorLike | null = null
+  let stream: MediaStream | null = null
+  let animationFrameId: number | null = null
+  let detectedCallback: DetectedCallback | null = null
+
+  async function resolveDetector(): Promise<BarcodeDetectorLike | null> {
+    if ('BarcodeDetector' in globalThis) {
+      const NativeDetector = (globalThis as Record<string, unknown>)
+        .BarcodeDetector as BarcodeDetectorConstructor
+      return new NativeDetector({ formats: ['ean_13'] })
+    }
+
+    try {
+      const { BarcodeDetector: Ponyfill } = await import('barcode-detector/ponyfill')
+      const PonyfillConstructor = Ponyfill as unknown as BarcodeDetectorConstructor
+      return new PonyfillConstructor({ formats: ['ean_13'] })
+    } catch {
+      return null
+    }
+  }
+
+  async function start(): Promise<void> {
+    error.value = null
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      isSupported.value = false
+      error.value = 'Camera not available'
+      return
+    }
+
+    const resolvedDetector = await resolveDetector()
+    if (resolvedDetector === null) {
+      isSupported.value = false
+      error.value = 'Barcode detection not supported'
+      return
+    }
+
+    detector = resolvedDetector
+    isSupported.value = true
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+      })
+    } catch (err) {
+      isSupported.value = false
+      error.value = err instanceof Error ? err.message : 'Camera access denied'
+      return
+    }
+
+    const videoElement = toValue(videoRef)
+    if (videoElement) {
+      videoElement.srcObject = stream
+      await videoElement.play()
+    }
+
+    isScanning.value = true
+    scanLoop()
+  }
+
+  function scanLoop(): void {
+    const videoElement = toValue(videoRef)
+    if (!isScanning.value || detector === null || videoElement === null) {
+      return
+    }
+
+    animationFrameId = requestAnimationFrame(async () => {
+      if (!isScanning.value || detector === null) return
+
+      try {
+        const barcodes = await detector.detect(videoElement)
+        for (const barcode of barcodes) {
+          if (barcode.format === 'ean_13' && barcode.rawValue) {
+            detectedCallback?.(barcode.rawValue)
+            stop()
+            return
+          }
+        }
+      } catch {
+        // detection errors are non-fatal — continue scanning
+      }
+
+      scanLoop()
+    })
+  }
+
+  function stop(): void {
+    isScanning.value = false
+
+    if (animationFrameId !== null) {
+      cancelAnimationFrame(animationFrameId)
+      animationFrameId = null
+    }
+
+    if (stream !== null) {
+      for (const track of stream.getTracks()) {
+        track.stop()
+      }
+      stream = null
+    }
+
+    const videoElement = toValue(videoRef)
+    if (videoElement) {
+      videoElement.srcObject = null
+    }
+  }
+
+  function onDetected(callback: DetectedCallback): void {
+    detectedCallback = callback
+  }
+
+  onScopeDispose(stop)
+
+  return { isSupported, isScanning, error, start, stop, onDetected }
+}

--- a/front/src/composables/useScanSession.ts
+++ b/front/src/composables/useScanSession.ts
@@ -1,0 +1,44 @@
+import { ref, onScopeDispose } from 'vue'
+import { startScanSession } from '@/api/manga'
+
+export function useScanSession() {
+  const sessionId = ref<string | null>(null)
+  const pairingUrl = ref<string | null>(null)
+  let eventSource: EventSource | null = null
+
+  async function start(callbacks: { onIsbn: (isbn: string) => void }): Promise<void> {
+    close()
+
+    const sessionData = await startScanSession()
+    sessionId.value = sessionData.sessionId
+    pairingUrl.value = `${window.location.origin}/scan/${sessionData.sessionId}`
+
+    const url = new URL(sessionData.mercureUrl)
+    url.searchParams.append('topic', sessionData.topic)
+    url.searchParams.append('authorization', sessionData.subscriberToken)
+
+    eventSource = new EventSource(url.toString(), { withCredentials: false })
+
+    eventSource.onmessage = (message) => {
+      const event = JSON.parse(message.data as string) as {
+        type: string
+        isbn?: string
+      }
+
+      if (event.type === 'isbn_scanned' && event.isbn) {
+        callbacks.onIsbn(event.isbn)
+      }
+    }
+
+    eventSource.onerror = () => close()
+  }
+
+  function close(): void {
+    eventSource?.close()
+    eventSource = null
+  }
+
+  onScopeDispose(close)
+
+  return { sessionId, pairingUrl, start, close }
+}

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -65,7 +65,11 @@
     "noResults": "No results. You can fill in the form manually.",
     "fillManually": "Fill manually",
     "selectResult": "Select",
-    "selectedResult": "Selected"
+    "selectedResult": "Selected",
+    "edition": "Edition",
+    "chooseEdition": "Choose edition",
+    "editionsFor": "Available editions for",
+    "noEditionsFound": "No editions found — fill in manually"
   },
   "manga": {
     "title": "Title",
@@ -75,7 +79,18 @@
     "genre": "Genre",
     "coverUrl": "Cover URL",
     "summary": "Summary",
-    "totalVolumes": "Total volumes"
+    "totalVolumes": "Total volumes",
+    "publisher": "Publisher",
+    "editionYear": "Edition year"
+  },
+  "scan": {
+    "title": "Scan ISBN",
+    "cameraUnavailable": "Camera not available",
+    "viaPhone": "Via phone",
+    "scanWithPhone": "Scan with phone",
+    "manualIsbn": "Enter ISBN manually",
+    "sent": "ISBN sent",
+    "apply": "Apply"
   },
   "volume": {
     "price": "Price (€)",
@@ -185,6 +200,15 @@
     "edit": "Edit",
     "delete": "Delete",
     "remove": "Remove",
-    "next": "Next"
+    "next": "Next",
+    "or": "or"
+  },
+  "country": {
+    "fr": "France",
+    "it": "Italy",
+    "es": "Spain",
+    "de": "Germany",
+    "us": "United States",
+    "jp": "Japan"
   }
 }

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -65,7 +65,11 @@
     "noResults": "Aucun résultat. Vous pouvez saisir les informations manuellement.",
     "fillManually": "Saisir manuellement",
     "selectResult": "Sélectionner",
-    "selectedResult": "Sélectionné"
+    "selectedResult": "Sélectionné",
+    "edition": "Édition",
+    "chooseEdition": "Choisir l'édition",
+    "editionsFor": "Éditions disponibles pour",
+    "noEditionsFound": "Aucune édition trouvée — saisissez manuellement"
   },
   "manga": {
     "title": "Titre",
@@ -75,7 +79,18 @@
     "genre": "Genre",
     "coverUrl": "URL de couverture",
     "summary": "Résumé",
-    "totalVolumes": "Nombre de tomes"
+    "totalVolumes": "Nombre de tomes",
+    "publisher": "Éditeur",
+    "editionYear": "Année d'édition"
+  },
+  "scan": {
+    "title": "Scanner l'ISBN",
+    "cameraUnavailable": "Caméra non disponible",
+    "viaPhone": "Via téléphone",
+    "scanWithPhone": "Scanner avec le téléphone",
+    "manualIsbn": "Saisir l'ISBN manuellement",
+    "sent": "ISBN envoyé",
+    "apply": "Appliquer"
   },
   "volume": {
     "price": "Prix (€)",
@@ -185,6 +200,15 @@
     "edit": "Modifier",
     "delete": "Supprimer",
     "remove": "Retirer",
-    "next": "Suivant"
+    "next": "Suivant",
+    "or": "ou"
+  },
+  "country": {
+    "fr": "France",
+    "it": "Italie",
+    "es": "Espagne",
+    "de": "Allemagne",
+    "us": "États-Unis",
+    "jp": "Japon"
   }
 }

--- a/front/src/pages/AddMangaPage.vue
+++ b/front/src/pages/AddMangaPage.vue
@@ -4,6 +4,7 @@
   import { useMutation, useQueryClient } from '@tanstack/vue-query'
   import { ArrowLeft, Search, RefreshCw, Book, ImageOff, Star } from 'lucide-vue-next'
   import { importManga } from '@/api/manga'
+  import type { DiscoveredEdition } from '@/api/manga'
   import { addToCollection, addRemainingToWishlist } from '@/api/collection'
   import { useUiStore } from '@/stores/useUiStore'
   import { useI18n } from 'vue-i18n'
@@ -11,13 +12,14 @@
   import type { ExternalMangaResult } from '@/composables/useExternalSearch'
   import { coverUrl } from '@/utils/coverUrl'
   import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
+  import EditionPicker from '@/components/organisms/EditionPicker.vue'
 
   const router = useRouter()
   const qc = useQueryClient()
   const ui = useUiStore()
   const { t } = useI18n()
 
-  const step = ref<1 | 2 | 3>(1)
+  const step = ref<1 | 2 | 3 | 4>(1)
   const collectionEntryId = ref('')
 
   const {
@@ -49,6 +51,9 @@
     genre: '',
     totalVolumes: '' as string | number,
     externalId: '',
+    publisher: '',
+    editionYear: '' as string | number,
+    externalWorkId: '',
   })
 
   const coverPreview = computed(() => coverUrl(form.value.coverUrl))
@@ -64,14 +69,47 @@
       genre: result.genre ?? '',
       totalVolumes: result.totalVolumes ?? '',
       externalId: result.externalId ?? '',
+      publisher: '',
+      editionYear: '',
+      externalWorkId: '',
     }
     clearSearch()
     step.value = 2
   }
 
+  // The edition step lets the user pick a country; map the form language back to it.
+  // Japanese uses the legacy 'jp' form value while the ISO code is 'ja'.
+  function languageToCountry(language: string): string {
+    if (language === 'en') return 'US'
+    if (language === 'jp' || language === 'ja') return 'JP'
+    if (language === 'it') return 'IT'
+    if (language === 'es') return 'ES'
+    if (language === 'de') return 'DE'
+    return 'FR'
+  }
+
+  function applyEdition(edition: DiscoveredEdition): void {
+    form.value.publisher = edition.publisher
+    form.value.editionYear = edition.year ?? ''
+    form.value.externalWorkId = edition.sampleIsbn ?? ''
+    if (edition.language) form.value.language = edition.language === 'ja' ? 'jp' : edition.language
+    if (edition.coverUrl) form.value.coverUrl = edition.coverUrl
+    if (edition.volumeCount) form.value.totalVolumes = edition.volumeCount
+    step.value = 3
+  }
+
   function goToForm(): void {
     clearSearch()
-    step.value = 2
+    step.value = 3
+  }
+
+  function skipEdition(): void {
+    step.value = 3
+  }
+
+  function goBack(): void {
+    if (step.value === 3) step.value = form.value.title ? 2 : 1
+    else if (step.value === 2) step.value = 1
   }
 
   const importMutation = useMutation({
@@ -86,13 +124,15 @@
         genre: form.value.genre || undefined,
         externalId: form.value.externalId || undefined,
         totalVolumes: form.value.totalVolumes !== '' ? Number(form.value.totalVolumes) : undefined,
+        publisher: form.value.publisher || undefined,
+        editionYear: form.value.editionYear !== '' ? Number(form.value.editionYear) : undefined,
+        externalWorkId: form.value.externalWorkId || undefined,
       }),
     onSuccess: async (data) => {
-      // Always add to collection first (creates the oeuvre tracker with all volumes)
       const res = await addToCollection(data.id)
       collectionEntryId.value = res.id
       qc.invalidateQueries({ queryKey: ['collection'] })
-      step.value = 3
+      step.value = 4
     },
   })
 
@@ -137,9 +177,9 @@
   <div class="p-4 md:p-6 max-w-3xl mx-auto space-y-6">
     <div class="flex items-center gap-3">
       <button
-        v-if="step > 1 && step < 3"
+        v-if="step > 1 && step < 4"
         class="btn btn-ghost btn-sm btn-circle"
-        @click="step = step === 2 ? 1 : 2"
+        @click="goBack"
       >
         <ArrowLeft class="h-5 w-5" />
       </button>
@@ -149,8 +189,9 @@
     <!-- Step indicator -->
     <ul class="steps w-full text-xs">
       <li class="step" :class="step >= 1 ? 'step-primary' : ''">{{ t('add.search') }}</li>
-      <li class="step" :class="step >= 2 ? 'step-primary' : ''">{{ t('add.info') }}</li>
-      <li class="step" :class="step >= 3 ? 'step-primary' : ''">{{ t('add.destination') }}</li>
+      <li class="step" :class="step >= 2 ? 'step-primary' : ''">{{ t('add.edition') }}</li>
+      <li class="step" :class="step >= 3 ? 'step-primary' : ''">{{ t('add.info') }}</li>
+      <li class="step" :class="step >= 4 ? 'step-primary' : ''">{{ t('add.destination') }}</li>
     </ul>
 
     <!-- ── Step 1 : Recherche ── -->
@@ -247,8 +288,18 @@
       </button>
     </div>
 
-    <!-- ── Step 2 : Formulaire ── -->
-    <div v-if="step === 2" class="flex gap-5">
+    <!-- ── Step 2 : Édition ── -->
+    <div v-if="step === 2">
+      <EditionPicker
+        :title="form.title"
+        :initial-country="languageToCountry(form.language)"
+        @select="applyEdition"
+        @skip="skipEdition"
+      />
+    </div>
+
+    <!-- ── Step 3 : Formulaire ── -->
+    <div v-if="step === 3" class="flex gap-5">
       <!-- Cover preview (always visible: horizontal on mobile, sidebar on desktop) -->
       <div class="shrink-0 flex flex-col items-center gap-2">
         <div
@@ -313,6 +364,9 @@
             <label class="text-xs font-semibold text-base-content/60 uppercase tracking-wide">{{ t('manga.language') }}</label>
             <select v-model="form.language" class="select select-bordered select-sm w-full">
               <option value="fr">Français</option>
+              <option value="it">Italiano</option>
+              <option value="es">Español</option>
+              <option value="de">Deutsch</option>
               <option value="en">English</option>
               <option value="jp">日本語</option>
             </select>
@@ -376,8 +430,8 @@
       </form>
     </div>
 
-    <!-- ── Step 3 : Destination ── -->
-    <div v-if="step === 3" class="space-y-4">
+    <!-- ── Step 4 : Destination ── -->
+    <div v-if="step === 4" class="space-y-4">
       <p class="text-sm text-base-content/60 text-center">
         La série a été ajoutée à votre bibliothèque. Que voulez-vous faire ?
       </p>

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -499,6 +499,8 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                     </button>
                   </div>
                   <span class="badge badge-outline">{{ entry.manga.language.toUpperCase() }}</span>
+                  <span v-if="entry.manga.publisher" class="badge badge-outline text-base-content/60">{{ entry.manga.publisher }}</span>
+                  <span v-if="entry.manga.editionYear" class="badge badge-outline text-base-content/50">{{ entry.manga.editionYear }}</span>
                   <span v-if="entry.manga.genre" class="badge badge-outline capitalize">{{ entry.manga.genre }}</span>
 
                   <!-- Rating : à droite du genre -->
@@ -914,6 +916,8 @@ function volumeOpacityClass(ve: VolumeEntry): string {
         :manga-id="entry.manga.id"
         :manga-title="entry.manga.title"
         :manga-edition="entry.manga.edition"
+        :manga-publisher="entry.manga.publisher"
+        :manga-edition-year="entry.manga.editionYear"
         :volume="modalVolume"
         @close="closeModal"
       />

--- a/front/src/pages/ScanRelayPage.vue
+++ b/front/src/pages/ScanRelayPage.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { postScannedIsbn } from '@/api/manga'
+import IsbnScanner from '@/components/molecules/IsbnScanner.vue'
+
+const route = useRoute()
+const { t } = useI18n()
+
+const sessionId = route.params.sessionId as string
+const lastSentIsbn = ref<string | null>(null)
+const errorMessage = ref<string | null>(null)
+
+async function handleDetected(isbn: string) {
+  errorMessage.value = null
+  try {
+    await postScannedIsbn(sessionId, isbn)
+    lastSentIsbn.value = isbn
+  } catch {
+    errorMessage.value = 'Failed to send ISBN'
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-base-200 flex flex-col items-center justify-center gap-6 p-4">
+    <h1 class="text-2xl font-bold">{{ t('scan.title') }}</h1>
+
+    <IsbnScanner @detected="handleDetected" />
+
+    <div v-if="lastSentIsbn" class="alert alert-success text-sm">
+      {{ t('scan.sent') }}: {{ lastSentIsbn }}
+    </div>
+
+    <div v-if="errorMessage" class="alert alert-error text-sm">
+      {{ errorMessage }}
+    </div>
+  </div>
+</template>

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -108,6 +108,12 @@ const router = createRouter({
         },
       ],
     },
+    {
+      path: '/scan/:sessionId',
+      name: 'scan-relay',
+      component: () => import('@/pages/ScanRelayPage.vue'),
+      meta: { requiresAuth: true, title: 'Scanner' },
+    },
     { path: '/:pathMatch(.*)*', redirect: '/' },
   ],
 })

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -18,6 +18,9 @@ export interface Manga {
   coverUrl: string | null
   genre: string | null
   externalId: string | null
+  publisher: string | null
+  editionYear: number | null
+  externalWorkId: string | null
   totalVolumes: number
   createdAt: string
 }


### PR DESCRIPTION
- Add publisher/editionYear/externalWorkId fields to Manga entity + migration
- EditionContext VO replaces positional args in MangaCoverProviderInterface
- EditionGrouper domain service groups raw volumes by publisher/variant
- EditionDiscoveryInterface with Google Books + Open Library + Composite impls
- GET /manga/editions endpoint (DiscoverEditionsQuery/Handler)
- Isbn value object with checksum validation; ISBN anchoring in SearchVolumeExternal
- Scan session relay via Mercure: POST /manga/scan-session + /scan-session/{id}/isbn
- ScanSessionAuthorizerInterface / ScanSessionPublisherInterface ports + Mercure adapters
- useBarcodeScanner composable (native BarcodeDetector + ponyfill)
- useScanSession composable (EventSource over Mercure, pairingUrl QR)
- IsbnScanner, ScanViaPhone molecules; EditionCard, EditionPicker organisms
- ScanRelayPage + /scan/:sessionId route
- AddMangaPage: 4-step flow with edition picker between search and form
- MangaDetailPage: show publisher/editionYear badges; pass to EnrichVolumeModal
- EnrichVolumeModal: pass publisher/year to searchVolumeExternal for better precision
- Full test coverage: unit, functional, and component specs

https://claude.ai/code/session_01CRNa59pPG6kAytRJRFEZjr