### PR TITLE
Add on-demand manga summary translation (EN → FR)

### DIFF
--- a/back/.env
+++ b/back/.env
@@ -37,6 +37,8 @@ MANGADEX_BASE_URL=https://api.mangadex.org
 OPEN_LIBRARY_COVERS_BASE_URL=https://covers.openlibrary.org
 GOOGLE_BOOKS_WEB_BASE_URL=https://books.google.com
 BNF_BASE_URL=https://catalogue.bnf.fr
+# Keyless Google translation endpoint — used to translate manga summaries EN → FR.
+GOOGLE_TRANSLATE_BASE_URL=https://translate.googleapis.com
 # Hardcover (community DB) — optional ISBN cover source. Leave empty to disable;
 # set a personal Bearer token (account settings → Hardcover API) to enable.
 HARDCOVER_BASE_URL=https://api.hardcover.app/v1/graphql

--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -184,6 +184,14 @@ services:
         arguments:
             $apiKey: '%env(GOOGLE_BOOKS_API_KEY)%'
 
+    # Keyless summary translation (Google "gtx" web endpoint) — English → French.
+    App\Manga\Domain\SummaryTranslatorInterface:
+        alias: App\Manga\Infrastructure\Translation\GoogleTranslateSummaryTranslator
+
+    App\Manga\Infrastructure\Translation\GoogleTranslateSummaryTranslator:
+        arguments:
+            $baseUrl: '%env(GOOGLE_TRANSLATE_BASE_URL)%'
+
     App\Collection\Domain\CollectionRepositoryInterface:
         alias: App\Collection\Infrastructure\Doctrine\DoctrineCollectionRepository
 
@@ -274,6 +282,8 @@ when@test:
     services:
         App\Manga\Domain\ExternalApiClientInterface:
             alias: App\Manga\Infrastructure\ExternalApi\NullMangaApiClient
+        App\Manga\Domain\SummaryTranslatorInterface:
+            alias: App\Manga\Infrastructure\Translation\NullSummaryTranslator
         App\Manga\Application\SearchExternal\SearchExternalMangaHandler:
             autowire: true
             autoconfigure: true

--- a/back/src/Manga/Application/TranslateSummary/TranslateSummaryHandler.php
+++ b/back/src/Manga/Application/TranslateSummary/TranslateSummaryHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\TranslateSummary;
+
+use App\Manga\Domain\SummaryTranslatorInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'query.bus')]
+final readonly class TranslateSummaryHandler
+{
+    /** Source/target are fixed: only English → French is supported for now. */
+    private const SOURCE_LANGUAGE = 'en';
+    private const TARGET_LANGUAGE = 'fr';
+
+    public function __construct(private SummaryTranslatorInterface $translator)
+    {
+    }
+
+    /** @return array{translated: string} */
+    public function __invoke(TranslateSummaryQuery $query): array
+    {
+        $translated = $this->translator->translate(
+            $query->text,
+            self::SOURCE_LANGUAGE,
+            self::TARGET_LANGUAGE,
+        );
+
+        return ['translated' => $translated];
+    }
+}

--- a/back/src/Manga/Application/TranslateSummary/TranslateSummaryQuery.php
+++ b/back/src/Manga/Application/TranslateSummary/TranslateSummaryQuery.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\TranslateSummary;
+
+/**
+ * Asks for a manga summary to be translated into French.
+ *
+ * Only English → French is supported for now (see CLAUDE.md / feature scope),
+ * so the languages are fixed by the handler rather than carried on the query.
+ */
+final readonly class TranslateSummaryQuery
+{
+    public function __construct(public string $text)
+    {
+    }
+}

--- a/back/src/Manga/Domain/SummaryTranslatorInterface.php
+++ b/back/src/Manga/Domain/SummaryTranslatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+/**
+ * Translates free-text manga summaries from one language to another.
+ *
+ * Implementations call an external translation service; the application layer
+ * stays agnostic of the provider.
+ */
+interface SummaryTranslatorInterface
+{
+    /**
+     * Returns $text translated into $targetLanguage. Both language codes are
+     * ISO 639-1 (e.g. "en", "fr").
+     */
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage): string;
+}

--- a/back/src/Manga/Infrastructure/Http/MangaController.php
+++ b/back/src/Manga/Infrastructure/Http/MangaController.php
@@ -12,6 +12,7 @@ use App\Manga\Application\Import\ImportMangaCommand;
 use App\Manga\Application\Search\SearchMangaQuery;
 use App\Manga\Application\SearchExternal\SearchExternalMangaQuery;
 use App\Manga\Application\SearchVolumeExternal\SearchVolumeExternalQuery;
