### PR TITLE
fix(manga): fiabiliser la complétion temps réel des couvertures + lazy-load

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -302,8 +302,12 @@ jobs:
   # deploy jobs so the keys exist when the new code boots.
   # ---------------------------------------------------------------------------
 
+  # TEMPORARILY DISABLED (set to `if: false`) — env var key sync is skipped for
+  # now and handled manually. Re-enable later: remove `if: false` below and point
+  # the `needs` of deploy-api and deploy-front back to `sync-env`.
   sync-env:
     name: "Production: Sync env var keys"
+    if: false
     runs-on: ubuntu-latest
     needs: [approve]
     steps:
@@ -321,7 +325,7 @@ jobs:
   deploy-api:
     name: "Production: Deploy API (worker → backend)"
     runs-on: ubuntu-latest
-    needs: [sync-env]
+    needs: [approve]
     env:
       DEPLOY_MSG: "Deploy ${{ github.ref_name }}"
     steps:
@@ -356,7 +360,7 @@ jobs:
   deploy-front:
     name: "Production: Deploy Frontend"
     runs-on: ubuntu-latest
-    needs: [sync-env]
+    needs: [approve]
     steps:
       - uses: actions/checkout@v5
       - name: Install Railway CLI

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -344,8 +344,12 @@ jobs:
   # (never edits existing values). Fill them in the Railway dashboard afterward.
   # Runs before the deploy jobs so the keys exist when the new code boots.
 
+  # TEMPORARILY DISABLED (set to `if: false`) — env var key sync is skipped for
+  # now and handled manually. Re-enable later: remove `if: false` below and add
+  # `sync-env` back to the `needs` of deploy-api and deploy-front.
   sync-env:
     name: "Staging: Sync env var keys"
+    if: false
     runs-on: ubuntu-latest
     needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
     steps:
@@ -362,7 +366,7 @@ jobs:
   deploy-api:
     name: "Staging: Deploy API (worker → backend)"
     runs-on: ubuntu-latest
-    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build, sync-env]
+    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
     env:
       DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
     steps:
@@ -403,7 +407,7 @@ jobs:
   deploy-front:
     name: "Staging: Deploy Frontend"
     runs-on: ubuntu-latest
-    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build, sync-env]
+    needs: [guard, phpcs, deptrac, phpstan, db-migrations, tests, frontend, docker-build]
     env:
       DEPLOY_MSG: "Staging deploy ${{ inputs.ref || github.ref_name }} (${{ github.sha }})"
     steps:

