### PR TITLE
fix(ci): sentinel value + never block deploy in Railway env sync

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,7 +168,7 @@ Human-readable names (e.g. `fk_volumes_manga`) will always conflict with Doctrin
 - Emails: **Resend** — domain `ziggytheque.fr` verified, sender `notifications@ziggytheque.fr`, `MAILER_DSN=resend+api://KEY@default`. Full setup: `docs/resend.md`
 - Frontend nginx proxies `/api` and `/proxy` to the backend via `BACKEND_URL` (internal Railway URL), so the SPA stays same-origin
 - CORS prod value: `CORS_ALLOW_ORIGIN=^https://(www\.)?ziggytheque\.fr$`
-- **Env var sync at deploy**: a `sync-env` job (in both deploy workflows) compares the env vars declared in the repo's `.env` files against what's set on the target Railway environment and creates any **new** one **empty** (`--skip-deploys`, never edits existing values) so it only needs its value typed in Railway. Script + ignore-list: `scripts/railway-sync-env-keys.sh`; full doc: `docs/railway-env-sync.md`. When you add a `back/.env` var whose committed default IS the prod value, add its key to `IGNORE_KEYS` so it isn't shadowed by an empty Railway var.
+- **Env var sync at deploy**: a `sync-env` job (in both deploy workflows) compares the env vars declared in the repo's `.env` files against what's set on the target Railway environment and creates any **new** one with a sentinel value `CHANGEME` (the Railway CLI can't set empty; `--skip-deploys`, never edits existing values) so it only needs its real value typed in Railway. Always exits 0 — never blocks a deploy. Script + ignore-list (`IGNORE_KEYS` exact + `IGNORE_PATTERNS` globs, incl. `*_BASE_URL`): `scripts/railway-sync-env-keys.sh`; full doc: `docs/railway-env-sync.md`. When you add a `back/.env` var whose committed default IS the prod value, add its key to `IGNORE_KEYS` so it isn't shadowed by a `CHANGEME` placeholder.
 
 ## First time setup
 ```

--- a/docs/railway-env-sync.md
+++ b/docs/railway-env-sync.md
@@ -1,15 +1,24 @@
 # Synchronisation des variables d'env Railway au déploiement
 
 À chaque déploiement (**prod** ou **staging**), un job `sync-env` détecte les
-**nouvelles** variables d'environnement attendues par l'app et les crée
-**vides** sur l'environnement Railway ciblé. Il ne reste qu'à **saisir leur
-valeur** dans le dashboard Railway.
+**nouvelles** variables d'environnement attendues par l'app et crée sur
+l'environnement Railway ciblé un **placeholder** pour chacune. Il ne reste qu'à
+**remplacer la valeur** dans le dashboard Railway.
 
 - Script : [`scripts/railway-sync-env-keys.sh`](../scripts/railway-sync-env-keys.sh)
 - Wiring CI : job `sync-env` dans
   [`deploy-staging.yml`](../.github/workflows/deploy-staging.yml) et
   [`deploy-production.yml`](../.github/workflows/deploy-production.yml), exécuté
   **après** les gates QA (et l'approbation en prod) et **avant** `railway up`.
+
+## Valeur des placeholders : `CHANGEME` (pas vide)
+
+Le CLI Railway **refuse une valeur vide** (`railway variables --set "KEY="` →
+`Invalid variable format: KEY=`). Les placeholders sont donc créés avec une
+**valeur sentinelle visible**, `CHANGEME` par défaut (modifiable via la variable
+d'env `PLACEHOLDER_VALUE`). Tu la remplaces par la vraie valeur dans Railway —
+tant qu'elle vaut `CHANGEME`, la fonctionnalité concernée ne marche pas (comme
+avec une valeur vide), c'est volontairement visible.
 
 ## Comment ça marche
 
@@ -20,37 +29,45 @@ valeur** dans le dashboard Railway.
 2. Le script liste les variables **déjà présentes** sur l'environnement Railway
    ciblé (`railway variables --json`).
 3. Pour chaque clé attendue **absente** de Railway (et non ignorée), il crée la
-   variable **vide** avec `--skip-deploys` (la création ne déclenche donc pas de
-   déploiement supplémentaire ; c'est le `railway up` suivant qui la prend en
-   compte).
+   variable avec la valeur sentinelle et `--skip-deploys` (la création ne
+   déclenche donc pas de déploiement supplémentaire ; c'est le `railway up`
+   suivant qui la prend en compte).
 
 Le script est **non destructif** : il ne fait que **créer** des clés manquantes.
 Il ne modifie ni ne supprime jamais une variable existante — une valeur déjà
 saisie, ou une référence Railway (`${{Postgres.DATABASE_URL}}`), n'est jamais
-écrasée. Il **sort toujours en succès** : il ne peut pas bloquer un déploiement.
+écrasée. Il **n'interrompt jamais un déploiement** : un appel Railway en échec
+est signalé puis ignoré, et le script **sort toujours en succès** (`exit 0`).
 Les clés créées sont signalées en `::notice::` et dans le *job summary*.
 
 ## Clés ignorées (jamais créées sur Railway)
 
-Définies dans `IGNORE_KEYS` en tête du script :
+Définies en tête du script via `IGNORE_KEYS` (liste exacte) et `IGNORE_PATTERNS`
+(globs) :
 
-| Clé(s) | Raison |
+| Clé(s) / motif | Raison |
 |---|---|
 | `APP_ENV`, `APP_DEBUG` | figées dans l'image (`ENV APP_ENV=prod`) |
 | `JWT_SECRET_KEY`, `JWT_PUBLIC_KEY` | chemins de fichiers ; la paire de clés est générée au boot (`docker-entrypoint.sh`) |
-| `JWT_TTL`, `MESSENGER_TRANSPORT_DSN`, `MANGADEX_BASE_URL`, `OPEN_LIBRARY_COVERS_BASE_URL` | la valeur par défaut commitée dans `back/.env` **est** la valeur de prod |
+| `JWT_TTL`, `MESSENGER_TRANSPORT_DSN` | la valeur par défaut commitée dans `back/.env` **est** la valeur de prod |
 | `DATABASE_URL` | fournie par Railway en référence du service Postgres |
+| `*_BASE_URL` (motif) | URLs de base d'API publiques (`MANGADEX_BASE_URL`, `OPEN_LIBRARY_COVERS_BASE_URL`, `BNF_BASE_URL`, …) dont le défaut commité **est** la valeur de prod |
 | `VITE_API_BASE_URL`, `VITE_EXTERNAL_API_URL` | build arg volontairement vide / override optionnel du front |
+
+> Le motif `*_BASE_URL` ne matche **pas** `MERCURE_PUBLIC_URL`/`MERCURE_URL`
+> (spécifiques à l'env → gérés), `DATABASE_URL` (déjà explicite) ni
+> `DISCORD_WEBHOOK_URL` (secret → géré).
 
 > ⚠️ **Règle de maintenance** : quand tu ajoutes une variable à `back/.env` dont
 > la valeur par défaut commitée **est aussi** la valeur de production
-> (non-secrète, non spécifique à l'environnement), **ajoute sa clé à
-> `IGNORE_KEYS`**. Sinon le script créerait une variable **vide** sur Railway qui
-> masquerait la valeur par défaut au prochain déploiement.
+> (non-secrète, non spécifique à l'environnement) et qui ne matche pas déjà un
+> motif, **ajoute sa clé à `IGNORE_KEYS`**. Sinon le script créerait un
+> placeholder `CHANGEME` sur Railway qui **masquerait** la valeur par défaut au
+> prochain déploiement.
 >
 > À l'inverse, une nouvelle variable **secrète ou spécifique à l'environnement**
 > (ex. `change_me`, clé d'API, URL publique) ne doit **pas** être ignorée : le
-> déploiement créera son placeholder vide automatiquement.
+> déploiement crée son placeholder automatiquement.
 
 ## Exécuter / prévisualiser en local
 
@@ -58,9 +75,12 @@ Définies dans `IGNORE_KEYS` en tête du script :
 # Aperçu (aucun appel Railway) : montre ce qui serait créé sur un env vide.
 DRY_RUN=1 ./scripts/railway-sync-env-keys.sh
 
-# Tests unitaires des helpers (extraction de clés, ignore-list, diff).
+# Tests unitaires des helpers (extraction de clés, ignore-list + motifs, diff).
 ./scripts/railway-sync-env-keys.test.sh
 
 # Run réel (ex. en local, CLI authentifiée) contre un environnement précis.
 RAILWAY_TOKEN=... ./scripts/railway-sync-env-keys.sh <environment-id>
+
+# Changer la valeur sentinelle.
+PLACEHOLDER_VALUE=__FILL_ME__ ./scripts/railway-sync-env-keys.sh <environment-id>
 ```

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -45,9 +45,9 @@ railway environment                                       # récupère l'id de s
 La duplication copie les variables non-sealed. À ajuster / re-saisir **par
 service** dans le dashboard (onglet *Variables* de chaque service, env staging) :
 
-> 💡 Le job `sync-env` du déploiement crée automatiquement, **vides**, les clés
-> attendues qui manquent sur l'environnement ciblé (dont les **sealed** non
-> copiées) — il ne reste qu'à **saisir leur valeur**. Voir
+> 💡 Le job `sync-env` du déploiement crée automatiquement les clés attendues
+> qui manquent sur l'environnement ciblé (dont les **sealed** non copiées) avec
+> un placeholder `CHANGEME` — il ne reste qu'à **remplacer leur valeur**. Voir
 > [`docs/railway-env-sync.md`](./railway-env-sync.md). Le tableau ci-dessous
 > reste la référence des valeurs à fournir.
 