+use App\Manga\Application\TranslateSummary\TranslateSummaryQuery;
 use App\Manga\Application\Update\UpdateMangaCommand;
 use App\Manga\Application\UpdateVolume\UpdateVolumeCommand;
 use App\Shared\Application\Bus\CommandBusInterface;
@@ -78,6 +79,13 @@ final readonly class MangaController
             edition: $edition,
             provider: $provider,
         )));
+    }
+
+    /** Translate a manga summary into French (English → French for now). */
+    #[Route('/translate-summary', methods: ['POST'])]
+    public function translateSummary(#[MapRequestPayload] TranslateSummaryRequest $request): JsonResponse
+    {
+        return new JsonResponse($this->queryBus->ask(new TranslateSummaryQuery($request->text)));
     }
 
     #[Route('/{id}', methods: ['GET'])]

--- a/back/src/Manga/Infrastructure/Http/TranslateSummaryRequest.php
+++ b/back/src/Manga/Infrastructure/Http/TranslateSummaryRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Http;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class TranslateSummaryRequest
+{
+    public function __construct(
+        #[Assert\NotBlank]
+        public string $text,
+    ) {
+    }
+}

--- a/back/src/Manga/Infrastructure/Translation/GoogleTranslateSummaryTranslator.php
+++ b/back/src/Manga/Infrastructure/Translation/GoogleTranslateSummaryTranslator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Translation;
+
+use App\Manga\Domain\SummaryTranslatorInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Translates summaries via Google's keyless "gtx" web endpoint, mirroring the
+ * project's other keyless providers (BnF, OpenLibrary). No API key required.
+ *
+ * The endpoint answers with a nested JSON array where the first element holds
+ * the translated segments: [[["traduit","source",...], ...], ...].
+ */
+final readonly class GoogleTranslateSummaryTranslator implements SummaryTranslatorInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+        private string $baseUrl,
+    ) {
+    }
+
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage): string
+    {
+        if (trim($text) === '') {
+            return $text;
+        }
+
+        $this->logger->info('GoogleTranslate: translating summary', [
+            'source' => $sourceLanguage,
+            'target' => $targetLanguage,
+            'length' => mb_strlen($text),
+        ]);
+
+        try {
+            $response = $this->httpClient->request('GET', rtrim($this->baseUrl, '/') . '/translate_a/single', [
+                'query' => [
+                    'client' => 'gtx',
+                    'sl'     => $sourceLanguage,
+                    'tl'     => $targetLanguage,
+                    'dt'     => 't',
+                    'q'      => $text,
+                ],
+            ]);
+
+            $data     = $response->toArray();
+            $segments = $data[0] ?? [];
+
+            $translated = '';
+            foreach ($segments as $segment) {
+                $translated .= $segment[0] ?? '';
+            }
+
+            // Fall back to the original text if the response carried no translation.
+            return $translated !== '' ? $translated : $text;
+        } catch (Throwable $exception) {
+            $this->logger->error('GoogleTranslate: translation failed', ['error' => $exception->getMessage()]);
+            throw $exception;
+        }
+    }
+}

--- a/back/src/Manga/Infrastructure/Translation/NullSummaryTranslator.php
+++ b/back/src/Manga/Infrastructure/Translation/NullSummaryTranslator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Translation;
+
+use App\Manga\Domain\SummaryTranslatorInterface;
+
+/** No-op stub used in tests to avoid real HTTP calls; echoes the input back. */
+final readonly class NullSummaryTranslator implements SummaryTranslatorInterface
+{
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage): string
+    {
+        return $text;
+    }
+}

--- a/back/tests/Functional/Manga/MangaControllerTest.php
+++ b/back/tests/Functional/Manga/MangaControllerTest.php
@@ -326,4 +326,29 @@ final class MangaControllerTest extends AbstractApiTestCase
         $this->assertSame(2, $completedEvent->failed);
         $this->assertSame(0, $completedEvent->resolved);
     }
+
+    // ── POST /api/manga/translate-summary ─────────────────────────────────────
+
+    public function testTranslateSummaryRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/manga/translate-summary', ['text' => 'Pirates.'], auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testTranslateSummaryReturnsTranslatedText(): void
+    {
+        // The test translator (NullSummaryTranslator) echoes the input back, so the
+        // assertion proves the endpoint → query bus → handler → translator wiring.
+        $response = $this->jsonRequest('POST', '/api/manga/translate-summary', ['text' => 'A pirate story.']);
+        $data     = $this->assertJsonStatus(200, $response);
+
+        $this->assertArrayHasKey('translated', $data);
+        $this->assertSame('A pirate story.', $data['translated']);
+    }
+
+    public function testTranslateSummaryRejectsBlankText(): void
+    {
+        $response = $this->jsonRequest('POST', '/api/manga/translate-summary', ['text' => '']);
+        $this->assertSame(422, $response->getStatusCode());
+    }
 }

