### PR TITLE
Add pagination and search to wishlist with infinite scroll

### DIFF
--- a/back/src/Collection/Application/GetWishlist/GetWishlistHandler.php
+++ b/back/src/Collection/Application/GetWishlist/GetWishlistHandler.php
@@ -14,12 +14,16 @@ final readonly class GetWishlistHandler
     {
     }
 
-    /** @return array<int, array<string, mixed>> */
+    /** @return array{items: list<array<string, mixed>>, total: int, page: int, limit: int} */
     public function __invoke(GetWishlistQuery $query): array
     {
-        return array_map(
-            static fn ($entry) => $entry->toDetailArray(),
-            $this->repository->findWithWishedVolumes(),
-        );
+        $result = $this->repository->findWishedFiltered($query);
+
+        return (new WishlistPaginatedResult(
+            items: $result['items'],
+            total: $result['total'],
+            page:  $query->page,
+            limit: $query->limit,
+        ))->toArray();
     }
 }

--- a/back/src/Collection/Application/GetWishlist/GetWishlistQuery.php
+++ b/back/src/Collection/Application/GetWishlist/GetWishlistQuery.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace App\Collection\Application\GetWishlist;
 
-final readonly class GetWishlistQuery
+use App\Shared\Application\Pagination\AbstractPaginatedQuery;
+
+final readonly class GetWishlistQuery extends AbstractPaginatedQuery
 {
+    public function __construct(
+        public ?string $search = null,
+        int $page = 1,
+        int $limit = 20,
+    ) {
+        parent::__construct($page, $limit);
+    }
 }

--- a/back/src/Collection/Application/GetWishlist/WishlistPaginatedResult.php
+++ b/back/src/Collection/Application/GetWishlist/WishlistPaginatedResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Collection\Application\GetWishlist;
+
+use App\Collection\Domain\CollectionEntry;
+use App\Shared\Application\Pagination\PaginatedResult;
+
+/**
+ * @extends PaginatedResult<CollectionEntry>
+ */
+final class WishlistPaginatedResult extends PaginatedResult
+{
+    protected function serializeItems(): array
+    {
+        return array_map(
+            static fn (CollectionEntry $entry) => $entry->toDetailArray(),
+            $this->items,
+        );
+    }
+}

--- a/back/src/Collection/Domain/CollectionRepositoryInterface.php
+++ b/back/src/Collection/Domain/CollectionRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Collection\Domain;
 
 use App\Collection\Application\Get\GetCollectionQuery;
+use App\Collection\Application\GetWishlist\GetWishlistQuery;
 
 interface CollectionRepositoryInterface
 {
@@ -18,8 +19,12 @@ interface CollectionRepositoryInterface
     /** @return array{items: list<CollectionEntry>, total: int} */
     public function findFiltered(GetCollectionQuery $query): array;
 
-    /** @return CollectionEntry[] Only entries that have at least one wished (non-owned) volume */
-    public function findWithWishedVolumes(): array;
+    /**
+     * Entries with at least one wished (non-owned) volume, filtered by title search and paginated.
+     *
+     * @return array{items: list<CollectionEntry>, total: int}
+     */
+    public function findWishedFiltered(GetWishlistQuery $query): array;
 
     /** @return CollectionEntry[] Only entries with notificationsEnabled = true */
     public function findFollowed(): array;

--- a/back/src/Collection/Infrastructure/Doctrine/DoctrineCollectionRepository.php
+++ b/back/src/Collection/Infrastructure/Doctrine/DoctrineCollectionRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Collection\Infrastructure\Doctrine;
 
 use App\Collection\Application\Get\GetCollectionQuery;
+use App\Collection\Application\GetWishlist\GetWishlistQuery;
 use App\Collection\Domain\CollectionEntry;
 use App\Collection\Domain\CollectionRepositoryInterface;
 use App\Collection\Domain\CollectionSortEnum;
@@ -123,17 +124,41 @@ final readonly class DoctrineCollectionRepository implements CollectionRepositor
         return ['items' => $items, 'total' => $total];
     }
 