--- a/front/.env
+++ b/front/.env
@@ -8,6 +8,6 @@
 # In production it MUST be set on the Railway "ziggytheque-front" service to the
 # backend's internal URL, e.g.
 #   http://${{ziggytheque-back.RAILWAY_PRIVATE_DOMAIN}}:${{ziggytheque-back.PORT}}
-# The deploy's env-sync step creates this key empty in Railway when missing so it
-# only needs its value filled in.
+# The deploy's env-sync step creates this key in Railway (value CHANGEME) when
+# missing, so it only needs its real value filled in.
 BACKEND_URL=

--- a/scripts/railway-sync-env-keys.sh
+++ b/scripts/railway-sync-env-keys.sh
@@ -2,28 +2,34 @@
 #
 # railway-sync-env-keys.sh
 # ------------------------
-# During a deploy, create an EMPTY placeholder Railway variable for every env var
-# the app declares in its .env files but that is not yet present in the target
-# Railway environment. The only manual step left is then typing the value in the
-# Railway dashboard ("j'ai juste a les remplir").
+# During a deploy, create a PLACEHOLDER Railway variable for every env var the
+# app declares in its .env files but that is not yet present in the target
+# Railway environment. The only manual step left is then overwriting the
+# placeholder with the real value in the Railway dashboard ("j'ai juste a les
+# remplir").
 #
