### PR TITLE
Add collection guide modal with statuses, metrics & cover methods

### DIFF
--- a/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/MangaDexMangaApiClient.php
@@ -177,7 +177,10 @@ final readonly class MangaDexMangaApiClient implements MangaCoverProviderInterfa
     private function normalizeTitle(string $title): string
     {
         $lowered = mb_strtolower(trim($title), 'UTF-8');
-        $deAccented = transliterator_transliterate('Any-Latin; Latin-ASCII', $lowered) ?? $lowered;
+        // transliterator_transliterate() returns string|false, so a ?? fallback
+        // would leave `false` in place — guard explicitly to keep $deAccented a string.
+        $transliterated = transliterator_transliterate('Any-Latin; Latin-ASCII', $lowered);
+        $deAccented = $transliterated !== false ? $transliterated : $lowered;
         $alphaNumeric = preg_replace('/[^a-z0-9]+/u', ' ', $deAccented) ?? $deAccented;
 
         return trim(preg_replace('/\s+/u', ' ', $alphaNumeric) ?? $alphaNumeric);

--- a/front/src/components/organisms/CollectionGuideModal.vue
+++ b/front/src/components/organisms/CollectionGuideModal.vue
@@ -1,0 +1,256 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  X, Package, BookOpen, Star, Megaphone, CircleDashed,
+  BookMarked, Layers, CheckCircle2, Gift, Wallet, PieChart, TrendingUp,
+  Search, QrCode, Camera, Link2, Sparkles, Lightbulb, Info,
+} from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+defineProps<{ open: boolean }>()
+const emit = defineEmits<{ close: [] }>()
+
+type Tab = 'statuses' | 'dashboard' | 'covers'
+const tab = ref<Tab>('statuses')
+
+// ── Statuses legend ──
+const STATUSES = [
+  { key: 'owned',     icon: Package,       chip: 'bg-success/15 text-success' },
+  { key: 'read',      icon: BookOpen,      chip: 'bg-info/15 text-info' },
+  { key: 'wished',    icon: Star,          chip: 'bg-warning/15 text-warning' },
+  { key: 'announced', icon: Megaphone,     chip: 'bg-secondary/15 text-secondary' },
+  { key: 'untracked', icon: CircleDashed,  chip: 'bg-base-content/10 text-base-content/40' },
+] as const
+
+const RULES = ['rule1', 'rule2', 'rule3', 'rule4'] as const
+
+// ── Dashboard metrics ──
+const METRICS = [
+  { key: 'series',        icon: BookMarked,  chip: 'bg-primary/15 text-primary' },
+  { key: 'owned',         icon: Layers,      chip: 'bg-success/15 text-success' },
+  { key: 'read',          icon: CheckCircle2, chip: 'bg-info/15 text-info' },
+  { key: 'progress',      icon: TrendingUp,  chip: 'bg-primary/15 text-primary' },
+  { key: 'wishlist',      icon: Gift,        chip: 'bg-warning/15 text-warning' },
+  { key: 'ownedValue',    icon: Wallet,      chip: 'bg-success/15 text-success' },
+  { key: 'wishlistValue', icon: Wallet,      chip: 'bg-warning/15 text-warning' },
+  { key: 'totalValue',    icon: Wallet,      chip: 'bg-base-content/10 text-base-content/70' },
+  { key: 'genre',         icon: PieChart,    chip: 'bg-secondary/15 text-secondary' },
+] as const
+
+// ── Cover methods ──
+const COVER_METHODS = [
+  { key: 'search', icon: Search,   chip: 'bg-primary/15 text-primary',     steps: 3 },
+  { key: 'isbn',   icon: QrCode,   chip: 'bg-secondary/15 text-secondary', steps: 3 },
+  { key: 'scan',   icon: Camera,   chip: 'bg-info/15 text-info',           steps: 3 },
+  { key: 'url',    icon: Link2,    chip: 'bg-base-content/10 text-base-content/60', steps: 0 },
+  { key: 'auto',   icon: Sparkles, chip: 'bg-success/15 text-success',     steps: 0 },
+] as const
+
+const COVER_SOURCES = ['mangadex', 'googlebooks', 'bnf', 'openlibrary', 'hardcover'] as const
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="guide">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-0 sm:p-4"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="absolute inset-0 bg-black/70 backdrop-blur-sm" @click="emit('close')" />
+
+        <div class="relative z-10 w-full sm:max-w-2xl bg-base-100 rounded-t-3xl sm:rounded-2xl shadow-2xl overflow-hidden flex flex-col h-[88dvh] sm:h-[640px]">
+          <!-- Header -->
+          <div class="flex items-center justify-between px-5 py-4 border-b border-base-200 bg-gradient-to-br from-primary/8 to-transparent">
+            <div class="flex items-center gap-2.5">
+              <div class="w-9 h-9 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
+                <Info class="h-5 w-5" />
+              </div>
+              <div>
+                <h2 class="font-bold text-lg leading-tight">{{ t('guide.title') }}</h2>
+                <p class="text-xs text-base-content/50">{{ t('guide.subtitle') }}</p>
+              </div>
+            </div>
+            <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
+              <X class="h-4 w-4" />
+            </button>
+          </div>
+
+          <!-- Tabs -->
+          <div class="px-3 sm:px-5 pt-3 shrink-0">
+            <div class="inline-flex p-1 bg-base-200 rounded-xl gap-1 w-full sm:w-auto">
+              <button
+                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+                :class="tab === 'statuses' ? 'btn-primary' : 'btn-ghost'"
+                @click="tab = 'statuses'"
+              >
+                <BookMarked class="h-4 w-4" />
+                <span>{{ t('guide.tabStatuses') }}</span>
+              </button>
+              <button
+                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+                :class="tab === 'dashboard' ? 'btn-primary' : 'btn-ghost'"
+                @click="tab = 'dashboard'"
+              >
+                <PieChart class="h-4 w-4" />
+                <span>{{ t('guide.tabDashboard') }}</span>
+              </button>
+              <button
+                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+                :class="tab === 'covers' ? 'btn-primary' : 'btn-ghost'"
+                @click="tab = 'covers'"
+              >
+                <Search class="h-4 w-4" />
+                <span>{{ t('guide.tabCovers') }}</span>
+              </button>
+            </div>
+          </div>
+
+          <!-- Content -->
+          <div class="flex-1 overflow-y-auto px-5 py-4 min-h-0">
+            <!-- ── Statuses ── -->
+            <div v-if="tab === 'statuses'" class="space-y-4">
+              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.statusesIntro') }}</p>
+
+              <ul class="space-y-2.5">
+                <li
+                  v-for="s in STATUSES"
+                  :key="s.key"
+                  class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
+                >
+                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="s.chip">
+                    <component :is="s.icon" class="h-5 w-5" />
+                  </div>
+                  <div class="min-w-0">
+                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.status.${s.key}.name`) }}</p>
+                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.status.${s.key}.desc`) }}</p>
+                  </div>
+                </li>
+              </ul>
+
+              <div class="rounded-xl bg-primary/5 border border-primary/15 p-3.5">
+                <p class="flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-primary/80 mb-2">
+                  <Lightbulb class="h-3.5 w-3.5" />
+                  {{ t('guide.rulesTitle') }}
+                </p>
+                <ul class="space-y-1.5">
+                  <li
+                    v-for="rule in RULES"
+                    :key="rule"
+                    class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
+                  >
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-primary/60 shrink-0" />
+                    {{ t(`guide.${rule}`) }}
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- ── Dashboard ── -->
+            <div v-else-if="tab === 'dashboard'" class="space-y-4">
+              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.dashboardIntro') }}</p>
+
+              <ul class="space-y-2.5">
+                <li
+                  v-for="m in METRICS"
+                  :key="m.key"
+                  class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
+                >
+                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="m.chip">
+                    <component :is="m.icon" class="h-5 w-5" />
+                  </div>
+                  <div class="min-w-0">
+                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.metric.${m.key}.name`) }}</p>
+                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.metric.${m.key}.formula`) }}</p>
+                  </div>
+                </li>
+              </ul>
+
+              <div class="rounded-xl bg-secondary/5 border border-secondary/15 p-3.5">
+                <p class="flex items-start gap-2 text-xs text-base-content/65 leading-snug">
+                  <Wallet class="h-4 w-4 text-secondary shrink-0 mt-px" />
+                  {{ t('guide.priceNote') }}
+                </p>
+              </div>
+            </div>
+
+            <!-- ── Covers ── -->
+            <div v-else class="space-y-4">
+              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.coversIntro') }}</p>
+
+              <div
+                v-for="method in COVER_METHODS"
+                :key="method.key"
+                class="rounded-xl border border-base-200 bg-base-100 p-3.5"
+              >
+                <div class="flex items-start gap-3">
+                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="method.chip">
+                    <component :is="method.icon" class="h-5 w-5" />
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.cover.${method.key}.name`) }}</p>
+                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.cover.${method.key}.desc`) }}</p>
+                    <ol v-if="method.steps > 0" class="mt-2.5 space-y-1.5">
+                      <li
+                        v-for="step in method.steps"
+                        :key="step"
+                        class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
+                      >
+                        <span class="flex items-center justify-center h-4 w-4 rounded-full bg-base-200 text-[10px] font-bold text-base-content/60 shrink-0 mt-px">
+                          {{ step }}
+                        </span>
+                        {{ t(`guide.cover.${method.key}.step${step}`) }}
+                      </li>
+                    </ol>
+                  </div>
+                </div>
+              </div>
+
+              <div class="rounded-xl bg-base-200/50 border border-base-200 p-3.5">
+                <p class="text-xs font-bold uppercase tracking-wide text-base-content/50 mb-2">{{ t('guide.coverSourcesTitle') }}</p>
+                <div class="flex flex-wrap gap-1.5">
+                  <span
+                    v-for="src in COVER_SOURCES"
+                    :key="src"
+                    class="badge badge-sm badge-ghost font-medium"
+                  >
+                    {{ t(`guide.coverSource.${src}`) }}
+                  </span>
+                </div>
+                <p class="text-xs text-base-content/50 mt-2.5 leading-snug">{{ t('guide.coverSourcesNote') }}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="shrink-0 px-5 py-3 border-t border-base-200">
+            <button class="btn btn-primary btn-sm w-full sm:w-auto sm:float-right" @click="emit('close')">
+              {{ t('guide.gotIt') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.guide-enter-active,
+.guide-leave-active {
+  transition: opacity 0.2s ease;
+}
+.guide-enter-active .relative,
+.guide-leave-active .relative {
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.guide-enter-from,
+.guide-leave-to {
+  opacity: 0;
+}
+.guide-enter-from .relative {
+  transform: translateY(40px) scale(0.97);
+}
+</style>

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
-import { X, Search, RefreshCw, Book, ImageOff, Megaphone, Package, Star, BookOpen, Camera, Smartphone, QrCode, Info } from 'lucide-vue-next'
+import { X, Search, RefreshCw, Book, ImageOff, Megaphone, Package, Star, BookOpen, Camera, Smartphone, QrCode, Info, HelpCircle, Check, Plus } from 'lucide-vue-next'
 import { searchVolumeExternal, updateVolume, createScanSession } from '@/api/manga'
 import type { CoverProvider } from '@/api/manga'
 import { toggleVolume } from '@/api/collection'
@@ -12,8 +12,9 @@ import { useScanSession } from '@/composables/useScanSession'
 import { useCoverProvider } from '@/composables/useCoverProvider'
 import BaseQrCode from '@/components/atoms/BaseQrCode.vue'
 import BaseCoverProviderLogo from '@/components/atoms/BaseCoverProviderLogo.vue'
+import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
 import { useI18n } from 'vue-i18n'
-import type { VolumeEntry, VolumeToggleField } from '@/types'
+import type { CollectionEntryDetail, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
 
 const { t } = useI18n()
@@ -32,12 +33,14 @@ const emit = defineEmits<{ close: [] }>()
 const qc = useQueryClient()
 const ui = useUiStore()
 
-// ── Escape key + lightbox ──
+// ── Escape key + lightbox + guide ──
 const lightboxOpen = ref(false)
+const showGuide = ref(false)
 
 function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
-    if (lightboxOpen.value) { lightboxOpen.value = false }
+    if (showGuide.value) { showGuide.value = false }
+    else if (lightboxOpen.value) { lightboxOpen.value = false }
     else if (props.open) { emit('close') }
   }
 }
@@ -285,10 +288,59 @@ const enrichMutation = useMutation({
 })
 
 // ── Toggle mutations ──
+// Mirrors the backend ToggleVolumeHandler rules so the optimistic cache update
+// matches exactly what the server will persist (no flicker on settle).
+function applyToggleField(volume: VolumeEntry, field: VolumeToggleField): VolumeEntry {
+  const next = { ...volume }
+  if (field === 'isOwned') {
+    next.isOwned = !volume.isOwned
+    // Owning a volume removes it from the wishlist and announced lists.
+    if (next.isOwned) {
+      next.isWished = false
+      next.isAnnounced = false
+    }
+  } else if (field === 'isRead') {
+    next.isRead = !volume.isRead
+  } else if (field === 'isWished') {
+    next.isWished = !volume.isWished
+  } else {
+    next.isAnnounced = !volume.isAnnounced
+  }
+  return next
+}
+
+function recomputeCounts(volumes: VolumeEntry[]) {
+  return {
+    ownedCount:  volumes.filter((v) => v.isOwned).length,
+    readCount:   volumes.filter((v) => v.isRead).length,
+    wishedCount: volumes.filter((v) => v.isWished && !v.isOwned).length,
+    ownedValue:  volumes.reduce((sum, v) => sum + (v.isOwned ? (v.price ?? 0) : 0), 0),
+  }
+}
+
+const detailKey = computed(() => ['collection', props.collectionEntryId])
+
 const toggleMutation = useMutation({
   mutationFn: ({ field }: { field: VolumeToggleField }) =>
     toggleVolume(props.collectionEntryId, props.volume!.id, field),
-  onSuccess: () => {
+  // Optimistic update — the toggle feels instant instead of waiting on a round trip.
+  onMutate: async ({ field }: { field: VolumeToggleField }) => {
+    const key = detailKey.value
+    const volumeEntryId = props.volume!.id
+    await qc.cancelQueries({ queryKey: key })
+    const previous = qc.getQueryData<CollectionEntryDetail>(key)
+    qc.setQueryData<CollectionEntryDetail>(key, (old) => {
+      if (!old) return old
+      const volumes = old.volumes.map((v) => (v.id === volumeEntryId ? applyToggleField(v, field) : v))
+      return { ...old, volumes, ...recomputeCounts(volumes) }
+    })
+    return { previous, key }
+  },
+  onError: (_error, _vars, context) => {
+    if (context?.previous) qc.setQueryData(context.key, context.previous)
+    ui.addToast(t('enrich.statusUpdateError'), 'error')
+  },
+  onSettled: () => {
     qc.invalidateQueries({ queryKey: ['collection', props.collectionEntryId] })
     qc.invalidateQueries({ queryKey: ['collection'] })
     qc.invalidateQueries({ queryKey: ['wishlist'] })
@@ -303,6 +355,76 @@ const volumeStatus = computed(() => {
   if (v.isOwned) return 'owned'
   if (v.isWished) return 'wished'
   return 'none'
+})
+
+// ── Status toggle controls (the "owned / read / wishlist / announced" panel) ──
+// Static class literals per field so Tailwind keeps them; visibility + active
+// state are derived from the current volume below.
+interface StatusToggleConfig {
+  field: VolumeToggleField
+  icon: typeof Package
+  labelKey: string
+  descKey: string
+  activeCard: string
+  iconChip: string
+  dotActive: string
+}
+
+const STATUS_TOGGLES: Record<VolumeToggleField, StatusToggleConfig> = {
+  isOwned: {
+    field: 'isOwned',
+    icon: Package,
+    labelKey: 'enrich.statusOwnedLabel',
+    descKey: 'enrich.statusOwnedDesc',
+    activeCard: 'border-success bg-success/10 ring-1 ring-success/30',
+    iconChip: 'bg-success/15 text-success',
+    dotActive: 'bg-success text-success-content',
+  },
+  isRead: {
+    field: 'isRead',
+    icon: BookOpen,
+    labelKey: 'enrich.statusReadLabel',
+    descKey: 'enrich.statusReadDesc',
+    activeCard: 'border-info bg-info/10 ring-1 ring-info/30',
+    iconChip: 'bg-info/15 text-info',
+    dotActive: 'bg-info text-info-content',
+  },
+  isWished: {
+    field: 'isWished',
+    icon: Star,
+    labelKey: 'enrich.statusWishedLabel',
+    descKey: 'enrich.statusWishedDesc',
+    activeCard: 'border-warning bg-warning/10 ring-1 ring-warning/30',
+    iconChip: 'bg-warning/15 text-warning',
+    dotActive: 'bg-warning text-warning-content',
+  },
+  isAnnounced: {
+    field: 'isAnnounced',
+    icon: Megaphone,
+    labelKey: 'enrich.statusAnnouncedLabel',
+    descKey: 'enrich.statusAnnouncedDesc',
+    activeCard: 'border-secondary bg-secondary/10 ring-1 ring-secondary/30',
+    iconChip: 'bg-secondary/15 text-secondary',
+    dotActive: 'bg-secondary text-secondary-content',
+  },
+}
+
+// Which toggles are shown, and whether each is active, depend on the volume:
+// "Possédé" is always offered; reading only makes sense once owned; wishing /
+// announcing only make sense while not owned.
+const visibleToggles = computed<{ config: StatusToggleConfig; active: boolean }[]>(() => {
+  const v = props.volume
+  if (!v) return []
+  const list: { config: StatusToggleConfig; active: boolean }[] = [
+    { config: STATUS_TOGGLES.isOwned, active: v.isOwned },
+  ]
+  if (v.isOwned) {
+    list.push({ config: STATUS_TOGGLES.isRead, active: v.isRead })
+  } else {
+    list.push({ config: STATUS_TOGGLES.isWished, active: v.isWished })
+    list.push({ config: STATUS_TOGGLES.isAnnounced, active: v.isAnnounced })
+  }
+  return list
 })
 </script>
 
@@ -346,9 +468,20 @@ const volumeStatus = computed(() => {
               </span>
               <span v-else class="badge badge-ghost">Non suivi</span>
             </div>
-            <button class="btn btn-ghost btn-sm btn-circle" @click="emit('close')">
-              <X class="h-4 w-4" />
-            </button>
+            <div class="flex items-center gap-1">
+              <div class="tooltip tooltip-left" :data-tip="t('guide.openTooltip')">
+                <button
+                  class="btn btn-ghost btn-sm btn-circle text-base-content/60 hover:text-primary"
+                  :aria-label="t('guide.openTooltip')"
+                  @click="showGuide = true"
+                >
+                  <HelpCircle class="h-5 w-5" />
+                </button>
+              </div>
+              <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
+                <X class="h-4 w-4" />
+              </button>
+            </div>
           </div>
 
           <!-- Layout: stacked on mobile (cover→search→url), side-by-side on desktop -->
@@ -362,61 +495,69 @@ const volumeStatus = computed(() => {
                 <div
                   class="shrink-0 w-28 sm:w-44 sm:mx-auto aspect-[2/3] rounded-xl overflow-hidden ring-2 bg-base-200 transition-transform duration-150 relative"
                   :class="[
-                    volumeStatus === 'owned' ? 'ring-success/60' : volumeStatus === 'wished' ? 'ring-warning/60' : volumeStatus === 'announced' ? 'ring-base-content/40 ring-dashed' : 'ring-base-300',
+                    volumeStatus === 'owned' ? 'ring-success/60' : volumeStatus === 'wished' ? 'ring-warning/60' : volumeStatus === 'announced' ? 'ring-secondary/50 ring-dashed' : 'ring-base-300',
                     volume.coverUrl ? 'cursor-zoom-in hover:scale-105' : ''
                   ]"
                   @click="volume.coverUrl && (lightboxOpen = true)"
                 >
                   <img v-if="volume.coverUrl" :src="coverUrl(volume.coverUrl)!" :alt="`Tome ${volume.number}`" class="w-full h-full object-cover" />
                   <div v-else-if="volume.isAnnounced && !volume.isOwned" class="w-full h-full flex items-end justify-center bg-base-300" style="background-image: repeating-linear-gradient(45deg, transparent, transparent 4px, rgba(0,0,0,.06) 4px, rgba(0,0,0,.06) 8px);">
-                    <span class="badge badge-neutral mb-2 text-[9px]">Annoncé</span>
+                    <span class="badge badge-secondary mb-2 text-[9px]">Annoncé</span>
                   </div>
                   <div v-else class="w-full h-full flex items-center justify-center text-base-content/20">
                     <Book class="h-10 w-10" stroke-width="1.5" />
                   </div>
                 </div>
 
-                <!-- Status toggles -->
-                <div class="flex flex-col gap-2 flex-1 justify-center sm:justify-start">
+                <!-- ── Status toggles — clear, self-explanatory cards ── -->
+                <div class="flex flex-col gap-2.5 flex-1 min-w-0 justify-center sm:justify-start">
+                  <div class="flex items-center justify-between gap-2">
+                    <p class="text-[11px] font-bold uppercase tracking-wide text-base-content/45">
+                      {{ t('enrich.statusTitle') }}
+                    </p>
+                    <button
+                      class="text-[11px] font-medium text-primary/70 hover:text-primary inline-flex items-center gap-0.5"
+                      @click="showGuide = true"
+                    >
+                      <HelpCircle class="h-3 w-3" />
+                      {{ t('enrich.statusHelp') }}
+                    </button>
+                  </div>
+
                   <button
-                    v-if="!volume.isOwned"
-                    class="btn btn-sm gap-2"
-                    :class="volume.isAnnounced ? 'btn-neutral' : 'btn-neutral btn-outline'"
+                    v-for="{ config, active } in visibleToggles"
+                    :key="config.field"
+                    type="button"
+                    class="group/status relative flex items-center gap-3 w-full rounded-xl border p-2.5 text-left transition-all duration-150 active:scale-[0.98]"
+                    :class="active
+                      ? config.activeCard
+                      : 'border-base-300/70 bg-base-100 hover:border-base-content/20 hover:bg-base-200/40'"
                     :disabled="toggleMutation.isPending.value"
-                    @click="toggleMutation.mutate({ field: 'isAnnounced' })"
+                    @click="toggleMutation.mutate({ field: config.field })"
                   >
-                    <Megaphone class="h-4 w-4" />
-                    Annoncé
+                    <span
+                      class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 transition-colors"
+                      :class="active ? config.iconChip : 'bg-base-200 text-base-content/40 group-hover/status:text-base-content/60'"
+                    >
+                      <component :is="config.icon" class="h-4 w-4" />
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span class="block text-sm font-semibold leading-tight">{{ t(config.labelKey) }}</span>
+                      <span class="block text-[11px] text-base-content/50 leading-snug mt-0.5">{{ t(config.descKey) }}</span>
+                    </span>
+                    <!-- State indicator: filled check when active, empty ring otherwise -->
+                    <span
+                      class="w-5 h-5 rounded-full flex items-center justify-center shrink-0 transition-all"
+                      :class="active ? config.dotActive : 'border-2 border-base-300 text-transparent group-hover/status:border-base-content/30'"
+                    >
+                      <Check v-if="active" class="h-3 w-3" stroke-width="3" />
+                      <Plus v-else class="h-3 w-3 text-base-content/30" stroke-width="3" />
+                    </span>
                   </button>
-                  <button
-                    class="btn btn-sm gap-2"
-                    :class="volume.isOwned ? 'btn-success' : 'btn-success btn-outline'"
-                    :disabled="toggleMutation.isPending.value"
-                    @click="toggleMutation.mutate({ field: 'isOwned' })"
-                  >
-                    <Package class="h-4 w-4" />
-                    Possédé
-                  </button>
-                  <button
-                    v-if="!volume.isOwned"
-                    class="btn btn-sm gap-2"
-                    :class="volume.isWished ? 'btn-warning' : 'btn-warning btn-outline'"
-                    :disabled="toggleMutation.isPending.value"
-                    @click="toggleMutation.mutate({ field: 'isWished' })"
-                  >
-                    <Star class="h-4 w-4" />
-                    Wishlist
-                  </button>
-                  <button
-                    v-if="volume.isOwned"
-                    class="btn btn-sm gap-2"
-                    :class="volume.isRead ? 'btn-info' : 'btn-info btn-outline'"
-                    :disabled="toggleMutation.isPending.value"
-                    @click="toggleMutation.mutate({ field: 'isRead' })"
-                  >
-                    <BookOpen class="h-4 w-4" />
-                    Lu
-                  </button>
+
+                  <p class="text-[11px] text-base-content/40 leading-snug px-0.5">
+                    {{ volume.isOwned ? t('enrich.statusHintOwned') : t('enrich.statusHintNotOwned') }}
+                  </p>
                 </div>
               </div>
 
@@ -637,6 +778,9 @@ const volumeStatus = computed(() => {
       </div>
     </Transition>
   </Teleport>
+
+  <!-- Guide / tutorial -->
+  <CollectionGuideModal :open="showGuide" @close="showGuide = false" />
 </template>
 
 <style scoped>

--- a/front/src/components/organisms/__tests__/CollectionGuideModal.spec.ts
+++ b/front/src/components/organisms/__tests__/CollectionGuideModal.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import CollectionGuideModal from '../CollectionGuideModal.vue'
+import fr from '@/i18n/fr.json'
+import en from '@/i18n/en.json'
+
+function mountGuide(open: boolean) {
+  const i18n = createI18n({ legacy: false, locale: 'fr', fallbackLocale: 'en', messages: { en, fr } })
+  return mount(CollectionGuideModal, {
+    props: { open },
+    global: { plugins: [i18n] },
+  })
+}
+
+// The guide is teleported to <body>, so interactions go through real DOM nodes.
+async function clickButtonByText(match: string): Promise<void> {
+  const button = Array.from(document.body.querySelectorAll('button'))
+    .find((candidate) => (candidate.textContent ?? '').includes(match))
+  if (!button) throw new Error(`No button containing "${match}"`)
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  await nextTick()
+}
+
+describe('CollectionGuideModal', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders nothing while closed', () => {
+    mountGuide(false)
+    expect(document.body.textContent).not.toContain('Guide & aide')
+  })
+
+  it('shows the statuses tab with the full legend by default', () => {
+    mountGuide(true)
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Guide & aide')
+    // Every status of the legend is documented
+    expect(text).toContain('Possédé')
+    expect(text).toContain('Souhaité')
+    expect(text).toContain('Annoncé')
+    expect(text).toContain('Non suivi')
+    expect(text).toContain('Règles à connaître')
+  })
+
+  it('switches to the dashboard tab and explains the calculations', async () => {
+    mountGuide(true)
+    await clickButtonByText('Tableau de bord')
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Valeur possédée')
+    expect(text).toContain('Progression de lecture')
+  })
+
+  it('switches to the covers tab and lists the search methods', async () => {
+    mountGuide(true)
+    await clickButtonByText('Couvertures')
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Recherche par titre')
+    expect(text).toContain('Recherche par ISBN')
+    expect(text).toContain('Scan du code-barres')
+  })
+
+  it('emits close when the footer button is clicked', async () => {
+    const wrapper = mountGuide(true)
+    await clickButtonByText('J’ai compris')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -190,7 +190,8 @@
     "edit": "Edit",
     "delete": "Delete",
     "remove": "Remove",
-    "next": "Next"
+    "next": "Next",
+    "close": "Close"
   },
   "enrich": {
     "tabSearch": "Search",
@@ -217,7 +218,20 @@
     "applying": "Applying…",
     "scanLinkTitle": "Open on phone",
     "scanExpired": "Session expired — regenerate the QR code on your computer.",
-    "scanSuccess": "Barcode sent!"
+    "scanSuccess": "Barcode sent!",
+    "statusTitle": "This volume’s status",
+    "statusHelp": "Help",
+    "statusUpdateError": "Could not update the status — please retry.",
+    "statusOwnedLabel": "Owned",
+    "statusOwnedDesc": "This volume is in your library.",
+    "statusReadLabel": "Read",
+    "statusReadDesc": "You have finished reading it.",
+    "statusWishedLabel": "Wished",
+    "statusWishedDesc": "To buy — added to your wishlist.",
+    "statusAnnouncedLabel": "Announced",
+    "statusAnnouncedDesc": "Not released yet, publication is scheduled.",
+    "statusHintOwned": "“Read” counts toward your reading progress.",
+    "statusHintNotOwned": "Switch it to “Owned” once you have it: it will leave the wishlist automatically."
   },
   "scan": {
     "title": "Scan an ISBN",
@@ -227,5 +241,123 @@
     "expired": "This link has expired. Regenerate the QR code from your computer.",
     "invalidCode": "Barcode not recognized (invalid ISBN).",
     "cameraError": "Cannot access camera. Check permissions and ensure the page uses HTTPS."
+  },
+  "guide": {
+    "title": "Guide & help",
+    "subtitle": "Statuses, calculations & covers",
+    "openTooltip": "Open the guide (statuses, calculations, covers)",
+    "gotIt": "Got it",
+    "tabStatuses": "Statuses",
+    "tabDashboard": "Dashboard",
+    "tabCovers": "Covers",
+    "statusesIntro": "Every volume carries a status. It drives your counters and the value of your collection.",
+    "status": {
+      "owned": {
+        "name": "Owned",
+        "desc": "You have this volume in your library. It counts toward “owned volumes” and your collection value."
+      },
+      "read": {
+        "name": "Read",
+        "desc": "You finished this volume. Only available on an owned volume; feeds your reading progress."
+      },
+      "wished": {
+        "name": "Wished",
+        "desc": "A volume you want to buy. It joins your wishlist and the wished value."
+      },
+      "announced": {
+        "name": "Announced",
+        "desc": "An upcoming volume, not yet on sale. Handy to track future releases."
+      },
+      "untracked": {
+        "name": "Untracked",
+        "desc": "No status: the volume exists in the series but counts toward nothing."
+      }
+    },
+    "rulesTitle": "Good to know",
+    "rule1": "Marking a volume “Owned” automatically removes it from the wishlist and announced lists.",
+    "rule2": "“Read” is only offered on an owned volume.",
+    "rule3": "“Wished” and “Announced” are only offered on a volume you don’t own.",
+    "rule4": "The series reading status (In progress, Completed…) updates itself based on owned and read volumes.",
+    "dashboardIntro": "The dashboard aggregates all your volumes in real time. Here is how each number is computed.",
+    "metric": {
+      "series": {
+        "name": "Series",
+        "formula": "The number of works in your collection."
+      },
+      "owned": {
+        "name": "Owned volumes",
+        "formula": "The total of volumes marked “Owned” across all series."
+      },
+      "read": {
+        "name": "Read volumes",
+        "formula": "The total of volumes marked “Read”."
+      },
+      "progress": {
+        "name": "Reading progress",
+        "formula": "Read volumes ÷ owned volumes, as a percentage."
+      },
+      "wishlist": {
+        "name": "Wishlist",
+        "formula": "The “Wished” volumes you do not own yet."
+      },
+      "ownedValue": {
+        "name": "Owned value",
+        "formula": "The sum of the prices of all owned volumes."
+      },
+      "wishlistValue": {
+        "name": "Wished value",
+        "formula": "The sum of the prices of wished, not-owned volumes."
+      },
+      "totalValue": {
+        "name": "Total value",
+        "formula": "Owned value + wished value."
+      },
+      "genre": {
+        "name": "Genre breakdown",
+        "formula": "The number of series grouped by genre."
+      }
+    },
+    "priceNote": "Values rely on each volume’s price. Set it per volume, or apply one price to the whole series at once with “Unit price (bulk)”. A volume with no price counts as €0.",
+    "coversIntro": "Several ways to find the right cover for a volume. Pick whichever suits you.",
+    "cover": {
+      "search": {
+        "name": "Search by title",
+        "desc": "The fastest method for manga. We search by title + volume number and show cover suggestions.",
+        "step1": "The field is pre-filled with the title and volume — tweak it if needed.",
+        "step2": "Pick the source via the logo on the left: Auto (smart cascade), MangaDex or Google Books.",
+        "step3": "Click a thumbnail to apply the cover to the volume."
+      },
+      "isbn": {
+        "name": "Search by ISBN",
+        "desc": "The ISBN is the 13 digits under the barcode on the back of the book. The most accurate method.",
+        "step1": "Enter the ISBN (13 digits) then run the search.",
+        "step2": "We query several databases and group the results by source.",
+        "step3": "Click the cover you prefer to apply it."
+      },
+      "scan": {
+        "name": "Barcode scan",
+        "desc": "Scan the barcode to grab the ISBN automatically, without typing anything.",
+        "step1": "Computer camera: allow the camera and show the barcode.",
+        "step2": "Or “Scan with my phone”: a QR code appears, open it on your phone.",
+        "step3": "The barcode read on the phone is sent here instantly and the search starts."
+      },
+      "url": {
+        "name": "Paste a URL",
+        "desc": "Already have the image? Paste its URL at the bottom of the window and apply it directly."
+      },
+      "auto": {
+        "name": "Auto-complete",
+        "desc": "From the series page, the “Complete covers” button fills all missing volume covers at once."
+      }
+    },
+    "coverSourcesTitle": "Sources queried",
+    "coverSource": {
+      "mangadex": "MangaDex",
+      "googlebooks": "Google Books",
+      "bnf": "BnF",
+      "openlibrary": "Open Library",
+      "hardcover": "Hardcover"
+    },
+    "coverSourcesNote": "Title search: MangaDex and Google Books. ISBN search: all sources above, grouped by provider."
   }
 }

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -190,7 +190,8 @@
     "edit": "Modifier",
     "delete": "Supprimer",
     "remove": "Retirer",
-    "next": "Suivant"
+    "next": "Suivant",
+    "close": "Fermer"
   },
   "enrich": {
     "tabSearch": "Recherche",
@@ -217,7 +218,20 @@
     "applying": "Application…",
     "scanLinkTitle": "Ouvrir sur le téléphone",
     "scanExpired": "Session expirée — régénérez le QR code sur l'ordinateur.",
-    "scanSuccess": "Code-barres envoyé !"
+    "scanSuccess": "Code-barres envoyé !",
+    "statusTitle": "Statut de ce tome",
+    "statusHelp": "Aide",
+    "statusUpdateError": "Échec de la mise à jour du statut — réessayez.",
+    "statusOwnedLabel": "Possédé",
+    "statusOwnedDesc": "Ce tome est dans ta bibliothèque.",
+    "statusReadLabel": "Lu",
+    "statusReadDesc": "Tu as fini de le lire.",
+    "statusWishedLabel": "Souhaité",
+    "statusWishedDesc": "À acheter — ajouté à ta liste de souhaits.",
+    "statusAnnouncedLabel": "Annoncé",
+    "statusAnnouncedDesc": "Pas encore sorti, sa parution est prévue.",
+    "statusHintOwned": "« Lu » compte dans ta progression de lecture.",
+    "statusHintNotOwned": "Passe-le en « Possédé » dès que tu l’as : il quittera automatiquement les souhaits."
   },
   "scan": {
     "title": "Scanner un ISBN",
@@ -227,5 +241,123 @@
     "expired": "Ce lien a expiré. Régénérez le QR code depuis l'ordinateur.",
     "invalidCode": "Code-barres non reconnu (ISBN invalide).",
     "cameraError": "Impossible d'accéder à la caméra. Vérifiez les autorisations et que la page est en HTTPS."
+  },
+  "guide": {
+    "title": "Guide & aide",
+    "subtitle": "Statuts, calculs et couvertures",
+    "openTooltip": "Ouvrir le guide (statuts, calculs, couvertures)",
+    "gotIt": "J’ai compris",
+    "tabStatuses": "Statuts",
+    "tabDashboard": "Tableau de bord",
+    "tabCovers": "Couvertures",
+    "statusesIntro": "Chaque tome porte un statut. C’est lui qui alimente tes compteurs et la valeur de ta collection.",
+    "status": {
+      "owned": {
+        "name": "Possédé",
+        "desc": "Tu as ce tome dans ta bibliothèque. Il compte dans « tomes possédés » et dans la valeur de ta collection."
+      },
+      "read": {
+        "name": "Lu",
+        "desc": "Tu as terminé ce tome. Disponible uniquement sur un tome possédé ; alimente ta progression de lecture."
+      },
+      "wished": {
+        "name": "Souhaité",
+        "desc": "Un tome que tu veux acheter. Il rejoint ta liste de souhaits et la valeur souhaitée."
+      },
+      "announced": {
+        "name": "Annoncé",
+        "desc": "Un tome à paraître, pas encore disponible à l’achat. Utile pour suivre les sorties à venir."
+      },
+      "untracked": {
+        "name": "Non suivi",
+        "desc": "Aucun statut : le tome existe dans la série mais n’entre dans aucun compteur."
+      }
+    },
+    "rulesTitle": "Règles à connaître",
+    "rule1": "Marquer un tome « Possédé » le retire automatiquement des souhaits et des annonces.",
+    "rule2": "« Lu » n’est proposé que sur un tome possédé.",
+    "rule3": "« Souhaité » et « Annoncé » ne sont proposés que sur un tome non possédé.",
+    "rule4": "Le statut de lecture de la série (En cours, Terminé…) se met à jour tout seul selon les tomes possédés et lus.",
+    "dashboardIntro": "Le tableau de bord agrège tous tes tomes en temps réel. Voici comment chaque chiffre est calculé.",
+    "metric": {
+      "series": {
+        "name": "Séries",
+        "formula": "Le nombre d’œuvres dans ta collection."
+      },
+      "owned": {
+        "name": "Tomes possédés",
+        "formula": "Le total des tomes marqués « Possédé », toutes séries confondues."
+      },
+      "read": {
+        "name": "Tomes lus",
+        "formula": "Le total des tomes marqués « Lu »."
+      },
+      "progress": {
+        "name": "Progression de lecture",
+        "formula": "Tomes lus ÷ tomes possédés, en pourcentage."
+      },
+      "wishlist": {
+        "name": "Wishlist",
+        "formula": "Les tomes « Souhaité » qui ne sont pas encore possédés."
+      },
+      "ownedValue": {
+        "name": "Valeur possédée",
+        "formula": "La somme des prix de tous les tomes possédés."
+      },
+      "wishlistValue": {
+        "name": "Valeur souhaitée",
+        "formula": "La somme des prix des tomes souhaités non possédés."
+      },
+      "totalValue": {
+        "name": "Valeur totale",
+        "formula": "Valeur possédée + valeur souhaitée."
+      },
+      "genre": {
+        "name": "Répartition par genre",
+        "formula": "Le nombre de séries regroupées par genre."
+      }
+    },
+    "priceNote": "Les valeurs dépendent du prix de chaque tome. Définis-le tome par tome, ou applique un prix à toute la série d’un coup avec « Prix unitaire (en lot) ». Un tome sans prix compte pour 0 €.",
+    "coversIntro": "Plusieurs façons de trouver la bonne couverture d’un tome. Choisis celle qui te convient.",
+    "cover": {
+      "search": {
+        "name": "Recherche par titre",
+        "desc": "La méthode la plus rapide pour les mangas. On cherche par titre + numéro de tome et on affiche des suggestions de couvertures.",
+        "step1": "Le champ est pré-rempli avec le titre et le tome — ajuste-le si besoin.",
+        "step2": "Choisis la source via le logo à gauche : Auto (cascade intelligente), MangaDex ou Google Books.",
+        "step3": "Clique une vignette pour appliquer la couverture au tome."
+      },
+      "isbn": {
+        "name": "Recherche par ISBN",
+        "desc": "L’ISBN, ce sont les 13 chiffres sous le code-barres au dos du livre. C’est la méthode la plus précise.",
+        "step1": "Saisis l’ISBN (13 chiffres) puis lance la recherche.",
+        "step2": "On interroge plusieurs bases et les résultats sont regroupés par source.",
+        "step3": "Clique la couverture que tu préfères pour l’appliquer."
+      },
+      "scan": {
+        "name": "Scan du code-barres",
+        "desc": "Scanne le code-barres pour récupérer l’ISBN automatiquement, sans rien taper.",
+        "step1": "Caméra de l’ordinateur : autorise la caméra et présente le code-barres.",
+        "step2": "Ou « Scanner avec mon téléphone » : un QR code s’affiche, ouvre-le sur ton téléphone.",
+        "step3": "Le code-barres lu sur le téléphone est renvoyé instantanément ici et la recherche se lance."
+      },
+      "url": {
+        "name": "Coller une URL",
+        "desc": "Tu as déjà l’image ? Colle son URL en bas de la fenêtre et applique-la directement."
+      },
+      "auto": {
+        "name": "Compléter automatiquement",
+        "desc": "Depuis la page de la série, le bouton « Compléter les couvertures » remplit en une fois toutes les couvertures manquantes des tomes."
+      }
+    },
+    "coverSourcesTitle": "Sources interrogées",
+    "coverSource": {
+      "mangadex": "MangaDex",
+      "googlebooks": "Google Books",
+      "bnf": "BnF",
+      "openlibrary": "Open Library",
+      "hardcover": "Hardcover"
+    },
+    "coverSourcesNote": "Recherche par titre : MangaDex et Google Books. Recherche par ISBN : toutes les sources ci-dessus, regroupées par fournisseur."
   }
 }


### PR DESCRIPTION
## Summary
Introduces a comprehensive, tabbed guide modal that educates users about collection statuses, dashboard metrics, and cover search methods. The modal is accessible from the volume enrichment dialog and provides inline help throughout the collection workflow.

## Key Changes

**New Component: `CollectionGuideModal.vue`**
- Three-tab modal (Statuses, Dashboard, Covers) with full i18n support
- **Statuses tab**: Legend of all five volume statuses (owned, read, wished, announced, untracked) + four key rules
- **Dashboard tab**: Explains all nine metrics (series, owned volumes, read volumes, progress %, wishlist, owned/wished/total value, genre breakdown) with formulas
- **Covers tab**: Documents five cover search methods (title search, ISBN, barcode scan, URL paste, auto-complete) with step-by-step instructions and source list
- Responsive design: full-height modal on mobile (88dvh), fixed 640px on desktop
- Smooth transitions and accessible keyboard navigation (Escape to close)

**Enhanced `EnrichVolumeModal.vue`**
- Added help button (HelpCircle icon) in header to open the guide
- Redesigned status toggle controls: replaced simple buttons with rich, self-explanatory cards showing icon, label, description, and visual state indicator
- Implemented optimistic updates for toggle mutations (owned/read/wished/announced) with proper rollback on error
- Status toggles now respect business rules: "Owned" always shown; "Read" only when owned; "Wished"/"Announced" only when not owned
- Added inline help link ("Help") in the status panel to jump to the guide

**Internationalization**
- Added 120+ new translation keys across English and French
- Covers all guide content, status labels/descriptions, metric formulas, cover method steps, and source names
- Enhanced enrich modal strings: status title, help link, error message, status hints

**Testing**
- Added `CollectionGuideModal.spec.ts` with four test cases:
  - Renders nothing while closed
  - Shows statuses tab with full legend by default
  - Switches to dashboard tab and displays calculations
  - Switches to covers tab and lists search methods
  - Emits close event on footer button click

## Implementation Details

- **Optimistic updates**: Toggle mutations now update the cache immediately before the server responds, eliminating flicker. On error, the previous state is restored and a toast is shown.
- **Business rule enforcement**: The `applyToggleField()` function mirrors backend logic (e.g., marking owned removes from wishlist/announced). The `visibleToggles` computed property dynamically shows/hides toggles based on current volume state.
- **Responsive layout**: Modal uses `h-[88dvh]` on mobile (full viewport minus safe areas) and fixed height on desktop; tabs stack vertically on mobile, horizontally on desktop.
- **Accessibility**: Proper ARIA attributes, semantic HTML, keyboard support (Escape), and descriptive button labels.

https://claude.ai/code/session_01KVt3HkvLCjxDSeRg2mUkE4