-    public function findWithWishedVolumes(): array
+    public function findWishedFiltered(GetWishlistQuery $query): array
     {
-        return $this->em->createQueryBuilder()
-            ->select('DISTINCT c')
-            ->from(CollectionEntry::class, 'c')
-            ->join('c.volumeEntries', 've')
-            ->where('ve.isWished = true')
-            ->andWhere('ve.isOwned = false')
-            ->orderBy('c.addedAt', 'DESC')
+        // EXISTS keeps the parent row count intact (no join fan-out) so the wished
+        // filter composes cleanly with the title search and pagination.
+        $qb = $this->em->createQueryBuilder()
+            ->select('ce')
+            ->from(CollectionEntry::class, 'ce')
+            ->join('ce.manga', 'm')
+            ->where(
+                'EXISTS (SELECT wishedVolume.id FROM ' . VolumeEntry::class . ' wishedVolume '
+                . 'WHERE wishedVolume.collectionEntry = ce '
+                . 'AND wishedVolume.isWished = true AND wishedVolume.isOwned = false)',
+            );
+
+        if ($query->search !== null && $query->search !== '') {
+            $qb->andWhere('LOWER(m.title) LIKE LOWER(:search)')
+               ->setParameter('search', '%' . $query->search . '%');
+        }
+
+        // Count total before pagination
+        $countQb = clone $qb;
+        $countQb->select('COUNT(ce.id)');
+        $total = (int) $countQb->getQuery()->getSingleScalarResult();
+
+        $offset = ($query->page - 1) * $query->limit;
+
+        /** @var list<CollectionEntry> $items */
+        $items = $qb
+            ->orderBy('ce.addedAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($query->limit)
             ->getQuery()
             ->getResult();
+
+        return ['items' => $items, 'total' => $total];
     }
 
     public function findFollowed(): array

--- a/back/src/Wishlist/Infrastructure/Http/WishlistController.php
+++ b/back/src/Wishlist/Infrastructure/Http/WishlistController.php
@@ -12,6 +12,7 @@ use App\Shared\Application\Bus\CommandBusInterface;
 use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/api/wishlist')]
@@ -23,11 +24,20 @@ final readonly class WishlistController
     ) {
     }
 
-    /** Returns all collection entries that have at least one wished (non-owned) volume */
+    /**
+     * Paginated collection entries that have at least one wished (non-owned) volume,
+     * optionally filtered by a manga title search.
+     */
     #[Route('', methods: ['GET'])]
-    public function list(): JsonResponse
+    public function list(#[MapQueryString] WishlistFilterRequest $request): JsonResponse
     {
-        return new JsonResponse($this->queryBus->ask(new GetWishlistQuery()));
+        $query = new GetWishlistQuery(
+            search: $request->search,
+            page:   $request->page,
+            limit:  20,
+        );
+
+        return new JsonResponse($this->queryBus->ask($query));
     }
 
     /** Add all non-owned volumes of a collection entry to the wishlist */

--- a/back/src/Wishlist/Infrastructure/Http/WishlistFilterRequest.php
+++ b/back/src/Wishlist/Infrastructure/Http/WishlistFilterRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Wishlist\Infrastructure\Http;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class WishlistFilterRequest
+{
+    public ?string $search = null;
+
+    #[Assert\Positive]
+    public int $page = 1;
+}

--- a/back/tests/Functional/Wishlist/WishlistControllerTest.php
+++ b/back/tests/Functional/Wishlist/WishlistControllerTest.php
@@ -41,11 +41,16 @@ final class WishlistControllerTest extends AbstractApiTestCase
         $this->assertSame(401, $response->getStatusCode());
     }
 
-    public function testListReturnsArray(): void
+    public function testListReturnsPaginatedShape(): void
     {
         $response = $this->jsonRequest('GET', '/api/wishlist');
         $data     = $this->assertJsonStatus(200, $response);
-        $this->assertIsArray($data);
+
+        $this->assertArrayHasKey('items', $data);
+        $this->assertArrayHasKey('total', $data);
+        $this->assertArrayHasKey('page', $data);
+        $this->assertArrayHasKey('limit', $data);
+        $this->assertIsArray($data['items']);
     }
 
     public function testListShowsEntriesWithWishedVolumes(): void