-# Design guarantees (intentionally non-destructive):
+# The Railway CLI refuses an empty value ("Invalid variable format: KEY="), so
+# placeholders are created with a visible sentinel value (default: CHANGEME,
+# override with PLACEHOLDER_VALUE) that you replace.
+#
+# Design guarantees (intentionally non-destructive and deploy-safe):
 #   * Only ever CREATES keys that are MISSING. It never edits or deletes an
 #     existing variable, so a value you already set — or a Railway reference such
 #     as ${{Postgres.DATABASE_URL}} — is never clobbered.
 #   * New keys are created with --skip-deploys (when the CLI supports it) so the
-#     creation itself does not trigger an extra, empty-valued deploy. The regular
-#     `railway up` that runs right after picks the new keys up.
-#   * Always exits 0 so it can never block a deploy. Newly created keys are
-#     reported as GitHub Actions notices and in the job step summary.
+#     creation itself does not trigger an extra deploy; the regular `railway up`
+#     that runs right after picks them up.
+#   * It NEVER aborts the deploy: a failed Railway call is reported and skipped,
+#     and the script always exits 0.
 #
-# Source of truth = the committed .env files. Symfony's `back/.env` is the
-# canonical list of backend vars (its defaults are live in prod: the image runs
-# `composer install` without `dump-env` and ships `back/.env`); `front/.env` is
-# the SPA's list. Keys that must NOT be managed on Railway are listed in
-# IGNORE_KEYS below — build-time vars, image-generated key paths, Railway-provided
-# references, and vars whose committed default is already the production value
-# (creating those empty would shadow a working default).
+# Source of truth = the committed .env files. `back/.env` is the canonical list
+# of backend vars (its defaults are live in prod: the image runs `composer
+# install` without `dump-env` and ships `back/.env`); `front/.env` for the SPA.
+# Keys that must NOT be managed on Railway are skipped via IGNORE_KEYS /
+# IGNORE_PATTERNS below — build-time vars, image-generated key paths,
+# Railway-provided references, and vars whose committed default is already the
+# production value (creating a placeholder for those would shadow a working
+# default and break the app).
 #
 # Usage:
 #   RAILWAY_TOKEN=... [RAILWAY_PROJECT_ID=...] ./scripts/railway-sync-env-keys.sh [environment-id]
