### PR TITLE
feat(ci): create empty Railway placeholders for new env vars on deploy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,6 +168,7 @@ Human-readable names (e.g. `fk_volumes_manga`) will always conflict with Doctrin
 - Emails: **Resend** — domain `ziggytheque.fr` verified, sender `notifications@ziggytheque.fr`, `MAILER_DSN=resend+api://KEY@default`. Full setup: `docs/resend.md`
 - Frontend nginx proxies `/api` and `/proxy` to the backend via `BACKEND_URL` (internal Railway URL), so the SPA stays same-origin
 - CORS prod value: `CORS_ALLOW_ORIGIN=^https://(www\.)?ziggytheque\.fr$`
+- **Env var sync at deploy**: a `sync-env` job (in both deploy workflows) compares the env vars declared in the repo's `.env` files against what's set on the target Railway environment and creates any **new** one **empty** (`--skip-deploys`, never edits existing values) so it only needs its value typed in Railway. Script + ignore-list: `scripts/railway-sync-env-keys.sh`; full doc: `docs/railway-env-sync.md`. When you add a `back/.env` var whose committed default IS the prod value, add its key to `IGNORE_KEYS` so it isn't shadowed by an empty Railway var.
 
 ## First time setup
 ```

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -295,6 +295,25 @@ jobs:
       - run: echo "Production deployment of ${{ github.ref_name }} approved — proceeding"
 
   # ---------------------------------------------------------------------------
+  # Sync env var keys — after approval, before the deploy. Compares the env vars
+  # declared in the repo's .env files against what is already set on production
+  # and creates any missing one EMPTY (never edits existing values), so a new
+  # var only needs its value typed in the Railway dashboard. Runs before the
+  # deploy jobs so the keys exist when the new code boots.
+  # ---------------------------------------------------------------------------
+
+  sync-env:
+    name: "Production: Sync env var keys"
+    runs-on: ubuntu-latest
+    needs: [approve]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Create empty placeholders for new env vars
+        run: ./scripts/railway-sync-env-keys.sh "$RAILWAY_ENVIRONMENT_ID"
+
+  # ---------------------------------------------------------------------------
   # Deploy to production — single API job: worker first (messenger:consume),
   # then backend (frankenphp run).  Front deploys in parallel.
   # ---------------------------------------------------------------------------
@@ -302,7 +321,7 @@ jobs:
   deploy-api:
     name: "Production: Deploy API (worker → backend)"
     runs-on: ubuntu-latest
-    needs: [approve]
+    needs: [sync-env]
     env:
       DEPLOY_MSG: "Deploy ${{ github.ref_name }}"
     steps:
@@ -337,7 +356,7 @@ jobs:
   deploy-front:
     name: "Production: Deploy Frontend"
     runs-on: ubuntu-latest
-    needs: [approve]
+    needs: [sync-env]
     steps:
       - uses: actions/checkout@v5
       - name: Install Railway CLI

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -338,12 +338,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # --- Sync env var keys: create empty placeholders for any NEW vars ---------
+  # Compares the env vars declared in the repo's .env files against what is
+  # already set on the staging environment and creates the missing ones EMPTY
+  # (never edits existing values). Fill them in the Railway dashboard afterward.
+  # Runs before the deploy jobs so the keys exist when the new code boots.
+
+  sync-env:
+    name: "Staging: Sync env var keys"
+    runs-on: ubuntu-latest
+    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Create empty placeholders for new env vars
+        run: ./scripts/railway-sync-env-keys.sh "$RAILWAY_ENVIRONMENT_ID"
+
   # --- Deploy API: worker first (messenger:consume), then backend ------------
 
   deploy-api:
     name: "Staging: Deploy API (worker → backend)"
     runs-on: ubuntu-latest
-    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
+    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build, sync-env]
     env:
       DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
     steps:
@@ -384,7 +403,7 @@ jobs:
   deploy-front:
     name: "Staging: Deploy Frontend"
     runs-on: ubuntu-latest
-    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
+    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build, sync-env]
     env:
       DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
     steps:

--- a/docs/railway-env-sync.md
+++ b/docs/railway-env-sync.md
@@ -1,0 +1,66 @@
+# Synchronisation des variables d'env Railway au déploiement
+
+À chaque déploiement (**prod** ou **staging**), un job `sync-env` détecte les
+**nouvelles** variables d'environnement attendues par l'app et les crée
+**vides** sur l'environnement Railway ciblé. Il ne reste qu'à **saisir leur
+valeur** dans le dashboard Railway.
+
+- Script : [`scripts/railway-sync-env-keys.sh`](../scripts/railway-sync-env-keys.sh)
+- Wiring CI : job `sync-env` dans
+  [`deploy-staging.yml`](../.github/workflows/deploy-staging.yml) et
+  [`deploy-production.yml`](../.github/workflows/deploy-production.yml), exécuté
+  **après** les gates QA (et l'approbation en prod) et **avant** `railway up`.
+
+## Comment ça marche
+
+1. **Source de vérité = les fichiers `.env` du repo.** Les clés attendues sont
+   extraites de `back/.env` (contrat Symfony, partagé par les services
+   `ziggytheque-back` et `ziggytheque-worker`) et de `front/.env` (service
+   `ziggytheque-front`).
+2. Le script liste les variables **déjà présentes** sur l'environnement Railway
+   ciblé (`railway variables --json`).
+3. Pour chaque clé attendue **absente** de Railway (et non ignorée), il crée la
+   variable **vide** avec `--skip-deploys` (la création ne déclenche donc pas de
+   déploiement supplémentaire ; c'est le `railway up` suivant qui la prend en
+   compte).
+
+Le script est **non destructif** : il ne fait que **créer** des clés manquantes.
+Il ne modifie ni ne supprime jamais une variable existante — une valeur déjà
+saisie, ou une référence Railway (`${{Postgres.DATABASE_URL}}`), n'est jamais
+écrasée. Il **sort toujours en succès** : il ne peut pas bloquer un déploiement.
+Les clés créées sont signalées en `::notice::` et dans le *job summary*.
+
+## Clés ignorées (jamais créées sur Railway)
+
+Définies dans `IGNORE_KEYS` en tête du script :
+
+| Clé(s) | Raison |
+|---|---|
+| `APP_ENV`, `APP_DEBUG` | figées dans l'image (`ENV APP_ENV=prod`) |
+| `JWT_SECRET_KEY`, `JWT_PUBLIC_KEY` | chemins de fichiers ; la paire de clés est générée au boot (`docker-entrypoint.sh`) |
+| `JWT_TTL`, `MESSENGER_TRANSPORT_DSN`, `MANGADEX_BASE_URL`, `OPEN_LIBRARY_COVERS_BASE_URL` | la valeur par défaut commitée dans `back/.env` **est** la valeur de prod |
+| `DATABASE_URL` | fournie par Railway en référence du service Postgres |
+| `VITE_API_BASE_URL`, `VITE_EXTERNAL_API_URL` | build arg volontairement vide / override optionnel du front |
+
+> ⚠️ **Règle de maintenance** : quand tu ajoutes une variable à `back/.env` dont
+> la valeur par défaut commitée **est aussi** la valeur de production
+> (non-secrète, non spécifique à l'environnement), **ajoute sa clé à
+> `IGNORE_KEYS`**. Sinon le script créerait une variable **vide** sur Railway qui
+> masquerait la valeur par défaut au prochain déploiement.
+>
+> À l'inverse, une nouvelle variable **secrète ou spécifique à l'environnement**
+> (ex. `change_me`, clé d'API, URL publique) ne doit **pas** être ignorée : le
+> déploiement créera son placeholder vide automatiquement.
+
+## Exécuter / prévisualiser en local
+
+```bash
+# Aperçu (aucun appel Railway) : montre ce qui serait créé sur un env vide.
+DRY_RUN=1 ./scripts/railway-sync-env-keys.sh
+
+# Tests unitaires des helpers (extraction de clés, ignore-list, diff).
+./scripts/railway-sync-env-keys.test.sh
+
+# Run réel (ex. en local, CLI authentifiée) contre un environnement précis.
+RAILWAY_TOKEN=... ./scripts/railway-sync-env-keys.sh <environment-id>
+```

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -45,6 +45,12 @@ railway environment                                       # récupère l'id de s
 La duplication copie les variables non-sealed. À ajuster / re-saisir **par
 service** dans le dashboard (onglet *Variables* de chaque service, env staging) :
 
+> 💡 Le job `sync-env` du déploiement crée automatiquement, **vides**, les clés
+> attendues qui manquent sur l'environnement ciblé (dont les **sealed** non
+> copiées) — il ne reste qu'à **saisir leur valeur**. Voir
+> [`docs/railway-env-sync.md`](./railway-env-sync.md). Le tableau ci-dessous
+> reste la référence des valeurs à fournir.
+
 | Service | Variable | Pourquoi |
 |---|---|---|
 | backend | `CORS_ALLOW_ORIGIN` | origine du domaine staging, ex. `^https://staging\.ziggytheque\.fr$` |