--- a/back/src/Manga/Application/AutoCovers/StartCoverBatchHandler.php
+++ b/back/src/Manga/Application/AutoCovers/StartCoverBatchHandler.php
@@ -9,11 +9,19 @@ use App\Manga\Domain\MangaRepositoryInterface;
 use App\Shared\Domain\Exception\NotFoundException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Uid\Uuid;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class StartCoverBatchHandler
 {
+    /**
+     * Give the SPA's EventSource time to subscribe to the private Mercure topic
+     * before the worker starts publishing — Mercure drops events sent to a topic
+     * that has no subscriber yet, so a too-eager worker would race the browser.
+     */
+    private const int SUBSCRIBE_GRACE_MS = 1000;
+
     public function __construct(
         private MangaRepositoryInterface $mangaRepository,
         private MessageBusInterface $messageBus,
@@ -31,12 +39,15 @@ final readonly class StartCoverBatchHandler
 
         $batchId = Uuid::v4()->toRfc4122();
 
-        $this->messageBus->dispatch(new AutoCoversBatchMessage(
-            mangaId: $command->mangaId,
-            batchId: $batchId,
-            force: $command->force,
-            volumeIds: $command->volumeIds,
-        ));
+        $this->messageBus->dispatch(
+            new AutoCoversBatchMessage(
+                mangaId: $command->mangaId,
+                batchId: $batchId,
+                force: $command->force,
+                volumeIds: $command->volumeIds,
+            ),
+            [new DelayStamp(self::SUBSCRIBE_GRACE_MS)],
+        );
 
         $subscriberToken = $this->subscriberAuthorizer->issueToken($batchId, ttlSeconds: 600);
         $topic = $this->subscriberAuthorizer->topicFor($batchId);

--- a/back/tests/Unit/Manga/Application/AutoCovers/StartCoverBatchHandlerTest.php
+++ b/back/tests/Unit/Manga/Application/AutoCovers/StartCoverBatchHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Application\AutoCovers;
 
+use App\Manga\Application\AutoCovers\AutoCoversBatchMessage;
 use App\Manga\Application\AutoCovers\StartCoverBatchCommand;
 use App\Manga\Application\AutoCovers\StartCoverBatchHandler;
 use App\Manga\Application\AutoCovers\StartCoverBatchResult;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 final class StartCoverBatchHandlerTest extends TestCase
 {
@@ -63,6 +65,18 @@ final class StartCoverBatchHandlerTest extends TestCase
         $this->messageBus
             ->expects($this->once())
             ->method('dispatch')
+            ->with(
+                $this->isInstanceOf(AutoCoversBatchMessage::class),
+                $this->callback(static function (array $stamps): bool {
+                    foreach ($stamps as $stamp) {
+                        if ($stamp instanceof DelayStamp && $stamp->getDelay() === 1000) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }),
+            )
             ->willReturnCallback(static fn (object $message) => new Envelope($message));
 
         $result = ($this->handler)(new StartCoverBatchCommand(

--- a/front/nginx.conf.template
+++ b/front/nginx.conf.template
@@ -27,6 +27,29 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Mercure SSE hub — proxied so the SPA's EventSource stays same-origin.
+    # Buffering must be off or nginx would hold the stream and break live updates.
+    location /.well-known/mercure {
+        set $backend ${BACKEND_URL};
+        proxy_pass $backend;
+
+        proxy_ssl_server_name on;
+        proxy_ssl_verify     off;
+
+        proxy_set_header Host              $proxy_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Server-Sent Events: forward chunks immediately and hold the connection open.
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+        chunked_transfer_encoding off;
+    }
+
     # SPA fallback: all unknown routes → index.html
     location / {
         try_files $uri $uri/ /index.html;

--- a/front/src/components/atoms/BaseLazyImage.vue
+++ b/front/src/components/atoms/BaseLazyImage.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    src: string
+    alt?: string
+    /** Distance from the viewport at which loading begins (IntersectionObserver rootMargin). */
+    rootMargin?: string
+  }>(),
+  {
+    alt: '',
+    rootMargin: '200px',
+  },
+)
+
+const root = ref<HTMLElement | null>(null)
+
+// The <img> src is only set once the tile approaches the viewport, so a series
+// with 100+ volumes never fires 100+ cover requests up front — off-screen tiles
+// stay as a cheap placeholder until the user scrolls them into view.
+const shouldLoad = ref(false)
+const loaded = ref(false)
+const errored = ref(false)
+
+let observer: IntersectionObserver | null = null
+
+function reveal(): void {
+  shouldLoad.value = true
+  // Load once: stop observing as soon as the tile has entered the viewport.
+  observer?.disconnect()
+  observer = null
+}
+
+onMounted(() => {
+  // Graceful degradation: without IntersectionObserver, load straight away.
+  if (typeof IntersectionObserver === 'undefined') {
+    reveal()
+    return
+  }
+
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        reveal()
+      }
+    },
+    { rootMargin: props.rootMargin },
+  )
+
+  if (root.value) {
+    observer.observe(root.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  observer = null
+})
+
+function onLoad(): void {
+  loaded.value = true
+}
+
+function onError(): void {
+  errored.value = true
+}
+</script>
+
+<template>
+  <div ref="root" class="relative h-full w-full">
+    <!-- Placeholder: static while off-screen, pulsing only while the image decodes. -->
+    <div
+      v-if="!loaded && !errored"
+      class="absolute inset-0 bg-base-200"
+      :class="{ 'animate-pulse': shouldLoad }"
+    />
+
+    <img
+      v-if="shouldLoad && !errored"
+      :src="src"
+      :alt="alt"
+      class="h-full w-full object-cover transition-opacity duration-300"
+      :style="{ opacity: loaded ? 1 : 0 }"
+      decoding="async"
+      loading="lazy"
+      @load="onLoad"
+      @error="onError"
+    />
+
+    <slot v-if="errored" name="fallback" />
+  </div>
+</template>

--- a/front/src/components/atoms/__tests__/BaseLazyImage.spec.ts
+++ b/front/src/components/atoms/__tests__/BaseLazyImage.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import BaseLazyImage from '../BaseLazyImage.vue'
+
+const observers: MockIntersectionObserver[] = []
+
+class MockIntersectionObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds: number[] = []
+  private readonly callback: IntersectionObserverCallback
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    observers.push(this)
+  }
+
+  trigger(isIntersecting: boolean): void {
+    this.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    )
+  }
+}
+
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+
+describe('BaseLazyImage', () => {
+  beforeEach(() => {
+    observers.length = 0
+  })
+
+  it('does not request the image until it scrolls into view', async () => {
+    const wrapper = mount(BaseLazyImage, { props: { src: 'http://x/cover.jpg', alt: 'Tome 1' } })
+
+    // Off-screen: no <img> in the DOM, so no network request is fired.
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(observers).toHaveLength(1)
+
+    observers[0].trigger(true)
+    await nextTick()
+
+    const img = wrapper.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('http://x/cover.jpg')
+    expect(img.attributes('alt')).toBe('Tome 1')
+    // Loads once: the observer is disconnected after the tile appears.
+    expect(observers[0].disconnect).toHaveBeenCalled()
+  })
+
+  it('fades the image in once it has loaded', async () => {
+    const wrapper = mount(BaseLazyImage, { props: { src: 'http://x/c.jpg' } })
+
+    observers[0].trigger(true)
+    await nextTick()
+
+    const img = wrapper.find('img')
+    expect(img.attributes('style')).toContain('opacity: 0')
+
+    await img.trigger('load')
+    expect(wrapper.find('img').attributes('style')).toContain('opacity: 1')
+  })
+
+  it('shows the fallback slot when the image fails to load', async () => {
+    const wrapper = mount(BaseLazyImage, {
+      props: { src: 'http://x/broken.jpg' },
+      slots: { fallback: '<span class="fb">42</span>' },
+    })
+
+    observers[0].trigger(true)
+    await nextTick()
+    await wrapper.find('img').trigger('error')
+
+    expect(wrapper.find('.fb').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+})

--- a/front/src/components/organisms/MangaCard.vue
+++ b/front/src/components/organisms/MangaCard.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { Book } from 'lucide-vue-next'
 import type { CollectionEntry } from '@/types'
 import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
+import BaseLazyImage from '@/components/atoms/BaseLazyImage.vue'
 import { coverUrl } from '@/utils/coverUrl'
 
 const props = defineProps<{ entry: CollectionEntry }>()
@@ -73,14 +74,19 @@ function open() {
     >
       <!-- Cover -->
       <div class="aspect-[2/3] overflow-hidden">
-        <img
+        <BaseLazyImage
           v-if="entry.manga.coverUrl"
           :src="coverUrl(entry.manga.coverUrl)!"
           :alt="entry.manga.title"
-          class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+          class="transition-transform duration-500 group-hover:scale-110"
           :style="coverStyle"
-          loading="lazy"
-        />
+        >
+          <template #fallback>
+            <div class="w-full h-full flex items-center justify-center bg-base-200 text-base-content/15">
+              <Book class="h-12 w-12" stroke-width="1" />
+            </div>
+          </template>
+        </BaseLazyImage>
         <div v-else class="w-full h-full flex items-center justify-center bg-base-200 text-base-content/15">
           <Book class="h-12 w-12" stroke-width="1" />
         </div>

--- a/front/src/composables/__tests__/useCoverBatchProgress.spec.ts
+++ b/front/src/composables/__tests__/useCoverBatchProgress.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { effectScope } from 'vue'
-import { useCoverBatchProgress } from '../useCoverBatchProgress'
+import { useCoverBatchProgress, PACE_MAX_STEP_MS } from '../useCoverBatchProgress'
 import type { CoverBatchStartResponse } from '@/api/manga'
 
 interface MockEventSourceInstance {
@@ -8,15 +8,21 @@ interface MockEventSourceInstance {
   onerror: (() => void) | null
   close: ReturnType<typeof vi.fn>
   url: string
+  readyState: number
 }
 
 const instances: MockEventSourceInstance[] = []
 
 class MockEventSource {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 2
+
   onmessage: ((event: MessageEvent) => void) | null = null
   onerror: (() => void) | null = null
   close = vi.fn()
   url: string
+  readyState = MockEventSource.OPEN
 
   constructor(url: string) {
     this.url = url
@@ -51,7 +57,12 @@ describe('useCoverBatchProgress', () => {
     vi.clearAllMocks()
   })
 
-  it('calls onUpdate for each event and onDone on batch_completed', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('replays each event through onUpdate and finishes on batch_completed', () => {
+    vi.useFakeTimers()
     const scope = effectScope()
     const onUpdate = vi.fn()
     const onDone = vi.fn()
@@ -69,10 +80,14 @@ describe('useCoverBatchProgress', () => {
         data: makeEventData('volume_resolved', { processed: 1, resolved: 1, failed: 0, skipped: 0 }),
       }),
     )
+    // Paced: the snapshot is buffered, not delivered until the cadence timer fires.
+    expect(onUpdate).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(PACE_MAX_STEP_MS)
     expect(onUpdate).toHaveBeenCalledOnce()
     expect(onUpdate.mock.calls[0][0]).toMatchObject({ resolved: 1, done: false })
 
     source.onmessage!(new MessageEvent('message', { data: makeEventData('batch_completed') }))
+    vi.advanceTimersByTime(PACE_MAX_STEP_MS)
     expect(onDone).toHaveBeenCalledOnce()
     expect(onDone.mock.calls[0][0]).toMatchObject({ done: true })
     expect(source.close).toHaveBeenCalledOnce()
@@ -80,7 +95,7 @@ describe('useCoverBatchProgress', () => {
     scope.stop()
   })
 
-  it('closes EventSource on onerror', () => {
+  it('connects same-origin and carries the topic + authorization params', () => {
     const scope = effectScope()
 
     scope.run(() => {
@@ -88,8 +103,57 @@ describe('useCoverBatchProgress', () => {
       start(mockPayload, {})
     })
 
+    const capturedUrl = instances[0].url
+    // Same-origin: the host follows the current page, not the backend payload.
+    expect(capturedUrl.startsWith(window.location.origin)).toBe(true)
+    expect(capturedUrl).toContain('/.well-known/mercure')
+    expect(capturedUrl).toContain('topic=')
+    expect(capturedUrl).toContain('authorization=stub-token')
+    expect(capturedUrl).toContain(encodeURIComponent('https://ziggytheque.app/cover-batch/test-batch-id'))
+
+    scope.stop()
+  })
+
+  it('keeps the connection on a transient error but resyncs on a permanent one', () => {
+    const scope = effectScope()
+    const onError = vi.fn()
+
+    scope.run(() => {
+      const { start } = useCoverBatchProgress()
+      start(mockPayload, { onError })
+    })
+
     const source = instances[0]
+
+    // Transient drop: the browser will auto-reconnect, so we must NOT close.
+    source.readyState = MockEventSource.CONNECTING
     source.onerror!()
+    expect(source.close).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+
+    // Permanent failure: connection is dead → close and let the page resync.
+    source.readyState = MockEventSource.CLOSED
+    source.onerror!()
+    expect(source.close).toHaveBeenCalledOnce()
+    expect(onError).toHaveBeenCalledOnce()
+
+    scope.stop()
+  })
+
+  it('resyncs through onError when the stream never completes (watchdog)', () => {
+    vi.useFakeTimers()
+    const scope = effectScope()
+    const onError = vi.fn()
+
+    scope.run(() => {
+      const { start } = useCoverBatchProgress()
+      start(mockPayload, { onError })
+    })
+
+    const source = instances[0]
+    vi.advanceTimersByTime(300_000)
+
+    expect(onError).toHaveBeenCalledOnce()
     expect(source.close).toHaveBeenCalledOnce()
 
     scope.stop()
@@ -109,23 +173,8 @@ describe('useCoverBatchProgress', () => {
     expect(source.close).toHaveBeenCalledOnce()
   })
 
-  it('URL contains topic and authorization query params', () => {
-    const scope = effectScope()
-
-    scope.run(() => {
-      const { start } = useCoverBatchProgress()
-      start(mockPayload, {})
-    })
-
-    const capturedUrl = instances[0].url
-    expect(capturedUrl).toContain('topic=')
-    expect(capturedUrl).toContain('authorization=stub-token')
-    expect(capturedUrl).toContain(encodeURIComponent('https://ziggytheque.app/cover-batch/test-batch-id'))
-
-    scope.stop()
-  })
-
-  it('progress ref is updated with each event', () => {
+  it('progress ref is updated as events are replayed', () => {
+    vi.useFakeTimers()
     const scope = effectScope()
     let progressRef: ReturnType<typeof useCoverBatchProgress>['progress'] | null = null
 
@@ -140,9 +189,13 @@ describe('useCoverBatchProgress', () => {
     expect(progressRef!.value).toBeNull()
 
     source.onmessage!(new MessageEvent('message', { data: makeEventData('batch_started', { processed: 0, resolved: 0, failed: 0 }) }))
+    // Buffered until the paced timer releases it.
+    expect(progressRef!.value).toBeNull()
+    vi.advanceTimersByTime(PACE_MAX_STEP_MS)
     expect(progressRef!.value).toMatchObject({ processed: 0, done: false })
 
     source.onmessage!(new MessageEvent('message', { data: makeEventData('batch_completed') }))
+    vi.advanceTimersByTime(PACE_MAX_STEP_MS)
     expect(progressRef!.value).toMatchObject({ done: true })
 
     scope.stop()

--- a/front/src/composables/useCoverBatchProgress.ts
+++ b/front/src/composables/useCoverBatchProgress.ts
@@ -12,27 +12,63 @@ export interface CoverBatchProgress {
   volumeNumber?: number
 }
 
+export interface CoverBatchCallbacks {
+  onUpdate?: (progress: CoverBatchProgress) => void
+  onDone?: (progress: CoverBatchProgress) => void
+  /** Called once when the stream dies for good or never completes, so the page can resync. */
+  onError?: () => void
+}
+
+// Hard ceiling: if the stream goes silent without ever sending batch_completed
+// (dead connection or a lost completion event), resolve the UI anyway so the
+// progress toast never hangs on "Démarrage…" forever.
+const WATCHDOG_MS = 300_000
+
+const DEFAULT_HUB_PATH = '/.well-known/mercure'
+
+// The backend often resolves every cover in a few hundred milliseconds, so all
+// SSE events arrive in one burst and the toast would jump straight from
+// "Démarrage…" to the final summary — unreadable. We buffer the snapshots and
+// replay them at a human-readable cadence instead: each step is held for
+// `stepMs`, derived from the batch size so the whole climb lasts roughly
+// PACE_TARGET_MS whatever the volume count (small batch → slow steps, big batch
+// → quick but still smooth). A genuinely slow stream already exceeds the
+// min-gap, so it passes through untouched.
+export const PACE_TARGET_MS = 2200
+export const PACE_MIN_STEP_MS = 90
+export const PACE_MAX_STEP_MS = 550
+
 export function useCoverBatchProgress() {
   const progress = ref<CoverBatchProgress | null>(null)
   let source: EventSource | null = null
+  let watchdog: ReturnType<typeof setTimeout> | null = null
+  let settled = false
 
-  function start(
-    payload: CoverBatchStartResponse,
-    callbacks: {
-      onUpdate?: (progress: CoverBatchProgress) => void
-      onDone?: (progress: CoverBatchProgress) => void
-    },
-  ): void {
+  // Paced-replay state, reset on every start().
+  const queue: CoverBatchProgress[] = []
+  let paceTimer: ReturnType<typeof setTimeout> | null = null
+  let lastDeliveredAt: number | null = null
+  let stepMs = PACE_MAX_STEP_MS
+  let activeCallbacks: CoverBatchCallbacks = {}
+
+  function start(payload: CoverBatchStartResponse, callbacks: CoverBatchCallbacks): void {
     close()
+    settled = false
+    activeCallbacks = callbacks
+    lastDeliveredAt = null
+    stepMs = PACE_MAX_STEP_MS
 
-    const url = new URL(payload.mercureUrl)
+    // Connect same-origin so the SSE stream is reachable without CORS in dev
+    // (Vite proxy) and in prod (nginx proxy). We borrow only the hub path from
+    // the backend payload and always follow the current page origin for the host.
+    const url = new URL(hubPathFrom(payload.mercureUrl), window.location.origin)
     url.searchParams.append('topic', payload.topic)
     url.searchParams.append('authorization', payload.subscriberToken)
 
     source = new EventSource(url.toString(), { withCredentials: false })
 
-    source.onmessage = (msg) => {
-      const event = JSON.parse(msg.data as string) as {
+    source.onmessage = (message) => {
+      const event = JSON.parse(message.data as string) as {
         type: string
         total: number
         resolved: number
@@ -42,7 +78,16 @@ export function useCoverBatchProgress() {
         volumeNumber?: number
       }
 
-      progress.value = {
+      // batch_started carries the volume count → size the cadence so the whole
+      // replay lands near PACE_TARGET_MS regardless of how many tomes there are.
+      if (event.type === 'batch_started') {
+        stepMs = Math.min(
+          PACE_MAX_STEP_MS,
+          Math.max(PACE_MIN_STEP_MS, Math.round(PACE_TARGET_MS / Math.max(1, event.total))),
+        )
+      }
+
+      queue.push({
         total: event.total,
         resolved: event.resolved,
         failed: event.failed,
@@ -51,20 +96,69 @@ export function useCoverBatchProgress() {
         done: event.type === 'batch_completed',
         lastType: event.type,
         volumeNumber: event.volumeNumber,
-      }
+      })
+      scheduleDrain()
+    }
 
-      callbacks.onUpdate?.(progress.value)
-
-      if (event.type === 'batch_completed') {
-        callbacks.onDone?.(progress.value)
-        close()
+    // EventSource transparently reconnects after a transient drop (readyState
+    // stays CONNECTING). Only give up — and let the page resync — once the
+    // browser has closed the connection for good.
+    source.onerror = () => {
+      if (source?.readyState === EventSource.CLOSED) {
+        fail()
       }
     }
 
-    source.onerror = () => close()
+    watchdog = setTimeout(fail, WATCHDOG_MS)
+  }
+
+  // Release the next buffered snapshot once at least `stepMs` has elapsed since
+  // the previous one, so a burst of events is spread out into a readable climb.
+  function scheduleDrain(): void {
+    if (paceTimer !== null || queue.length === 0) return
+    const sinceLast = lastDeliveredAt === null ? Number.POSITIVE_INFINITY : Date.now() - lastDeliveredAt
+    paceTimer = setTimeout(deliverNext, Math.max(0, stepMs - sinceLast))
+  }
+
+  function deliverNext(): void {
+    paceTimer = null
+    const snapshot = queue.shift()
+    if (!snapshot) return
+
+    lastDeliveredAt = Date.now()
+    progress.value = snapshot
+
+    if (snapshot.done) {
+      settle()
+      activeCallbacks.onDone?.(snapshot)
+      return
+    }
+
+    activeCallbacks.onUpdate?.(snapshot)
+    scheduleDrain()
+  }
+
+  function fail(): void {
+    if (settled) return
+    settle()
+    activeCallbacks.onError?.()
+  }
+
+  function settle(): void {
+    settled = true
+    close()
   }
 
   function close(): void {
+    if (watchdog !== null) {
+      clearTimeout(watchdog)
+      watchdog = null
+    }
+    if (paceTimer !== null) {
+      clearTimeout(paceTimer)
+      paceTimer = null
+    }
+    queue.length = 0
     source?.close()
     source = null
   }
@@ -72,4 +166,12 @@ export function useCoverBatchProgress() {
   onScopeDispose(close)
 
   return { progress, start, close }
+}
+
+function hubPathFrom(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).pathname
+  } catch {
+    return DEFAULT_HUB_PATH
+  }
 }

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -24,6 +24,7 @@ import EnrichVolumeModal from '@/components/organisms/EnrichVolumeModal.vue'
 import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
 import { FRENCH_EDITIONS } from '@/data/editions'
 import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
+import BaseLazyImage from '@/components/atoms/BaseLazyImage.vue'
 import type { ReadingStatus, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
 
@@ -325,6 +326,13 @@ const autoFillMutation = useMutation({
           parts.length > 0 ? parts.join(' · ') : 'Terminé',
           p.failed > 0 && p.resolved === 0 ? 'error' : 'success',
         )
+        qc.invalidateQueries({ queryKey: ['collection', id] })
+        qc.invalidateQueries({ queryKey: ['collection'] })
+      },
+      onError: () => {
+        // The SSE stream died or never completed — the covers were still filled
+        // server-side, so resync silently instead of leaving the toast hanging.
+        ui.closeProgressToast(toastId, 'Couvertures mises à jour', 'info')
         qc.invalidateQueries({ queryKey: ['collection', id] })
         qc.invalidateQueries({ queryKey: ['collection'] })
       },
@@ -799,7 +807,7 @@ function volumeOpacityClass(ve: VolumeEntry): string {
           <button class="btn btn-xs btn-ghost text-base-content/30" @click="selectedIds = new Set()">Vider</button>
         </div>
 
-        <div v-if="sortedVolumes.length" class="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-9 xl:grid-cols-11 gap-3">
+        <div v-if="sortedVolumes.length" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8 gap-3">
           <div
             v-for="ve in sortedVolumes"
             :key="ve.id"
@@ -831,13 +839,22 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   : 'group-hover:scale-105 group-hover:shadow-lg group-hover:z-10',
               ]"
             >
-              <img
+              <BaseLazyImage
                 v-if="ve.coverUrl"
                 :src="coverUrl(ve.coverUrl)!"
                 :alt="`Tome ${ve.number}`"
-                class="w-full h-full object-cover"
-                loading="lazy"
-              />
+              >
+                <template #fallback>
+                  <div class="w-full h-full flex items-center justify-center bg-base-200">
+                    <span
+                      class="font-bold text-xl"
+                      :class="ve.isOwned ? 'text-base-content/50' : ve.isWished ? 'text-warning/60' : ve.isAnnounced ? 'text-secondary/50' : 'text-base-content/15'"
+                    >
+                      {{ ve.number }}
+                    </span>
+                  </div>
+                </template>
+              </BaseLazyImage>
               <div
                 v-else
                 class="w-full h-full flex items-center justify-center bg-base-200"

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
         target: process.env.BACKEND_URL ?? 'http://localhost:8000',
         changeOrigin: true,
       },
+      // Mercure SSE hub — proxied so the EventSource stays same-origin (no CORS).
+      '/.well-known/mercure': {
+        target: process.env.BACKEND_URL ?? 'http://localhost:8000',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Contexte

La complétion automatique des couvertures remplissait bien les tomes, mais le suivi temps réel restait **bloqué sur « Démarrage… »** : le SPA ne recevait jamais les events Mercure et il fallait recharger la page pour voir le résultat. En parallèle, une série de 100+ tomes faisait ramer la page (toutes les couvertures chargées d'un coup).

## Pourquoi le temps réel cassait

Le canal Mercure échouait silencieusement (`source.onerror = () => close()` fermait tout sans rien afficher) :

1. **Dev** : en-tête CORS invalide du hub (`MERCURE_CORS_ORIGINS` = 2 origines séparées par un espace) → l'`EventSource` cross-origin `:5173 → :8000` était bloqué par le navigateur.
2. **Prod** : `nginx` ne proxifiait que `^/(api|proxy)/` → la requête SSE vers `/.well-known/mercure` retombait sur `index.html`.
3. **Course** : le worker (`use_notify`) publiait avant que l'abonné soit connecté ; Mercure ne rejoue pas les events perdus.

## Correctifs

**Temps réel (Mercure conservé)**
- **SSE same-origin** : l'`EventSource` se connecte sur l'origine courante (on ne garde que le *chemin* du hub renvoyé par le back), proxifié vers Mercure par **Vite** (dev) et **nginx** (prod, `proxy_buffering off`). → plus de CORS, plus de SSE perdu en prod, indépendant de l'hôte de `MERCURE_PUBLIC_URL`.
- **Résilience** : plus de fermeture sur erreur transitoire (reconnexion auto de l'`EventSource`) ; un **watchdog** + un callback **`onError`** resynchronisent la collection et ferment le toast si le flux meurt → plus jamais coincé, plus besoin de refresh.
- **Anti-course** : `DelayStamp(1 s)` sur le message worker, le temps que l'abonné rejoigne le topic privé avant publication.

**Lazy-load des couvertures**
- Nouveau composant **`BaseLazyImage`** (`IntersectionObserver`) : l'image n'est chargée qu'à l'approche du viewport, uniquement si elle existe (placeholder sinon et en cas d'échec).
- Appliqué à la **grille des tomes** (page série) **et aux vignettes de séries** (`/collection`) — une série de 100+ tomes ne déclenche plus 100+ requêtes d'un coup.
- Grille des tomes allégée : `3 → 8` colonnes max (au lieu de `11`).

**Désactivation temporaire du job `sync-env`** (CI deploy)
- Le job `sync-env` est **conservé mais passé à `if: false`** dans les workflows staging + production, et retiré du `needs` des jobs de déploiement (`deploy-api`, `deploy-front`, repointés sur les gates / `approve`) pour ne pas les faire skipper en cascade.
- Le script `scripts/railway-sync-env-keys.sh` **reste en place** — réactivation triviale plus tard (retirer `if: false` + remettre `sync-env` dans les `needs`). Les gates qualité et l'approbation prod restent intacts.

## Vérifications
- **Front** : `vue-tsc` ✅, **36 tests** vitest ✅, eslint ✅.
- **Back** : Unit ✅ (assertion du `DelayStamp`) + tests fonctionnels `auto-covers` ✅, contre un PostgreSQL local + migrations.
- **Workflows** : YAML valide (parse OK), aucun job de déploiement ne dépend plus de `sync-env`, chaîne de gates + approbation prod préservée.
- Branche **rebasée sur `main`** (le fix sync-env Railway est déjà sur `main` via `63c07e8`).

> ⚠️ Le démon Docker n'étant pas disponible dans l'environnement, le *flux SSE de bout en bout en navigateur* n'a pas pu être lancé. La connexion same-origin + le proxy SSE sont validés par la config standard et par le code source de `dunglas/mercure` (le hub accepte bien le JWT via le query param `authorization`), mais pas par un run live — à confirmer visuellement avec `make dev`.

https://claude.ai/code/session_01RKrUiBUBRfZfHyFSki7sbZ