@@ -37,6 +43,9 @@ set -euo pipefail
 
 # --- Configuration ------------------------------------------------------------
 
+# Value given to newly created placeholder variables (the CLI cannot set empty).
+PLACEHOLDER_VALUE="${PLACEHOLDER_VALUE:-CHANGEME}"
+
 # Map each Railway service to the .env file that declares its variables.
 # back and worker share the same backend contract (docker-compose proves it:
 # the worker boots the same image with the same env as `back`).
@@ -47,10 +56,9 @@ ziggytheque-front:front/.env
 MAP
 )
 
-# Keys this script must NEVER create on Railway. When you add a var to back/.env
-# whose committed default is ALSO the production value (a non-secret, non
-# per-environment default), add its key here so it is not shadowed by an empty
-# Railway variable.
+# Exact keys this script must NEVER create on Railway. When you add a var to
+# back/.env whose committed default is ALSO the production value (a non-secret,
+# non per-environment default), add its key here (or rely on IGNORE_PATTERNS).
 IGNORE_KEYS=$(cat <<'KEYS'
 APP_ENV
 APP_DEBUG
@@ -59,12 +67,17 @@ JWT_PUBLIC_KEY
 JWT_TTL
 DATABASE_URL
 MESSENGER_TRANSPORT_DSN
-MANGADEX_BASE_URL
-OPEN_LIBRARY_COVERS_BASE_URL
 VITE_API_BASE_URL
 VITE_EXTERNAL_API_URL
 KEYS
 )
+
+# Glob patterns of keys to ignore. `*_BASE_URL` covers public API base URLs
+# (MANGADEX_BASE_URL, OPEN_LIBRARY_COVERS_BASE_URL, BNF_BASE_URL, ...) whose
+# committed .env default IS the production value — a placeholder must never
+# shadow them. This intentionally does NOT match MERCURE_*_URL, DATABASE_URL or
+# DISCORD_WEBHOOK_URL (per-environment / secret → managed or handled explicitly).
+IGNORE_PATTERNS="*_BASE_URL"
 
 # --- Logging helpers ----------------------------------------------------------
 
@@ -87,9 +100,17 @@ extract_keys() {
     | sort -u
 }
 
-# is_ignored <key> — succeed if the key is in IGNORE_KEYS.
+# is_ignored <key> — succeed if the key is in IGNORE_KEYS or matches IGNORE_PATTERNS.
 is_ignored() {
-  printf '%s\n' "$IGNORE_KEYS" | grep -qxF "$1"
+  local key="$1" pattern
+  printf '%s\n' "$IGNORE_KEYS" | grep -qxF "$key" && return 0
+  for pattern in $IGNORE_PATTERNS; do
+    # shellcheck disable=SC2254  # $pattern is an intentional glob
+    case "$key" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
 }
 
 # compute_missing <expected-newline-list> <current-newline-list>
@@ -104,6 +125,7 @@ compute_missing() {
   done <<EOF
 $expected
 EOF
+  return 0
 }
 
 # --- Railway I/O --------------------------------------------------------------
@@ -124,24 +146,30 @@ get_current_keys() {
   printf '%s' "$out" | jq -r 'keys[]' 2>/dev/null
 }
 
