### PR TITLE
Improve MangaDex manga search to prefer exact title matches

### DIFF
--- a/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
@@ -16,6 +16,9 @@ final readonly class MangaDexMangaApiClient implements MangaCoverProviderInterfa
     private const string PREFIX_LOGGER = 'MANGADEX : ';
     private const string UPLOADS_BASE_URL = 'https://uploads.mangadex.org/covers';
     private const int COVER_PAGE_SIZE = 100;
+    // Candidates fetched per title search: enough to find the exact series when a
+    // fuzzy match (spin-off, doujinshi, colour edition) outranks it.
+    private const int SEARCH_PAGE_SIZE = 10;
     // Safety cap on cover pagination (~5 pages) for very long series (e.g. One Piece, 100+ volumes).
     private const int COVER_MAX_OFFSET = 500;
 
@@ -107,14 +110,77 @@ final readonly class MangaDexMangaApiClient implements MangaCoverProviderInterfa
         $response = $this->httpClient->request('GET', $this->baseUrl . '/manga', [
             'query' => [
                 'title' => $mangaTitle,
-                'limit' => 5,
+                'limit' => self::SEARCH_PAGE_SIZE,
+                'order[relevance]' => 'desc',
             ],
         ]);
 
         $data = $response->toArray();
         $results = $data['data'] ?? [];
 
+        if ($results === []) {
+            return null;
+        }
+
+        // MangaDex's title search is fuzzy and relevance-ordered, so for a common
+        // term ("Naruto") a spin-off, doujinshi or unrelated series can rank first.
+        // Blindly taking the top hit then resolves covers for the WRONG series.
+        // Prefer a candidate whose own title (or any alt-title) matches the query
+        // exactly once normalised; only fall back to the top hit when none does.
+        $normalizedQuery = $this->normalizeTitle($mangaTitle);
+
+        foreach ($results as $candidate) {
+            foreach ($this->candidateTitles($candidate) as $candidateTitle) {
+                if ($this->normalizeTitle($candidateTitle) === $normalizedQuery) {
+                    return $candidate['id'] ?? null;
+                }
+            }
+        }
+
         return $results[0]['id'] ?? null;
+    }
+
+    /**
+     * Every title string MangaDex exposes for a manga: the localised main titles
+     * plus every alt-title, flattened across locales.
+     *
+     * @param array<string, mixed> $candidate
+     * @return list<string>
+     */
+    private function candidateTitles(array $candidate): array
+    {
+        $attributes = $candidate['attributes'] ?? [];
+        $titles = [];
+
+        foreach ((array) ($attributes['title'] ?? []) as $title) {
+            if (is_string($title) && $title !== '') {
+                $titles[] = $title;
+            }
+        }
+
+        foreach ((array) ($attributes['altTitles'] ?? []) as $altTitle) {
+            foreach ((array) $altTitle as $title) {
+                if (is_string($title) && $title !== '') {
+                    $titles[] = $title;
+                }
+            }
+        }
+
+        return $titles;
+    }
+
+    /**
+     * Lower-cases, strips accents and reduces punctuation to spaces so that
+     * "NARUTO -ナルト-" and "Naruto" compare equal, while "Naruto: Sasuke's Story"
+     * stays distinct.
+     */
+    private function normalizeTitle(string $title): string
+    {
+        $lowered = mb_strtolower(trim($title), 'UTF-8');
+        $deAccented = transliterator_transliterate('Any-Latin; Latin-ASCII', $lowered) ?? $lowered;
+        $alphaNumeric = preg_replace('/[^a-z0-9]+/u', ' ', $deAccented) ?? $deAccented;
+
+        return trim(preg_replace('/\s+/u', ' ', $alphaNumeric) ?? $alphaNumeric);
     }
 
     private function findVolumeCover(string $mangaId, int $volumeNumber, string $language): ?MangaVolumeCoverDto

--- a/back/tests/Unit/Manga/Infrastructure/MangaDexMangaApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/MangaDexMangaApiClientTest.php
@@ -67,6 +67,28 @@ final class MangaDexMangaApiClientTest extends TestCase
         );
     }
 