--- a/back/tests/Unit/Manga/Infrastructure/GoogleTranslateSummaryTranslatorTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/GoogleTranslateSummaryTranslatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure;
+
+use App\Manga\Infrastructure\Translation\GoogleTranslateSummaryTranslator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class GoogleTranslateSummaryTranslatorTest extends TestCase
+{
+    private function makeTranslator(MockHttpClient $httpClient): GoogleTranslateSummaryTranslator
+    {
+        return new GoogleTranslateSummaryTranslator($httpClient, new NullLogger(), 'https://translate.googleapis.com');
+    }
+
+    public function testTranslateSendsLanguagesAndTextAndJoinsSegments(): void
+    {
+        $capturedUrl = null;
+        $httpClient  = new MockHttpClient(function (string $method, string $url) use (&$capturedUrl): MockResponse {
+            $capturedUrl = $url;
+
+            // Google's nested shape: [[[segmentFr, segmentEn, ...], ...], ...]
+            return new MockResponse((string) json_encode([
+                [
+                    ['Bonjour le monde. ', 'Hello world. '],
+                    ['Une histoire de pirates.', 'A pirate story.'],
+                ],
+                null,
+                'en',
+            ]));
+        });
+
+        $result = $this->makeTranslator($httpClient)->translate('Hello world. A pirate story.', 'en', 'fr');
+
+        $this->assertSame('Bonjour le monde. Une histoire de pirates.', $result);
+        $this->assertNotNull($capturedUrl);
+        $this->assertStringContainsString('/translate_a/single', $capturedUrl);
+        $this->assertStringContainsString('client=gtx', $capturedUrl);
+        $this->assertStringContainsString('sl=en', $capturedUrl);
+        $this->assertStringContainsString('tl=fr', $capturedUrl);
+    }
+
+    public function testTranslateReturnsBlankTextUnchangedWithoutCallingApi(): void
+    {
+        $called     = false;
+        $httpClient = new MockHttpClient(function () use (&$called): MockResponse {
+            $called = true;
+
+            return new MockResponse('[]');
+        });
+
+        $result = $this->makeTranslator($httpClient)->translate('   ', 'en', 'fr');
+
+        $this->assertSame('   ', $result);
+        $this->assertFalse($called);
+    }
+
+    public function testTranslateFallsBackToOriginalWhenResponseHasNoTranslation(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([null, null, 'en'])),
+        ]);
+
+        $result = $this->makeTranslator($httpClient)->translate('Untranslatable', 'en', 'fr');
+
+        $this->assertSame('Untranslatable', $result);
+    }
+}

--- a/front/src/api/manga.ts
+++ b/front/src/api/manga.ts
@@ -11,6 +11,12 @@ export async function getManga(id: string): Promise<MangaDetail> {
   return res.data
 }
 