-# create_empty_var <service> <key>
-create_empty_var() {
-  local service="$1" key="$2"
+# set_placeholder <service> <key> — create the key with the sentinel value.
+# Returns non-zero (without aborting the script) if the Railway call fails.
+set_placeholder() {
+  local service="$1" key="$2" out
   if [ -n "${DRY_RUN:-}" ]; then
-    log "DRY_RUN: would create ${service} / ${key}= (empty)"
+    log "DRY_RUN: would set ${service} / ${key}=${PLACEHOLDER_VALUE}"
     return 0
   fi
-  railway variables --service "$service" "${ENV_ARGS[@]}" \
-    --set "${key}=" "${SKIP_DEPLOYS_ARGS[@]}" >/dev/null
+  if out=$(railway variables --service "$service" "${ENV_ARGS[@]}" \
+            --set "${key}=${PLACEHOLDER_VALUE}" "${SKIP_DEPLOYS_ARGS[@]}" 2>&1); then
+    return 0
+  fi
+  warn "${service}: could not set ${key} — ${out}"
+  return 1
 }
 
 # sync_service <service> <env-file>
 CREATED_TOTAL=0
+FAILED_TOTAL=0
 sync_service() {
   local service="$1" env_file="$2"
   local expected current missing key
 
-  expected=$(extract_keys "$env_file")
+  expected=$(extract_keys "$env_file" || true)
   if [ -z "$expected" ]; then
     log "${service}: no keys declared in ${env_file} — nothing to do."
     return 0
@@ -154,23 +182,28 @@ sync_service() {
     return 0
   fi
 
-  missing=$(compute_missing "$expected" "$current")
+  missing=$(compute_missing "$expected" "$current" || true)
   if [ -z "$missing" ]; then
     log "${service}: up to date — no new env vars to create."
     return 0
   fi
 
-  log "${service}: creating empty placeholders for new env vars:"
+  log "${service}: creating placeholders (value: ${PLACEHOLDER_VALUE}) for new env vars:"
   summary "### ${service}"
   while IFS= read -r key; do
     [ -n "$key" ] || continue
-    log "  + ${key}"
-    create_empty_var "$service" "$key"
-    summary "- \`${key}\` (empty — fill its value in Railway)"
-    CREATED_TOTAL=$((CREATED_TOTAL + 1))
+    if set_placeholder "$service" "$key"; then
+      log "  + ${key}=${PLACEHOLDER_VALUE}"
+      summary "- \`${key}\` → \`${PLACEHOLDER_VALUE}\` (overwrite with the real value in Railway)"
+      CREATED_TOTAL=$((CREATED_TOTAL + 1))
+    else
+      summary "- \`${key}\` — ⚠️ creation failed (see logs)"
+      FAILED_TOTAL=$((FAILED_TOTAL + 1))
+    fi
   done <<EOF
 $missing
 EOF
+  return 0
 }
 
 # --- Entry point --------------------------------------------------------------
@@ -209,17 +242,20 @@ main() {
     [ -n "$line" ] || continue
     service="${line%%:*}"
     env_file="${line#*:}"
-    sync_service "$service" "$env_file"
+    sync_service "$service" "$env_file" || true
   done <<EOF
 $SERVICE_ENV_FILES
 EOF
 
   if [ "$CREATED_TOTAL" -gt 0 ]; then
-    notice "Created ${CREATED_TOTAL} empty Railway variable(s). Fill their values in the Railway dashboard."
-    log "Done — created ${CREATED_TOTAL} empty placeholder(s). Fill them in Railway."
+    notice "Created ${CREATED_TOTAL} placeholder Railway variable(s) with value '${PLACEHOLDER_VALUE}'. Overwrite them with the real values in the Railway dashboard."
+    log "Done — created ${CREATED_TOTAL} placeholder(s) (value: ${PLACEHOLDER_VALUE}). Overwrite them in Railway."
   else
     summary "_No new variables — every declared env var already exists._"
     log "Done — no new variables to create."
+  fi
+  if [ "$FAILED_TOTAL" -gt 0 ]; then
+    warn "${FAILED_TOTAL} variable(s) could not be created — see logs above. Not failing the deploy."
   fi
 
   # Never block the deploy.

--- a/scripts/railway-sync-env-keys.test.sh
+++ b/scripts/railway-sync-env-keys.test.sh
@@ -22,6 +22,8 @@ assert_eq() {
     failures=$((failures + 1))
   fi
 }
+assert_true()  { if "$@"; then printf 'ok   - %s\n' "$*"; else printf 'FAIL - expected success: %s\n' "$*"; failures=$((failures + 1)); fi; }
+assert_false() { if "$@"; then printf 'FAIL - expected failure: %s\n' "$*"; failures=$((failures + 1)); else printf 'ok   - ! %s\n' "$*"; fi; }
 
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
@@ -42,16 +44,24 @@ assert_eq "extract_keys parses keys and ignores comments/blanks" \
 
 assert_eq "extract_keys on a missing file is empty" "" "$(extract_keys /no/such/file)"
 
-# --- is_ignored ---------------------------------------------------------------
-if is_ignored "APP_ENV";    then printf 'ok   - is_ignored APP_ENV\n';    else printf 'FAIL - is_ignored APP_ENV\n';    failures=$((failures + 1)); fi
-if is_ignored "DATABASE_URL"; then printf 'ok   - is_ignored DATABASE_URL\n'; else printf 'FAIL - is_ignored DATABASE_URL\n'; failures=$((failures + 1)); fi
-if is_ignored "GATE_PASSWORD"; then printf 'FAIL - GATE_PASSWORD must NOT be ignored\n'; failures=$((failures + 1)); else printf 'ok   - GATE_PASSWORD not ignored\n'; fi
+# --- is_ignored: exact list + glob patterns -----------------------------------
+assert_true  is_ignored "APP_ENV"
+assert_true  is_ignored "DATABASE_URL"
+# *_BASE_URL pattern: public API base URLs must be ignored (their committed
+# default IS the prod value) — this is the BNF_BASE_URL regression.
+assert_true  is_ignored "BNF_BASE_URL"
+assert_true  is_ignored "MANGADEX_BASE_URL"
+assert_true  is_ignored "OPEN_LIBRARY_COVERS_BASE_URL"
+# Secrets / per-env vars must NOT be ignored.
+assert_false is_ignored "GATE_PASSWORD"
+assert_false is_ignored "MERCURE_PUBLIC_URL"
+assert_false is_ignored "DISCORD_WEBHOOK_URL"
 
 # --- compute_missing: expected − ignored − already-present --------------------
-expected=$'APP_SECRET\nGATE_PASSWORD\nDATABASE_URL\nGOOGLE_BOOKS_API_KEY\nAPP_ENV'
+expected=$'APP_SECRET\nGATE_PASSWORD\nDATABASE_URL\nGOOGLE_BOOKS_API_KEY\nAPP_ENV\nBNF_BASE_URL\nMANGADEX_BASE_URL'
 current=$'APP_SECRET\nRAILWAY_SERVICE_NAME\nDATABASE_URL'
-# Missing = GATE_PASSWORD + GOOGLE_BOOKS_API_KEY (APP_SECRET present, DATABASE_URL
-# present + ignored, APP_ENV ignored).
+# Missing = GATE_PASSWORD + GOOGLE_BOOKS_API_KEY only (APP_SECRET present;
+# DATABASE_URL present + ignored; APP_ENV ignored; *_BASE_URL ignored).
 assert_eq "compute_missing returns only new, non-ignored keys" \
   $'GATE_PASSWORD\nGOOGLE_BOOKS_API_KEY' \
   "$(compute_missing "$expected" "$current")"
@@ -61,18 +71,30 @@ assert_eq "compute_missing is empty when nothing new" \
   "$(compute_missing $'APP_SECRET\nAPP_ENV' $'APP_SECRET')"
 
 # --- DRY_RUN end-to-end against the real .env files ---------------------------
-# Exercises main()/sync_service wiring with no Railway calls; just asserts it
-# succeeds and reports at least the known backend secrets as "would create".
+# Exercises main()/sync_service wiring with no Railway calls; asserts it succeeds,
+# uses the sentinel value, and never touches ignored keys.
 out="$(cd "$SCRIPT_DIR/.." && DRY_RUN=1 GITHUB_ACTIONS= GITHUB_STEP_SUMMARY= bash scripts/railway-sync-env-keys.sh 2>&1)"
-if printf '%s' "$out" | grep -q 'would create ziggytheque-back / GATE_PASSWORD='; then
-  printf 'ok   - DRY_RUN flags GATE_PASSWORD for ziggytheque-back\n'
+rc=$?
+assert_eq "DRY_RUN exits 0" "0" "$rc"
+if printf '%s' "$out" | grep -q 'would set ziggytheque-back / GATE_PASSWORD=CHANGEME'; then
+  printf 'ok   - DRY_RUN sets GATE_PASSWORD to the sentinel value\n'
 else
-  printf 'FAIL - DRY_RUN did not flag GATE_PASSWORD\n%s\n' "$out"; failures=$((failures + 1))
+  printf 'FAIL - DRY_RUN did not set GATE_PASSWORD=CHANGEME\n%s\n' "$out"; failures=$((failures + 1))
 fi
-if printf '%s' "$out" | grep -q 'would create .* / DATABASE_URL='; then
-  printf 'FAIL - DATABASE_URL must never be created\n'; failures=$((failures + 1))
+for forbidden in DATABASE_URL MANGADEX_BASE_URL OPEN_LIBRARY_COVERS_BASE_URL APP_ENV; do
+  if printf '%s' "$out" | grep -q "would set .* / ${forbidden}="; then
+    printf 'FAIL - ignored key %s must never be set\n' "$forbidden"; failures=$((failures + 1))
+  else
+    printf 'ok   - DRY_RUN never sets %s\n' "$forbidden"
+  fi
+done
+
+# --- PLACEHOLDER_VALUE override -----------------------------------------------
+out2="$(cd "$SCRIPT_DIR/.." && DRY_RUN=1 PLACEHOLDER_VALUE=__FILL__ GITHUB_ACTIONS= GITHUB_STEP_SUMMARY= bash scripts/railway-sync-env-keys.sh 2>&1)"
+if printf '%s' "$out2" | grep -q 'GATE_PASSWORD=__FILL__'; then
+  printf 'ok   - PLACEHOLDER_VALUE override is honored\n'
 else
-  printf 'ok   - DRY_RUN never creates DATABASE_URL\n'
+  printf 'FAIL - PLACEHOLDER_VALUE override not honored\n'; failures=$((failures + 1))
 fi
 
 echo


### PR DESCRIPTION
Follow-up to #130 (the `sync-env` job, already on `main`). That first version broke a real deploy, surfacing two bugs + one dangerous classification. This PR fixes all three.

## Why

The production run failed with:

```
[sync-env]   + BNF_BASE_URL
error: invalid value 'BNF_BASE_URL=' for '--set <SET>': Invalid variable format: BNF_BASE_URL=
Error: Process completed with exit code 1.
```

1. **The Railway CLI rejects empty values** (`--set "KEY="`). → placeholders are now created with a **sentinel value `CHANGEME`** (override via `PLACEHOLDER_VALUE`).
2. **A failed `railway` call aborted the whole deploy** (`set -e`). → every Railway failure is now caught and logged, and the script **always exits `0`** so it can never block a deploy.
3. **`BNF_BASE_URL` would have shadowed a working prod default.** It's a public-API base URL (`https://catalogue.bnf.fr`) like `MANGADEX_BASE_URL` / `OPEN_LIBRARY_COVERS_BASE_URL`, whose committed `back/.env` default **is** the prod value (the image ships `back/.env`). Setting it to `CHANGEME` would have broken the BnF cover source. → added an **`IGNORE_PATTERNS` glob `*_BASE_URL`** so the whole family is ignored automatically, no per-var upkeep.

`*_BASE_URL` intentionally does **not** match `MERCURE_*_URL`, `DATABASE_URL`, or `DISCORD_WEBHOOK_URL` (per-environment / secret → still managed).

## What changed

- `scripts/railway-sync-env-keys.sh` — sentinel value, deploy-safe error handling (always exit 0), `IGNORE_PATTERNS` (+`*_BASE_URL`).
- `scripts/railway-sync-env-keys.test.sh` — added cases for the `BNF_BASE_URL`/`*_BASE_URL` regression and the `PLACEHOLDER_VALUE` override (19 assertions).
- `docs/railway-env-sync.md`, `docs/staging.md`, `.claude/CLAUDE.md`, `front/.env` — wording updated (placeholder = `CHANGEME`, not empty).

The deploy workflows already carry the `sync-env` job from #130 and are unchanged here.

## Verification

- Unit tests: 19/19 (`./scripts/railway-sync-env-keys.test.sh`).
- End-to-end against the real `back/.env` (now containing `BNF_BASE_URL`): `BNF_BASE_URL` is ignored, secrets like `GATE_PASSWORD` still get a `CHANGEME` placeholder.
- Simulated failing `railway --set` (fake CLI on PATH): 31 failures logged, **exit 0**.

https://claude.ai/code/session_01YR9nRxjVAqATtY5cCd6o2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01YR9nRxjVAqATtY5cCd6o2z)_