--- a/front/.env
+++ b/front/.env
@@ -1,3 +1,13 @@
 # External manga search endpoint (default: /api/manga/external → Symfony → Google Books)
 # Override only if you want to point at a different provider.
 # VITE_EXTERNAL_API_URL=/api/manga/external
+
+# Backend URL the nginx SPA proxies /api and /proxy to (see nginx.conf.template).
+# Local dev injects this via docker-compose (app service → http://back:80) and
+# vite.config.ts reads it from process.env, so this committed value stays empty.
+# In production it MUST be set on the Railway "ziggytheque-front" service to the
+# backend's internal URL, e.g.
+#   http://${{ziggytheque-back.RAILWAY_PRIVATE_DOMAIN}}:${{ziggytheque-back.PORT}}
+# The deploy's env-sync step creates this key empty in Railway when missing so it
+# only needs its value filled in.
+BACKEND_URL=

--- a/scripts/railway-sync-env-keys.sh
+++ b/scripts/railway-sync-env-keys.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# railway-sync-env-keys.sh
+# ------------------------
+# During a deploy, create an EMPTY placeholder Railway variable for every env var
+# the app declares in its .env files but that is not yet present in the target
+# Railway environment. The only manual step left is then typing the value in the
+# Railway dashboard ("j'ai juste a les remplir").
+#
+# Design guarantees (intentionally non-destructive):
+#   * Only ever CREATES keys that are MISSING. It never edits or deletes an
+#     existing variable, so a value you already set — or a Railway reference such
+#     as ${{Postgres.DATABASE_URL}} — is never clobbered.
+#   * New keys are created with --skip-deploys (when the CLI supports it) so the
+#     creation itself does not trigger an extra, empty-valued deploy. The regular
+#     `railway up` that runs right after picks the new keys up.
+#   * Always exits 0 so it can never block a deploy. Newly created keys are
+#     reported as GitHub Actions notices and in the job step summary.
+#
+# Source of truth = the committed .env files. Symfony's `back/.env` is the
+# canonical list of backend vars (its defaults are live in prod: the image runs
+# `composer install` without `dump-env` and ships `back/.env`); `front/.env` is
+# the SPA's list. Keys that must NOT be managed on Railway are listed in
+# IGNORE_KEYS below — build-time vars, image-generated key paths, Railway-provided
+# references, and vars whose committed default is already the production value
+# (creating those empty would shadow a working default).
+#
+# Usage:
+#   RAILWAY_TOKEN=... [RAILWAY_PROJECT_ID=...] ./scripts/railway-sync-env-keys.sh [environment-id]
+#   # environment-id defaults to $RAILWAY_ENVIRONMENT_ID; if empty, the Railway
+#   # CLI falls back to the token's default environment (matches `railway up`).
+#
+# Dry run (no Railway calls — prints what would be created against a fake empty env):
+#   DRY_RUN=1 ./scripts/railway-sync-env-keys.sh
+#
+set -euo pipefail
+
+# --- Configuration ------------------------------------------------------------
+
+# Map each Railway service to the .env file that declares its variables.
+# back and worker share the same backend contract (docker-compose proves it:
+# the worker boots the same image with the same env as `back`).
+SERVICE_ENV_FILES=$(cat <<'MAP'
+ziggytheque-back:back/.env
+ziggytheque-worker:back/.env
+ziggytheque-front:front/.env
+MAP
+)
+
+# Keys this script must NEVER create on Railway. When you add a var to back/.env
+# whose committed default is ALSO the production value (a non-secret, non
+# per-environment default), add its key here so it is not shadowed by an empty
+# Railway variable.
+IGNORE_KEYS=$(cat <<'KEYS'
+APP_ENV
+APP_DEBUG
+JWT_SECRET_KEY
+JWT_PUBLIC_KEY
+JWT_TTL
+DATABASE_URL
+MESSENGER_TRANSPORT_DSN
+MANGADEX_BASE_URL
+OPEN_LIBRARY_COVERS_BASE_URL
+VITE_API_BASE_URL
+VITE_EXTERNAL_API_URL
+KEYS
+)
+
+# --- Logging helpers ----------------------------------------------------------
+
+log()  { printf '[sync-env] %s\n' "$*"; }
+warn() { printf '[sync-env] WARNING: %s\n' "$*" >&2; }
+
+# Emit a GitHub Actions notice (no-op locally) and append a line to the job summary.
+notice()  { [ -n "${GITHUB_ACTIONS:-}" ] && printf '::notice::%s\n' "$*" || true; }
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY" || true; }
+
+# --- Pure helpers (unit-testable by sourcing this file) -----------------------
+
+# extract_keys <env-file> — print the variable keys declared in an .env file,
+# one per line, ignoring comments and blank lines.
+extract_keys() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  { grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "$file" || true; } \
+    | sed -E 's/^[[:space:]]*//; s/=.*$//' \
+    | sort -u
+}
+
+# is_ignored <key> — succeed if the key is in IGNORE_KEYS.
+is_ignored() {
+  printf '%s\n' "$IGNORE_KEYS" | grep -qxF "$1"
+}
+
+# compute_missing <expected-newline-list> <current-newline-list>
+# Print every expected key that is neither ignored nor already present.
+compute_missing() {
+  local expected="$1" current="$2" key
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    is_ignored "$key" && continue
+    printf '%s\n' "$current" | grep -qxF "$key" && continue
+    printf '%s\n' "$key"
+  done <<EOF
+$expected
+EOF
+}
+
+# --- Railway I/O --------------------------------------------------------------
+
+# Built once in main(): the --environment flag (omitted when no id is given) and
+# the --skip-deploys flag (only when the installed CLI supports it).
+ENV_ARGS=()
+SKIP_DEPLOYS_ARGS=()
+
+# get_current_keys <service> — print the keys currently set on the service in the
+# target environment. Returns non-zero if the variables cannot be read, so the
+# caller can skip the service instead of mass-creating placeholders on a glitch.
+get_current_keys() {
+  local service="$1" out
+  if ! out=$(railway variables --service "$service" "${ENV_ARGS[@]}" --json 2>/dev/null); then
+    return 1
+  fi
+  printf '%s' "$out" | jq -r 'keys[]' 2>/dev/null
+}
+
+# create_empty_var <service> <key>
+create_empty_var() {
+  local service="$1" key="$2"
+  if [ -n "${DRY_RUN:-}" ]; then
+    log "DRY_RUN: would create ${service} / ${key}= (empty)"
+    return 0
+  fi
+  railway variables --service "$service" "${ENV_ARGS[@]}" \
+    --set "${key}=" "${SKIP_DEPLOYS_ARGS[@]}" >/dev/null
+}
+
+# sync_service <service> <env-file>
+CREATED_TOTAL=0
+sync_service() {
+  local service="$1" env_file="$2"
+  local expected current missing key
+
+  expected=$(extract_keys "$env_file")
+  if [ -z "$expected" ]; then
+    log "${service}: no keys declared in ${env_file} — nothing to do."
+    return 0
+  fi
+
+  if [ -n "${DRY_RUN:-}" ]; then
+    current=""
+  elif ! current=$(get_current_keys "$service"); then
+    warn "${service}: could not read current Railway variables — skipping (nothing created)."
+    return 0
+  fi
+
+  missing=$(compute_missing "$expected" "$current")
+  if [ -z "$missing" ]; then
+    log "${service}: up to date — no new env vars to create."
+    return 0
+  fi
+
+  log "${service}: creating empty placeholders for new env vars:"
+  summary "### ${service}"
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    log "  + ${key}"
+    create_empty_var "$service" "$key"
+    summary "- \`${key}\` (empty — fill its value in Railway)"
+    CREATED_TOTAL=$((CREATED_TOTAL + 1))
+  done <<EOF
+$missing
+EOF
+}
+
+# --- Entry point --------------------------------------------------------------
+
+main() {
+  local environment_id="${1:-${RAILWAY_ENVIRONMENT_ID:-}}"
+
+  if [ -z "${DRY_RUN:-}" ]; then
+    command -v railway >/dev/null 2>&1 || { warn "railway CLI not found — skipping env sync."; exit 0; }
+    command -v jq      >/dev/null 2>&1 || { warn "jq not found — skipping env sync.";          exit 0; }
+    if [ -z "${RAILWAY_TOKEN:-}" ]; then
+      warn "RAILWAY_TOKEN is not set — skipping env sync."
+      exit 0
+    fi
+
+    if [ -n "$environment_id" ]; then
+      ENV_ARGS=(--environment "$environment_id")
+      log "Target environment: ${environment_id}"
+    else
+      log "No environment id given — using the Railway token's default environment."
+    fi
+
+    if railway variables --help 2>/dev/null | grep -q -- '--skip-deploys'; then
+      SKIP_DEPLOYS_ARGS=(--skip-deploys)
+    else
+      warn "This Railway CLI has no --skip-deploys flag; variable creation may trigger a deploy."
+    fi
+  else
+    log "DRY_RUN enabled — no Railway calls will be made."
+  fi
+
+  summary "## Railway env var sync"
+
+  local line service env_file
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    service="${line%%:*}"
+    env_file="${line#*:}"
+    sync_service "$service" "$env_file"
+  done <<EOF
+$SERVICE_ENV_FILES
+EOF
+
+  if [ "$CREATED_TOTAL" -gt 0 ]; then
+    notice "Created ${CREATED_TOTAL} empty Railway variable(s). Fill their values in the Railway dashboard."
+    log "Done — created ${CREATED_TOTAL} empty placeholder(s). Fill them in Railway."
+  else
+    summary "_No new variables — every declared env var already exists._"
+    log "Done — no new variables to create."
+  fi
+
+  # Never block the deploy.
+  exit 0
+}
+
+# Only run when executed directly, so tests can source the pure helpers.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi

--- a/scripts/railway-sync-env-keys.test.sh
+++ b/scripts/railway-sync-env-keys.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the pure helpers in railway-sync-env-keys.sh.
+# No Railway calls are made — the script is sourced and its functions exercised
+# against in-memory fixtures. Run: ./scripts/railway-sync-env-keys.test.sh
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/railway-sync-env-keys.sh"
+# The sourced script enables `set -e`; restore lenient mode so every assertion runs.
+set +e
+
+failures=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected: [%s]\n      actual:   [%s]\n' "$label" "$expected" "$actual"
+    failures=$((failures + 1))
+  fi
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# --- extract_keys: parses keys, skips comments / markers / blanks --------------
+cat > "$tmp" <<'ENVFILE'
+###> a-bundle ###
+APP_SECRET=change_me
+# a comment
+  GATE_PASSWORD=ziggy123
+
+DATABASE_URL="postgres://u:p@h/db?x=1&y=2"
+###< a-bundle ###
+ENVFILE
+assert_eq "extract_keys parses keys and ignores comments/blanks" \
+  $'APP_SECRET\nDATABASE_URL\nGATE_PASSWORD' \
+  "$(extract_keys "$tmp")"
+
+assert_eq "extract_keys on a missing file is empty" "" "$(extract_keys /no/such/file)"
+
+# --- is_ignored ---------------------------------------------------------------
+if is_ignored "APP_ENV";    then printf 'ok   - is_ignored APP_ENV\n';    else printf 'FAIL - is_ignored APP_ENV\n';    failures=$((failures + 1)); fi
+if is_ignored "DATABASE_URL"; then printf 'ok   - is_ignored DATABASE_URL\n'; else printf 'FAIL - is_ignored DATABASE_URL\n'; failures=$((failures + 1)); fi
+if is_ignored "GATE_PASSWORD"; then printf 'FAIL - GATE_PASSWORD must NOT be ignored\n'; failures=$((failures + 1)); else printf 'ok   - GATE_PASSWORD not ignored\n'; fi
+
+# --- compute_missing: expected − ignored − already-present --------------------
+expected=$'APP_SECRET\nGATE_PASSWORD\nDATABASE_URL\nGOOGLE_BOOKS_API_KEY\nAPP_ENV'
+current=$'APP_SECRET\nRAILWAY_SERVICE_NAME\nDATABASE_URL'
+# Missing = GATE_PASSWORD + GOOGLE_BOOKS_API_KEY (APP_SECRET present, DATABASE_URL
+# present + ignored, APP_ENV ignored).
+assert_eq "compute_missing returns only new, non-ignored keys" \
+  $'GATE_PASSWORD\nGOOGLE_BOOKS_API_KEY' \
+  "$(compute_missing "$expected" "$current")"
+
+assert_eq "compute_missing is empty when nothing new" \
+  "" \
+  "$(compute_missing $'APP_SECRET\nAPP_ENV' $'APP_SECRET')"
+
+# --- DRY_RUN end-to-end against the real .env files ---------------------------
+# Exercises main()/sync_service wiring with no Railway calls; just asserts it
+# succeeds and reports at least the known backend secrets as "would create".
+out="$(cd "$SCRIPT_DIR/.." && DRY_RUN=1 GITHUB_ACTIONS= GITHUB_STEP_SUMMARY= bash scripts/railway-sync-env-keys.sh 2>&1)"
+if printf '%s' "$out" | grep -q 'would create ziggytheque-back / GATE_PASSWORD='; then
+  printf 'ok   - DRY_RUN flags GATE_PASSWORD for ziggytheque-back\n'
+else
+  printf 'FAIL - DRY_RUN did not flag GATE_PASSWORD\n%s\n' "$out"; failures=$((failures + 1))
+fi
+if printf '%s' "$out" | grep -q 'would create .* / DATABASE_URL='; then
+  printf 'FAIL - DATABASE_URL must never be created\n'; failures=$((failures + 1))
+else
+  printf 'ok   - DRY_RUN never creates DATABASE_URL\n'
+fi
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "All tests passed."
+  exit 0
+fi
+echo "${failures} test(s) failed."
+exit 1


### PR DESCRIPTION
Add a sync-env job to the staging and production deploy workflows that diffs the env vars declared in the repo's .env files against those already set on the target Railway environment and creates any missing key empty (--skip-deploys, never editing existing values). New vars then only need their value typed in the Railway dashboard.

Source of truth is back/.env (back + worker) and front/.env (front), minus an ignore-list for build-time, image-generated, Railway-provided, and default-is-prod-value keys. The script is non-destructive and always exits 0 so it cannot block a deploy.

https://claude.ai/code/session_01YR9nRxjVAqATtY5cCd6o2z