+/** Translate a summary into French (English → French for now). */
+export async function translateSummary(text: string): Promise<string> {
+  const res = await client.post('/manga/translate-summary', { text })
+  return res.data.translated
+}
+
 export async function importManga(payload: {
   title: string
   language: string

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -77,7 +77,10 @@
     "genre": "Genre",
     "coverUrl": "Cover URL",
     "summary": "Summary",
-    "totalVolumes": "Total volumes"
+    "totalVolumes": "Total volumes",
+    "translate": "Translate to French",
+    "showOriginal": "Show original",
+    "translateError": "Translation failed"
   },
   "volume": {
     "price": "Price (€)",

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -77,7 +77,10 @@
     "genre": "Genre",
     "coverUrl": "URL de couverture",
     "summary": "Résumé",
-    "totalVolumes": "Nombre de tomes"
+    "totalVolumes": "Nombre de tomes",
+    "translate": "Traduire en français",
+    "showOriginal": "Voir l'original",
+    "translateError": "La traduction a échoué"
   },
   "volume": {
     "price": "Prix (€)",

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
-  ArrowLeft, Star, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info, Bell, BellOff, Plus, Sparkles, HelpCircle,
+  ArrowLeft, Star, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info, Bell, BellOff, Plus, Sparkles, HelpCircle, Languages,
 } from 'lucide-vue-next'
 import {
   getCollectionEntry,
@@ -16,7 +16,7 @@ import {
   updateCollectionRating,
   toggleFollow,
 } from '@/api/collection'
-import { updateManga, autoFillCovers } from '@/api/manga'
+import { updateManga, autoFillCovers, translateSummary } from '@/api/manga'
 import { useCoverBatchProgress } from '@/composables/useCoverBatchProgress'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
@@ -50,6 +50,38 @@ const sortedVolumes = computed<VolumeEntry[]>(() =>
 )
 
 const missingVolumes = computed(() => sortedVolumes.value.filter((v) => !v.isOwned && !v.isWished))
+
+// ── Summary translation (EN → FR, on demand) ──
+const showTranslation = ref(false)
+const translatedSummary = ref<string | null>(null)
+
+const translateMutation = useMutation({
+  mutationFn: (text: string) => translateSummary(text),
+  onSuccess: (text) => {
+    translatedSummary.value = text
+    showTranslation.value = true
+  },
+  onError: () => ui.addToast(t('manga.translateError'), 'error'),
+})
+
+const displayedSummary = computed(() =>
+  showTranslation.value && translatedSummary.value
+    ? translatedSummary.value
+    : entry.value?.manga.summary ?? '',
+)
+
+function toggleTranslation() {
+  if (showTranslation.value) {
+    showTranslation.value = false
+    return
+  }
+  if (translatedSummary.value) {
+    showTranslation.value = true
+    return
+  }
+  const summary = entry.value?.manga.summary
+  if (summary) translateMutation.mutate(summary)
+}
 
 // ── Modal state ──
 const modalVolumeId = ref<string | null>(null)
@@ -766,9 +798,20 @@ function volumeOpacityClass(ve: VolumeEntry): string {
             </div>
           </div>
 
-          <p v-if="entry.manga.summary" class="mt-4 text-sm text-base-content/60 line-clamp-3 max-w-2xl">
-            {{ entry.manga.summary }}
-          </p>
+          <div v-if="entry.manga.summary" class="mt-4 max-w-2xl">
+            <p class="text-sm text-base-content/60 line-clamp-3">
+              {{ displayedSummary }}
+            </p>
+            <button
+              class="btn btn-ghost btn-xs gap-1 mt-1 px-1 text-base-content/50 hover:text-base-content"
+              :class="{ loading: translateMutation.isPending.value }"
+              :disabled="translateMutation.isPending.value"
+              @click="toggleTranslation"
+            >
+              <Languages v-if="!translateMutation.isPending.value" class="h-3 w-3" />
+              {{ showTranslation ? t('manga.showOriginal') : t('manga.translate') }}
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Adds a new feature to translate manga summaries from English to French on demand via Google's keyless "gtx" web endpoint. Users can toggle between the original and translated summary on the manga detail page.

## Changes

### Backend
- **Domain layer**: New `SummaryTranslatorInterface` abstraction for translation providers
- **Application layer**: `TranslateSummaryQuery` and `TranslateSummaryHandler` implement the CQRS query pattern (fixed EN → FR)
- **Infrastructure layer**:
  - `GoogleTranslateSummaryTranslator`: Calls Google's `/translate_a/single` endpoint, parses nested JSON response, joins segments, falls back to original on empty translation
  - `NullSummaryTranslator`: Test stub that echoes input (used in test environment via `config/services.yaml`)
  - `TranslateSummaryRequest`: DTO with `#[Assert\NotBlank]` validation
  - `MangaController::translateSummary()`: New POST endpoint at `/api/manga/translate-summary`
- **Configuration**: Service binding in `config/services.yaml` + test override; new `GOOGLE_TRANSLATE_BASE_URL` env var
- **Tests**:
  - Unit test (`GoogleTranslateSummaryTranslatorTest`): Verifies URL construction, segment joining, blank text bypass, fallback on missing translation
  - Functional tests (`MangaControllerTest`): Auth requirement, success response shape, blank text rejection (422)

### Frontend
- **API layer** (`api/manga.ts`): New `translateSummary(text)` function
- **Page component** (`MangaDetailPage.vue`):
  - New state: `showTranslation`, `translatedSummary`, `displayedSummary` computed
  - `translateMutation` via `useMutation` with error toast
  - `toggleTranslation()` function: lazy-loads translation on first click, toggles display on subsequent clicks
  - UI: Languages icon button below summary, loading state, i18n labels
- **i18n**: Added `manga.translate`, `manga.showOriginal`, `manga.translateError` keys in both EN and FR

## Implementation Details
- **Keyless provider**: No API key required; mirrors the project's existing keyless approach (BnF, OpenLibrary)
- **Lazy loading**: Translation only fetched when user clicks the button
- **Graceful fallback**: If Google returns no translation, original text is returned
- **Error handling**: Translation errors logged and surfaced as toast; exceptions propagate
- **Test isolation**: `NullSummaryTranslator` prevents real HTTP calls in test environment
- **Validation**: Blank text rejected at request level (422) and skipped at translator level (no API call)

https://claude.ai/code/session_01BADi9ZAsWBVGpMQDFFrjkA