@@ -57,8 +62,41 @@ final class WishlistControllerTest extends AbstractApiTestCase
         $response = $this->jsonRequest('GET', '/api/wishlist');
         $data     = $this->assertJsonStatus(200, $response);
 
-        $ids = array_column($data, 'id');
+        $ids = array_column($data['items'], 'id');
         $this->assertContains($entryId, $ids);
+    }
+
+    public function testListFiltersBySearch(): void
+    {
+        $matchingId    = $this->createMangaWithVolumes(2);
+        $nonMatchingId = $this->createMangaWithVolumes(2);
+
+        $matchingEntry    = $this->addToCollection($matchingId);
+        $nonMatchingEntry = $this->addToCollection($nonMatchingId);
+        $this->wishVolumes($matchingEntry);
+        $this->wishVolumes($nonMatchingEntry);
+
+        // Both titles start with "Wishlist Manga "; narrow to the matching entry's exact title.
+        $title = (string) json_decode(
+            (string) $this->jsonRequest('GET', '/api/manga/' . $matchingId)->getContent(),
+            true,
+        )['title'];
+
+        $response = $this->jsonRequest('GET', '/api/wishlist?search=' . urlencode($title));
+        $data     = $this->assertJsonStatus(200, $response);
+
+        $ids = array_column($data['items'], 'id');
+        $this->assertContains($matchingEntry, $ids);
+        $this->assertNotContains($nonMatchingEntry, $ids);
+    }
+
+    public function testListSearchWithNoMatchReturnsEmpty(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/wishlist?search=' . urlencode('zzz-no-such-title-zzz'));
+        $data     = $this->assertJsonStatus(200, $response);
+
+        $this->assertSame(0, $data['total']);
+        $this->assertSame([], $data['items']);
     }
 
     // ── POST /api/wishlist/{id}/add-remaining ────────────────────────────────
@@ -72,7 +110,7 @@ final class WishlistControllerTest extends AbstractApiTestCase
         $this->assertSame(204, $response->getStatusCode());
 
         $wishlist = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/wishlist'));
-        $found    = array_filter($wishlist, static fn ($e) => $e['id'] === $entryId);
+        $found    = array_filter($wishlist['items'], static fn ($entry) => $entry['id'] === $entryId);
         $this->assertNotEmpty($found);
     }
 
@@ -94,7 +132,7 @@ final class WishlistControllerTest extends AbstractApiTestCase
         $this->assertSame(204, $response->getStatusCode());
 
         $wishlist = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/wishlist'));
-        $found    = array_filter($wishlist, static fn ($e) => $e['id'] === $entryId);
+        $found    = array_filter($wishlist['items'], static fn ($entry) => $entry['id'] === $entryId);
         $this->assertEmpty($found);
     }
 

--- a/front/src/api/wishlist.ts
+++ b/front/src/api/wishlist.ts
@@ -1,9 +1,21 @@
 import client from './client'
 import type { WishlistEntry } from '@/types'
 