+    /**
+     * @param list<array{id: string, titles: array<string, string>, altTitles?: list<array<string, string>>}> $candidates
+     */
+    private function mangaSearchResponseMulti(array $candidates): MockResponse
+    {
+        $data = [];
+        foreach ($candidates as $candidate) {
+            $data[] = [
+                'id' => $candidate['id'],
+                'attributes' => [
+                    'title' => $candidate['titles'],
+                    'altTitles' => $candidate['altTitles'] ?? [],
+                ],
+            ];
+        }
+
+        return new MockResponse(
+            json_encode(['data' => $data]),
+            ['response_headers' => ['Content-Type' => 'application/json']],
+        );
+    }
+
     public function testFindByIsbnAlwaysReturnsNull(): void
     {
         $client = $this->makeClient(new MockHttpClient([]));
@@ -160,6 +182,62 @@ final class MangaDexMangaApiClientTest extends TestCase
 
         $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
         $this->assertStringContainsString('french.jpg', $result->coverUrl);
+    }
+
+    public function testFindByContextPicksExactTitleMatchOverFuzzyTopHit(): void
+    {
+        // MangaDex ranks a spin-off first for the common term "Naruto"; the real
+        // series sits lower. Taking the top hit would resolve covers for the wrong
+        // (much shorter) series — the exact-title match must win instead.
+        $httpClient = new MockHttpClient([
+            $this->mangaSearchResponseMulti([
+                ['id' => 'spinoff-id', 'titles' => ['en' => "Naruto: Sasuke's Story"]],
+                ['id' => 'real-naruto-id', 'titles' => ['en' => 'Naruto'], 'altTitles' => [['ja' => 'ナルト']]],
+            ]),
+            $this->coverListResponseRaw([['volume' => '1', 'fileName' => 'cover.jpg', 'locale' => 'ja']]),
+        ]);
+
+        $result = $this->makeClient($httpClient)->findByContext('Naruto', null, 1);
+
+        $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
+        $this->assertStringContainsString('real-naruto-id', $result->coverUrl);
+        $this->assertStringNotContainsString('spinoff-id', $result->coverUrl);
+    }
+
+    public function testFindByContextMatchesOnAltTitleAndIgnoresAccents(): void
+    {
+        // The query matches a lower candidate only via an alt-title, and only once
+        // accents/punctuation are normalised ("NARUTO -ナルト-" vs "Naruto").
+        $httpClient = new MockHttpClient([
+            $this->mangaSearchResponseMulti([
+                ['id' => 'unrelated-id', 'titles' => ['en' => 'Boruto']],
+                ['id' => 'real-id', 'titles' => ['ja' => 'NARUTO -ナルト-'], 'altTitles' => [['fr' => 'Náruto']]],
+            ]),
+            $this->coverListResponseRaw([['volume' => '1', 'fileName' => 'cover.jpg', 'locale' => 'ja']]),
+        ]);
+
+        $result = $this->makeClient($httpClient)->findByContext('naruto', null, 1);
+
+        $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
+        $this->assertStringContainsString('real-id', $result->coverUrl);
+    }
+
+    public function testFindByContextFallsBackToTopHitWhenNoExactTitleMatch(): void
+    {
+        // No candidate title matches exactly → keep MangaDex's relevance ranking
+        // (top hit) rather than returning nothing.
+        $httpClient = new MockHttpClient([
+            $this->mangaSearchResponseMulti([
+                ['id' => 'top-hit-id', 'titles' => ['en' => 'Some Manga Vol. 1 Deluxe']],
+                ['id' => 'other-id', 'titles' => ['en' => 'Another Series']],
+            ]),
+            $this->coverListResponseRaw([['volume' => '1', 'fileName' => 'cover.jpg', 'locale' => 'ja']]),
+        ]);
+
+        $result = $this->makeClient($httpClient)->findByContext('Some Manga', null, 1);
+
+        $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
+        $this->assertStringContainsString('top-hit-id', $result->coverUrl);
     }
 
     public function testCleansTitleAndDropsRestrictiveFilters(): void


### PR DESCRIPTION
## Summary
Enhance the MangaDex manga search to intelligently select the correct series when fuzzy matching returns multiple candidates. The API now prefers exact title matches (including alt-titles) over the top-ranked result, falling back to MangaDex's relevance ranking only when no exact match exists.

## Changes
- **Added `mangaSearchResponseMulti()` test helper** — Generates mock MangaDex search responses with multiple candidates for testing ranking logic
- **Increased search result limit** — Changed from 5 to 10 candidates per search (`SEARCH_PAGE_SIZE`) to ensure the correct series is included even when outranked by spin-offs or doujinshi
- **Implemented exact title matching logic** — New `normalizeTitle()` method that:
  - Converts to lowercase
  - Strips accents and diacritics (e.g. "Náruto" → "naruto")
  - Reduces punctuation to spaces (e.g. "NARUTO -ナルト-" → "naruto")
  - Allows fuzzy queries to match normalized titles exactly
- **Added `candidateTitles()` helper** — Extracts all localised titles and alt-titles from a MangaDex candidate for comprehensive matching
- **Updated `searchMangaId()` logic** — Now iterates through candidates to find an exact normalized match before falling back to the top hit

## Test Coverage
Three new unit tests validate the ranking strategy:
1. **`testFindByContextPicksExactTitleMatchOverFuzzyTopHit`** — Verifies that "Naruto" selects the main series over "Naruto: Sasuke's Story" even when the spin-off ranks first
2. **`testFindByContextMatchesOnAltTitleAndIgnoresAccents`** — Confirms matching works on alt-titles and normalizes accents/punctuation correctly
3. **`testFindByContextFallsBackToTopHitWhenNoExactTitleMatch`** — Ensures graceful fallback to MangaDex's ranking when no exact match exists

## Implementation Details
- Title normalization uses ICU transliteration (`Any-Latin; Latin-ASCII`) for robust accent removal across Unicode scripts
- All candidate titles (main + alt-titles across all locales) are checked for exact matches
- Empty strings and non-string values are safely filtered out during title extraction
- The search maintains backward compatibility: queries that previously worked still resolve correctly

https://claude.ai/code/session_01UeCMKjaRabJigNySuVrN2v