-/** Returns collection entries that have at least one wished (non-owned) volume */
-export async function getWishlist(): Promise<WishlistEntry[]> {
-  const res = await client.get('/wishlist')
+export interface WishlistFilters {
+  search?: string
+  page?: number
+}
+
+export interface WishlistPage {
+  items: WishlistEntry[]
+  total: number
+  page: number
+  limit: number
+}
+
+/** Returns a page of collection entries that have at least one wished (non-owned) volume */
+export async function getWishlist(filters: WishlistFilters = {}): Promise<WishlistPage> {
+  const res = await client.get('/wishlist', { params: filters })
   return res.data
 }
 

--- a/front/src/pages/WishlistPage.vue
+++ b/front/src/pages/WishlistPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
-import { CheckSquare, X, Star, Plus, ArrowRight, Check, ShoppingCart, Book } from 'lucide-vue-next'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { CheckSquare, X, Star, Plus, ArrowRight, Check, ShoppingCart, Book, Search } from 'lucide-vue-next'
 import { getWishlist, clearWishlist, purchaseVolume } from '@/api/wishlist'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
@@ -14,9 +14,37 @@ const ui = useUiStore()
 const { t } = useI18n()
 const router = useRouter()
 
-const { data: entries, isPending } = useQuery({ queryKey: ['wishlist'], queryFn: getWishlist })
+// ── Search (debounced) ──
+const searchInput = ref('')
+const search = ref<string | undefined>(undefined)
 
-const totalWished = computed(() => entries.value?.reduce((s, e) => s + wishedVolumes(e).length, 0) ?? 0)
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+watch(searchInput, (val) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    search.value = val.trim() || undefined
+  }, 300)
+})
+
+// ── Infinite query ──
+const queryKey = computed(() => ['wishlist', { search: search.value }])
+
+const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
+  queryKey,
+  queryFn: ({ pageParam }) =>
+    getWishlist({ search: search.value, page: pageParam as number }),
+  getNextPageParam: (lastPage) => {
+    const fetched = lastPage.page * lastPage.limit
+    return fetched < lastPage.total ? lastPage.page + 1 : undefined
+  },
+  initialPageParam: 1,
+})
+
+const entries = computed<WishlistEntry[]>(() => data.value?.pages.flatMap((p) => p.items) ?? [])
+const totalSeries = computed(() => data.value?.pages[0]?.total ?? 0)
+const isPending = isLoading
+
+const totalWished = computed(() => entries.value.reduce((sum, entry) => sum + wishedVolumes(entry).length, 0))
 
 function wishedVolumes(entry: WishlistEntry): VolumeEntry[] {
   return entry.volumes.filter((v) => v.isWished && !v.isOwned)
@@ -106,6 +134,24 @@ const purchaseMutation = useMutation({
 function goToDetail(id: string) {
   router.push({ name: 'collection-detail', params: { id } })
 }
+
+// ── Infinite scroll sentinel ──
+const sentinel = ref<HTMLElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+onMounted(() => {
+  observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting && hasNextPage.value && !isFetchingNextPage.value) {
+      fetchNextPage()
+    }
+  })
+  if (sentinel.value) observer.observe(sentinel.value)
+})
+
+onUnmounted(() => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  observer?.disconnect()
+})
 </script>
 
 <template>
@@ -117,7 +163,7 @@ function goToDetail(id: string) {
           <h1 class="text-3xl font-extrabold tracking-tight">{{ t('wishlist.title') }}</h1>
           <p class="text-base-content/50 text-sm mt-1">
             <template v-if="!isPending">
-              {{ entries?.length ?? 0 }} série{{ (entries?.length ?? 0) !== 1 ? 's' : '' }} ·
+              {{ totalSeries }} série{{ totalSeries !== 1 ? 's' : '' }} ·
               <span class="text-warning font-semibold">{{ totalWished }} tome{{ totalWished !== 1 ? 's' : '' }} souhaité{{ totalWished !== 1 ? 's' : '' }}</span>
             </template>
           </p>
@@ -140,6 +186,27 @@ function goToDetail(id: string) {
         </div>
       </div>
 
+      <!-- Search bar -->
+      <div class="max-w-5xl mx-auto mt-4">
+        <div class="relative">
+          <Search class="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-base-content/40 pointer-events-none" />
+          <input
+            v-model="searchInput"
+            type="search"
+            class="input input-bordered w-full h-10 pl-10 pr-10 text-sm rounded-xl bg-base-100 focus:outline-none focus:ring-2 focus:ring-warning/30 focus:border-warning transition-all"
+            :placeholder="t('filter.searchPlaceholder')"
+          />
+          <button
+            v-if="searchInput"
+            class="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 flex items-center justify-center rounded-full hover:bg-base-200 text-base-content/40 hover:text-base-content/80 transition"
+            :aria-label="t('filter.reset')"
+            @click="searchInput = ''"
+          >
+            <X class="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
       <!-- Batch quick-select row -->
       <div v-if="batchMode" class="max-w-5xl mx-auto mt-3 flex flex-wrap gap-2 text-sm">
         <span class="text-xs text-base-content/40 self-center">Sélectionner :</span>
@@ -155,14 +222,20 @@ function goToDetail(id: string) {
       </div>
 
       <!-- Empty -->
-      <div v-else-if="!entries?.length" class="flex flex-col items-center justify-center py-24 gap-4">
+      <div v-else-if="!entries.length" class="flex flex-col items-center justify-center py-24 gap-4">
         <div class="opacity-20">
           <Star class="h-16 w-16" stroke-width="1" />
         </div>
-        <p class="text-base-content/40 text-lg font-medium">{{ t('wishlist.empty') }}</p>
-        <p class="text-base-content/30 text-sm text-center max-w-xs">
-          Depuis la vue collection, marquez des tomes comme souhaités ou utilisez le bouton "Ajouter à la liste"
-        </p>
+        <template v-if="search">
+          <p class="text-base-content/40 text-lg font-medium">Aucun résultat pour « {{ search }} »</p>
+          <button class="btn btn-ghost btn-sm" @click="searchInput = ''">Effacer la recherche</button>
+        </template>
+        <template v-else>
+          <p class="text-base-content/40 text-lg font-medium">{{ t('wishlist.empty') }}</p>
+          <p class="text-base-content/30 text-sm text-center max-w-xs">
+            Depuis la vue collection, marquez des tomes comme souhaités ou utilisez le bouton "Ajouter à la liste"
+          </p>
+        </template>
       </div>
 
       <!-- Wishlist cards -->
@@ -316,6 +389,12 @@ function goToDetail(id: string) {
             </p>
           </div>
         </div>
+      </div>
+
+      <!-- Infinite scroll sentinel + loading indicator -->
+      <div ref="sentinel" class="h-4" />
+      <div v-if="isFetchingNextPage" class="flex justify-center py-6">
+        <span class="loading loading-spinner loading-md text-warning" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Implement pagination and full-text search on the wishlist endpoint, with infinite scroll on the frontend. The wishlist now returns paginated results (20 items per page) and supports filtering by manga title.

## Key Changes

**Backend:**
- Modified `GetWishlistQuery` to extend `AbstractPaginatedQuery` with optional `search` parameter
- Renamed `findWithWishedVolumes()` → `findWishedFiltered()` in `CollectionRepositoryInterface` and its Doctrine implementation
- Updated query to use `EXISTS` subquery (prevents join fan-out) and adds `LIKE` search on manga title when provided
- Created `WishlistPaginatedResult` VO extending `PaginatedResult<CollectionEntry>` to serialize paginated results
- Updated `GetWishlistHandler` to return paginated shape: `{items, total, page, limit}`
- Added `WishlistFilterRequest` DTO with validation for `search` (optional) and `page` (positive, default 1)
- Updated `WishlistController::list()` to accept and map query parameters via `#[MapQueryString]`

**Frontend:**
- Replaced `useQuery` with `useInfiniteQuery` for automatic pagination support
- Added debounced search input (300ms) that resets pagination when search term changes
- Implemented `IntersectionObserver` sentinel pattern for infinite scroll triggering
- Updated computed properties: `entries` now flattens paginated results, `totalSeries` reflects actual total count
- Added search UI with clear button and empty state messaging for no results
- Proper cleanup of debounce timer and observer on unmount

**Tests:**
- Updated `testListReturnsPaginatedShape()` to verify response structure: `items`, `total`, `page`, `limit`
- Updated existing tests to access `data['items']` instead of treating response as direct array
- Added `testListFiltersBySearch()` to verify title-based filtering works correctly
- Added `testListSearchWithNoMatchReturnsEmpty()` to verify empty result handling

## Implementation Details
- Search is case-insensitive via `LOWER()` in the query
- Pagination uses offset/limit pattern with total count for client-side `hasNextPage` calculation
- `getNextPageParam` returns `undefined` when all items are fetched, stopping further requests
- Empty state distinguishes between "no wishlist items" and "no search results"
- All cleanup (timers, observers) happens in `onUnmounted` to prevent memory leaks

https://claude.ai/code/session_017op8KRU5obAKdjudpWsZ7o