### PR TITLE
feat(3d): rendu 3D d'un tome à la demande (tranche, 1ère et 4e de cou…

### DIFF
--- a/back/.env
+++ b/back/.env
@@ -65,3 +65,21 @@ MAILER_DSN=smtp://mailer:1025
 NOTIFICATION_EMAIL=you@example.com
 ###< mailer ###
 DISCORD_WEBHOOK_URL=replace_here
+
+###> symfony/resend-mailer ###
+# MAILER_DSN=resend+api://API_KEY@default
+# MAILER_DSN=resend+smtp://resend:API_KEY@default
+###< symfony/resend-mailer ###
+
+###> volume face storage (real photos for the 3D render) ###
+# Dev: face photos are written under public/uploads and served from this base path.
+UPLOADS_PUBLIC_BASE_URL=/uploads
+# Prod (Railway S3-compatible object storage). Leave blank in dev — the local disk
+# adapter is used unless APP_ENV=prod, which switches the alias to S3ImageStorage.
+S3_ENDPOINT=
+S3_REGION=auto
+S3_BUCKET=
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_PUBLIC_BASE_URL=
+###< volume face storage ###

--- a/back/composer.json
+++ b/back/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "async-aws/s3": "^3.3",
         "doctrine/doctrine-bundle": "^3.2",
         "doctrine/doctrine-migrations-bundle": "^4.0",
         "doctrine/orm": "^3.6",

--- a/back/composer.lock
+++ b/back/composer.lock
@@ -4,8 +4,145 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd1400fba2402adbba70f4b556462ace",
+    "content-hash": "3f079710b4dc95440485a1f4c8c1e869",
     "packages": [
+        {
+            "name": "async-aws/core",
+            "version": "1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/core.git",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/core/zipball/70899695fcc7b23a9247926ff8b581668583b993",
+                "reference": "70899695fcc7b23a9247926ff8b581668583b993",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+                "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "async-aws/s3": "<1.1",
+                "symfony/http-client": "5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.29-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core package to integrate with AWS. This is a lightweight AWS SDK provider by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "sts"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/core/tree/1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-18T17:06:10+00:00"
+        },
+        {
+            "name": "async-aws/s3",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/s3.git",
+                "reference": "26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/s3/zipball/26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3",
+                "reference": "26bf7e498df4fd135fb2c32cbaa5ba92c0615fa3",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.22",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\S3\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "S3 client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/s3/tree/3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-29T10:05:33+00:00"
+        },
         {
             "name": "doctrine/collections",
             "version": "2.6.0",

--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -292,6 +292,32 @@ services:
             $publisherJwtKey: '%env(MERCURE_PUBLISHER_JWT_KEY)%'
             $logger: '@logger'
 
+    # ── Volume face image storage (real photos for the 3D render) ──
+    # Default (dev/single host): local disk under public/. Prod swaps to S3 below.
+    App\Manga\Domain\Storage\ImageStorageInterface:
+        alias: App\Manga\Infrastructure\Storage\LocalImageStorage
+
+    App\Manga\Infrastructure\Storage\LocalImageStorage:
+        arguments:
+            $uploadsDir: '%kernel.project_dir%/public/uploads'
+            $publicBaseUrl: '%env(UPLOADS_PUBLIC_BASE_URL)%'
+
+    App\Manga\Infrastructure\Storage\S3ImageStorage:
+        arguments:
+            $client: '@app.s3_client.volume_faces'
+            $bucket: '%env(S3_BUCKET)%'
+            $publicBaseUrl: '%env(S3_PUBLIC_BASE_URL)%'
+
+    app.s3_client.volume_faces:
+        class: AsyncAws\S3\S3Client
+        arguments:
+            $configuration:
+                endpoint: '%env(S3_ENDPOINT)%'
+                accessKeyId: '%env(S3_ACCESS_KEY)%'
+                accessKeySecret: '%env(S3_SECRET_KEY)%'
+                region: '%env(S3_REGION)%'
+                pathStyleEndpoint: true
+
 when@test:
     services:
         App\Manga\Domain\ExternalApiClientInterface:
@@ -330,3 +356,12 @@ when@test:
             alias: App\Tests\Doubles\Manga\InMemoryScanResultPublisher
         App\Tests\Doubles\Manga\InMemoryScanResultPublisher:
             public: true
+        App\Manga\Domain\Storage\ImageStorageInterface:
+            alias: App\Tests\Doubles\Manga\InMemoryImageStorage
+        App\Tests\Doubles\Manga\InMemoryImageStorage:
+            public: true
+
+when@prod:
+    services:
+        App\Manga\Domain\Storage\ImageStorageInterface:
+            alias: App\Manga\Infrastructure\Storage\S3ImageStorage

--- a/back/migrations/Version20260604200000.php
+++ b/back/migrations/Version20260604200000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260604200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add back_cover_url nullable column to volumes table (4th-cover texture for 3D render)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE volumes ADD back_cover_url VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE volumes DROP COLUMN back_cover_url');
+    }
+}

--- a/back/src/Collection/Application/GetShelf/GetShelfHandler.php
+++ b/back/src/Collection/Application/GetShelf/GetShelfHandler.php
@@ -49,6 +49,7 @@ final readonly class GetShelfHandler
                         'number'   => $volumeEntry->volume->number,
                         'coverUrl' => $volumeEntry->volume->coverUrl,
                         'spineUrl' => $volumeEntry->volume->spineUrl,
+                        'backCoverUrl' => $volumeEntry->volume->backCoverUrl,
                     ],
                     $ownedVolumes,
                 ),

--- a/back/src/Collection/Domain/VolumeEntry.php
+++ b/back/src/Collection/Domain/VolumeEntry.php
@@ -54,6 +54,7 @@ class VolumeEntry
             'rating' => $this->rating,
             'isbn' => $this->volume->isbn?->value,
             'spineUrl' => $this->volume->spineUrl,
+            'backCoverUrl' => $this->volume->backCoverUrl,
         ];
     }
 }

--- a/back/src/Manga/Application/UpdateVolume/UpdateVolumeCommand.php
+++ b/back/src/Manga/Application/UpdateVolume/UpdateVolumeCommand.php
@@ -13,6 +13,7 @@ final readonly class UpdateVolumeCommand
         public ?string $releaseDate = null,
         public ?float $price = null,
         public ?string $spineUrl = null,
+        public ?string $backCoverUrl = null,
         public ?string $isbn = null,
     ) {
     }

--- a/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
+++ b/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
@@ -56,6 +56,10 @@ final readonly class UpdateVolumeHandler
                 $volume->spineUrl = $command->spineUrl;
             }
 
+            if ($command->backCoverUrl !== null) {
+                $volume->backCoverUrl = $command->backCoverUrl;
+            }
+
             if ($command->isbn !== null) {
                 $volume->isbn = Isbn::fromString($command->isbn);
             }

--- a/back/src/Manga/Application/UploadVolumeFace/UploadVolumeFaceCommand.php
+++ b/back/src/Manga/Application/UploadVolumeFace/UploadVolumeFaceCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\UploadVolumeFace;
+
+use App\Manga\Domain\VolumeFace;
+
+final readonly class UploadVolumeFaceCommand
+{
+    public function __construct(
+        public string $mangaId,
+        public string $volumeId,
+        public VolumeFace $face,
+        public string $imageBase64,
+        public string $contentType,
+    ) {
+    }
+}

--- a/back/src/Manga/Application/UploadVolumeFace/UploadVolumeFaceHandler.php
+++ b/back/src/Manga/Application/UploadVolumeFace/UploadVolumeFaceHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Application\UploadVolumeFace;
+
+use App\Manga\Domain\MangaRepositoryInterface;
+use App\Manga\Domain\Storage\ImageStorageInterface;
+use App\Manga\Domain\Volume;
+use App\Manga\Domain\VolumeFace;
+use App\Shared\Domain\Exception\NotFoundException;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'command.bus')]
+final readonly class UploadVolumeFaceHandler
+{
+    public function __construct(
+        private MangaRepositoryInterface $mangaRepository,
+        private ImageStorageInterface $imageStorage,
+    ) {
+    }
+
+    public function __invoke(UploadVolumeFaceCommand $command): void
+    {
+        $manga = $this->mangaRepository->findById($command->mangaId);
+
+        if ($manga === null) {
+            throw new NotFoundException('Manga', $command->mangaId);
+        }
+
+        $volume = $manga->volumes
+            ->filter(fn (Volume $volume) => $volume->id === $command->volumeId)
+            ->first();
+
+        if ($volume === false) {
+            throw new NotFoundException('Volume', $command->volumeId);
+        }
+
+        $binary = base64_decode($this->stripDataUrlPrefix($command->imageBase64), true);
+
+        if ($binary === false || $binary === '') {
+            throw new RuntimeException('Invalid base64 image payload.');
+        }
+
+        $key = sprintf(
+            'volume-faces/%s-%s-%s.%s',
+            $command->volumeId,
+            $command->face->value,
+            bin2hex(random_bytes(4)),
+            $this->extensionFor($command->contentType),
+        );
+
+        $url = $this->imageStorage->store($key, $binary, $command->contentType);
+
+        if ($command->face === VolumeFace::Cover) {
+            $volume->coverUrl = $url;
+        } elseif ($command->face === VolumeFace::Spine) {
+            $volume->spineUrl = $url;
+        } else {
+            $volume->backCoverUrl = $url;
+        }
+
+        $this->mangaRepository->save($manga);
+    }
+
+    private function stripDataUrlPrefix(string $payload): string
+    {
+        if (str_starts_with($payload, 'data:')) {
+            $comma = strpos($payload, ',');
+            if ($comma !== false) {
+                return substr($payload, $comma + 1);
+            }
+        }
+
+        return $payload;
+    }
+
+    private function extensionFor(string $contentType): string
+    {
+        return match ($contentType) {
+            'image/png' => 'png',
+            'image/webp' => 'webp',
+            'image/avif' => 'avif',
+            default => 'jpg',
+        };
+    }
+}

--- a/back/src/Manga/Domain/Storage/ImageStorageInterface.php
+++ b/back/src/Manga/Domain/Storage/ImageStorageInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain\Storage;
+
+interface ImageStorageInterface
+{
+    /**
+     * Persist a binary image under $key and return its public URL.
+     */
+    public function store(string $key, string $binary, string $contentType): string;
+}

--- a/back/src/Manga/Domain/Volume.php
+++ b/back/src/Manga/Domain/Volume.php
@@ -32,6 +32,8 @@ class Volume
         public ?Isbn $isbn = null,
         #[ORM\Column(nullable: true)]
         public ?string $spineUrl = null,
+        #[ORM\Column(nullable: true)]
+        public ?string $backCoverUrl = null,
     ) {
     }
 
@@ -46,6 +48,7 @@ class Volume
             'releaseDate' => $this->releaseDate?->format(DateTimeInterface::ATOM),
             'isbn' => $this->isbn?->value,
             'spineUrl' => $this->spineUrl,
+            'backCoverUrl' => $this->backCoverUrl,
         ];
     }
 }

--- a/back/src/Manga/Domain/VolumeFace.php
+++ b/back/src/Manga/Domain/VolumeFace.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+enum VolumeFace: string
+{
+    case Cover = 'cover';
+    case Spine = 'spine';
+    case Back = 'back';
+}

--- a/back/src/Manga/Infrastructure/Http/MangaController.php
+++ b/back/src/Manga/Infrastructure/Http/MangaController.php
@@ -15,6 +15,8 @@ use App\Manga\Application\SearchVolumeExternal\SearchVolumeExternalQuery;
 use App\Manga\Application\TranslateSummary\TranslateSummaryQuery;
 use App\Manga\Application\Update\UpdateMangaCommand;
 use App\Manga\Application\UpdateVolume\UpdateVolumeCommand;
+use App\Manga\Application\UploadVolumeFace\UploadVolumeFaceCommand;
+use App\Manga\Domain\VolumeFace;
 use App\Shared\Application\Bus\CommandBusInterface;
 use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -151,7 +153,25 @@ final readonly class MangaController
             releaseDate: $request->releaseDate,
             price: $request->price,
             spineUrl: $request->spineUrl,
+            backCoverUrl: $request->backCoverUrl,
             isbn: $request->isbn,
+        ));
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/{id}/volumes/{volumeId}/face', methods: ['POST'])]
+    public function uploadVolumeFace(
+        string $id,
+        string $volumeId,
+        #[MapRequestPayload] UploadVolumeFaceRequest $request,
+    ): JsonResponse {
+        $this->commandBus->dispatch(new UploadVolumeFaceCommand(
+            mangaId: $id,
+            volumeId: $volumeId,
+            face: VolumeFace::from($request->face),
+            imageBase64: $request->image,
+            contentType: $request->contentType,
         ));
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
+++ b/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
@@ -14,6 +14,7 @@ final readonly class UpdateVolumeRequest
         #[Assert\PositiveOrZero]
         public ?float $price = null,
         public ?string $spineUrl = null,
+        public ?string $backCoverUrl = null,
         public ?string $isbn = null,
     ) {
     }

--- a/back/src/Manga/Infrastructure/Http/UploadVolumeFaceRequest.php
+++ b/back/src/Manga/Infrastructure/Http/UploadVolumeFaceRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Http;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class UploadVolumeFaceRequest
+{
+    public function __construct(
+        #[Assert\Choice(choices: ['cover', 'spine', 'back'])]
+        public string $face = '',
+        #[Assert\NotBlank]
+        public string $image = '',
+        public string $contentType = 'image/jpeg',
+    ) {
+    }
+}

--- a/back/src/Manga/Infrastructure/Storage/LocalImageStorage.php
+++ b/back/src/Manga/Infrastructure/Storage/LocalImageStorage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Storage;
+
+use App\Manga\Domain\Storage\ImageStorageInterface;
+use RuntimeException;
+
+/**
+ * Dev / single-host adapter: writes under public/ and returns a path-based URL.
+ * Production uses S3ImageStorage (Railway bucket), wired via when@prod in services.yaml.
+ */
+final readonly class LocalImageStorage implements ImageStorageInterface
+{
+    public function __construct(
+        private string $uploadsDir,
+        private string $publicBaseUrl,
+    ) {
+    }
+
+    public function store(string $key, string $binary, string $contentType): string
+    {
+        $path = $this->uploadsDir . '/' . $key;
+        $directory = dirname($path);
+
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Unable to create upload directory: ' . $directory);
+        }
+
+        if (file_put_contents($path, $binary) === false) {
+            throw new RuntimeException('Unable to write upload: ' . $path);
+        }
+
+        return rtrim($this->publicBaseUrl, '/') . '/' . $key;
+    }
+}

--- a/back/src/Manga/Infrastructure/Storage/S3ImageStorage.php
+++ b/back/src/Manga/Infrastructure/Storage/S3ImageStorage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Storage;
+
+use App\Manga\Domain\Storage\ImageStorageInterface;
+use AsyncAws\S3\S3Client;
+
+/**
+ * Production adapter: stores volume-face photos in an S3-compatible bucket
+ * (Railway object storage) and returns their public URL.
+ */
+final readonly class S3ImageStorage implements ImageStorageInterface
+{
+    public function __construct(
+        private S3Client $client,
+        private string $bucket,
+        private string $publicBaseUrl,
+    ) {
+    }
+
+    public function store(string $key, string $binary, string $contentType): string
+    {
+        $this->client->putObject([
+            'Bucket' => $this->bucket,
+            'Key' => $key,
+            'Body' => $binary,
+            'ContentType' => $contentType,
+        ])->resolve();
+
+        return rtrim($this->publicBaseUrl, '/') . '/' . $key;
+    }
+}

--- a/back/symfony.lock
+++ b/back/symfony.lock
@@ -214,6 +214,15 @@
             "config/packages/property_info.yaml"
         ]
     },
+    "symfony/resend-mailer": {
+        "version": "8.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.1",
+            "ref": "487735bc20cbd1547ec311692ef0261a7687a3f0"
+        }
+    },
     "symfony/routing": {
         "version": "8.0",
         "recipe": {

--- a/back/tests/Doubles/Manga/InMemoryImageStorage.php
+++ b/back/tests/Doubles/Manga/InMemoryImageStorage.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Doubles\Manga;
+
+use App\Manga\Domain\Storage\ImageStorageInterface;
+
+final class InMemoryImageStorage implements ImageStorageInterface
+{
+    /** @var array<string, string> key => binary */
+    public array $stored = [];
+
+    public function store(string $key, string $binary, string $contentType): string
+    {
+        $this->stored[$key] = $binary;
+
+        return 'https://storage.test/' . $key;
+    }
+}

--- a/back/tests/Functional/Collection/ShelfControllerTest.php
+++ b/back/tests/Functional/Collection/ShelfControllerTest.php
@@ -72,6 +72,8 @@ final class ShelfControllerTest extends AbstractApiTestCase
         $this->assertArrayHasKey('coverUrl', $entry['manga']);
         $this->assertArrayHasKey('number', $entry['volumes'][0]);
         $this->assertArrayHasKey('coverUrl', $entry['volumes'][0]);
+        $this->assertArrayHasKey('spineUrl', $entry['volumes'][0]);
+        $this->assertArrayHasKey('backCoverUrl', $entry['volumes'][0]);
     }
 
     public function testShelfExcludesEntriesWithNoOwnedVolumes(): void

--- a/back/tests/Functional/Manga/MangaControllerTest.php
+++ b/back/tests/Functional/Manga/MangaControllerTest.php
@@ -176,13 +176,14 @@ final class MangaControllerTest extends AbstractApiTestCase
         $response = $this->jsonRequest(
             'PATCH',
             '/api/manga/' . $mangaId . '/volumes/' . $volumeId,
-            ['price' => 7.99, 'isbn' => '9782811645632'],
+            ['price' => 7.99, 'isbn' => '9782811645632', 'backCoverUrl' => 'https://example.com/back.jpg'],
         );
         $this->assertSame(204, $response->getStatusCode());
 
         $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
         $volume = $detail['volumes'][0];
         $this->assertSame('9782811645632', $volume['isbn']);
+        $this->assertSame('https://example.com/back.jpg', $volume['backCoverUrl']);
     }
 
     public function testUpdateVolumeRejectsInvalidIsbn(): void

--- a/back/tests/Functional/Manga/VolumeFaceUploadControllerTest.php
+++ b/back/tests/Functional/Manga/VolumeFaceUploadControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Manga;
+
+use App\Tests\Functional\AbstractApiTestCase;
+
+final class VolumeFaceUploadControllerTest extends AbstractApiTestCase
+{
+    private const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC';
+
+    /** @return array{string, string} [mangaId, volumeId] */
+    private function createMangaWithVolume(): array
+    {
+        $manga = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga',
+            ['title' => 'Face Manga', 'language' => 'fr'],
+        ));
+        $volume = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga/' . $manga['id'] . '/volumes',
+            ['number' => 1],
+        ));
+
+        return [(string) $manga['id'], (string) $volume['id']];
+    }
+
+    public function testUploadsBackCoverFace(): void
+    {
+        [$mangaId, $volumeId] = $this->createMangaWithVolume();
+
+        $response = $this->jsonRequest('POST', "/api/manga/{$mangaId}/volumes/{$volumeId}/face", [
+            'face' => 'back',
+            'image' => self::PNG_1X1,
+            'contentType' => 'image/png',
+        ]);
+        $this->assertSame(204, $response->getStatusCode());
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
+        $this->assertNotNull($detail['volumes'][0]['backCoverUrl']);
+        $this->assertStringContainsString('storage.test', (string) $detail['volumes'][0]['backCoverUrl']);
+    }
+
+    public function testUploadsSpineFace(): void
+    {
+        [$mangaId, $volumeId] = $this->createMangaWithVolume();
+
+        $this->jsonRequest('POST', "/api/manga/{$mangaId}/volumes/{$volumeId}/face", [
+            'face' => 'spine',
+            'image' => self::PNG_1X1,
+            'contentType' => 'image/png',
+        ]);
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
+        $this->assertNotNull($detail['volumes'][0]['spineUrl']);
+    }
+
+    public function testRejectsUnknownFace(): void
+    {
+        [$mangaId, $volumeId] = $this->createMangaWithVolume();
+
+        $response = $this->jsonRequest('POST', "/api/manga/{$mangaId}/volumes/{$volumeId}/face", [
+            'face' => 'middle',
+            'image' => self::PNG_1X1,
+            'contentType' => 'image/png',
+        ]);
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testRequiresImage(): void
+    {
+        [$mangaId, $volumeId] = $this->createMangaWithVolume();
+
+        $response = $this->jsonRequest('POST', "/api/manga/{$mangaId}/volumes/{$volumeId}/face", [
+            'face' => 'cover',
+            'contentType' => 'image/png',
+        ]);
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testVolumeNotFound(): void
+    {
+        [$mangaId] = $this->createMangaWithVolume();
+
+        $response = $this->jsonRequest('POST', "/api/manga/{$mangaId}/volumes/missing/face", [
+            'face' => 'cover',
+            'image' => self::PNG_1X1,
+            'contentType' => 'image/png',
+        ]);
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testRequiresAuth(): void
+    {
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/manga/x/volumes/y/face',
+            ['face' => 'cover', 'image' => self::PNG_1X1, 'contentType' => 'image/png'],
+            auth: false,
+        );
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}

--- a/back/tests/Unit/Manga/Application/UploadVolumeFace/UploadVolumeFaceHandlerTest.php
+++ b/back/tests/Unit/Manga/Application/UploadVolumeFace/UploadVolumeFaceHandlerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Application\UploadVolumeFace;
+
+use App\Manga\Application\UploadVolumeFace\UploadVolumeFaceCommand;
+use App\Manga\Application\UploadVolumeFace\UploadVolumeFaceHandler;
+use App\Manga\Domain\Manga;
+use App\Manga\Domain\MangaRepositoryInterface;
+use App\Manga\Domain\Volume;
+use App\Manga\Domain\VolumeFace;
+use App\Shared\Domain\Exception\NotFoundException;
+use App\Tests\Doubles\Manga\InMemoryImageStorage;
+use PHPUnit\Framework\TestCase;
+
+final class UploadVolumeFaceHandlerTest extends TestCase
+{
+    /**
+     * @return array{UploadVolumeFaceHandler, Manga, InMemoryImageStorage}
+     */
+    private function make(bool $withVolume = true): array
+    {
+        $manga = new Manga(id: 'm1', title: 'Berserk', edition: null, language: 'fr');
+        if ($withVolume) {
+            $manga->addVolume(new Volume(id: 'v1', manga: $manga, number: 1));
+        }
+
+        $repository = new class ($manga) implements MangaRepositoryInterface {
+            public bool $saved = false;
+
+            public function __construct(private Manga $manga)
+            {
+            }
+
+            public function findById(string $id): ?Manga
+            {
+                return $this->manga->id === $id ? $this->manga : null;
+            }
+
+            public function search(string $query): array
+            {
+                return [];
+            }
+
+            public function findAllPaginated(int $offset, int $limit): array
+            {
+                return [];
+            }
+
+            public function countAll(): int
+            {
+                return 0;
+            }
+
+            public function save(Manga $manga): void
+            {
+                $this->saved = true;
+            }
+        };
+
+        $storage = new InMemoryImageStorage();
+
+        return [new UploadVolumeFaceHandler($repository, $storage), $manga, $storage];
+    }
+
+    public function testStoresImageAndSetsBackCoverUrl(): void
+    {
+        [$handler, $manga, $storage] = $this->make();
+
+        $handler(new UploadVolumeFaceCommand('m1', 'v1', VolumeFace::Back, base64_encode('PNGBYTES'), 'image/png'));
+
+        /** @var Volume $volume */
+        $volume = $manga->volumes->first();
+        $this->assertCount(1, $storage->stored);
+        $key = array_key_first($storage->stored);
+        $this->assertStringStartsWith('volume-faces/v1-back-', (string) $key);
+        $this->assertStringEndsWith('.png', (string) $key);
+        $this->assertSame('PNGBYTES', $storage->stored[$key]);
+        $this->assertSame('https://storage.test/' . $key, $volume->backCoverUrl);
+        $this->assertNull($volume->coverUrl);
+        $this->assertNull($volume->spineUrl);
+    }
+
+    public function testCoverAndSpineFacesTargetTheRightProperty(): void
+    {
+        [$handlerCover, $mangaCover] = $this->make();
+        $handlerCover(new UploadVolumeFaceCommand('m1', 'v1', VolumeFace::Cover, base64_encode('x'), 'image/jpeg'));
+        /** @var Volume $coverVolume */
+        $coverVolume = $mangaCover->volumes->first();
+        $this->assertNotNull($coverVolume->coverUrl);
+        $this->assertNull($coverVolume->backCoverUrl);
+
+        [$handlerSpine, $mangaSpine] = $this->make();
+        $handlerSpine(new UploadVolumeFaceCommand('m1', 'v1', VolumeFace::Spine, base64_encode('x'), 'image/jpeg'));
+        /** @var Volume $spineVolume */
+        $spineVolume = $mangaSpine->volumes->first();
+        $this->assertNotNull($spineVolume->spineUrl);
+        $this->assertNull($spineVolume->coverUrl);
+    }
+
+    public function testStripsDataUrlPrefixBeforeDecoding(): void
+    {
+        [$handler, , $storage] = $this->make();
+
+        $handler(new UploadVolumeFaceCommand(
+            'm1',
+            'v1',
+            VolumeFace::Cover,
+            'data:image/png;base64,' . base64_encode('RAW'),
+            'image/png',
+        ));
+
+        $this->assertSame('RAW', $storage->stored[array_key_first($storage->stored)]);
+    }
+
+    public function testThrowsWhenMangaMissing(): void
+    {
+        [$handler] = $this->make(withVolume: false);
+
+        $this->expectException(NotFoundException::class);
+        $handler(new UploadVolumeFaceCommand('unknown', 'v1', VolumeFace::Cover, base64_encode('x'), 'image/jpeg'));
+    }
+
+    public function testThrowsWhenVolumeMissing(): void
+    {
+        [$handler] = $this->make(withVolume: false);
+
+        $this->expectException(NotFoundException::class);
+        $handler(new UploadVolumeFaceCommand('m1', 'absent', VolumeFace::Cover, base64_encode('x'), 'image/jpeg'));
+    }
+}

--- a/back/tests/Unit/Manga/Domain/VolumeFaceTest.php
+++ b/back/tests/Unit/Manga/Domain/VolumeFaceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain;
+
+use App\Manga\Domain\VolumeFace;
+use PHPUnit\Framework\TestCase;
+
+final class VolumeFaceTest extends TestCase
+{
+    public function testBackingValues(): void
+    {
+        $this->assertSame('cover', VolumeFace::Cover->value);
+        $this->assertSame('spine', VolumeFace::Spine->value);
+        $this->assertSame('back', VolumeFace::Back->value);
+    }
+
+    public function testFromString(): void
+    {
+        $this->assertSame(VolumeFace::Back, VolumeFace::from('back'));
+    }
+
+    public function testTryFromRejectsUnknownFace(): void
+    {
+        $this->assertNull(VolumeFace::tryFrom('middle'));
+    }
+}

--- a/back/tests/Unit/Manga/Domain/VolumeTest.php
+++ b/back/tests/Unit/Manga/Domain/VolumeTest.php
@@ -51,6 +51,7 @@ final class VolumeTest extends TestCase
         $this->assertNull($arr['releaseDate']);
         $this->assertNull($arr['isbn']);
         $this->assertNull($arr['spineUrl']);
+        $this->assertNull($arr['backCoverUrl']);
     }
 
     public function testToArrayExposesIsbnAsCanonicalString(): void
@@ -63,11 +64,13 @@ final class VolumeTest extends TestCase
             number: 2,
             isbn: $isbn,
             spineUrl: 'https://example.com/spine.jpg',
+            backCoverUrl: 'https://example.com/back.jpg',
         );
 
         $arr = $volume->toArray();
 
         $this->assertSame('9782123456780', $arr['isbn']);
         $this->assertSame('https://example.com/spine.jpg', $arr['spineUrl']);
+        $this->assertSame('https://example.com/back.jpg', $arr['backCoverUrl']);
     }
 }

--- a/front/src/api/manga.ts
+++ b/front/src/api/manga.ts
@@ -68,9 +68,22 @@ export async function updateManga(
 export async function updateVolume(
   mangaId: string,
   volumeId: string,
-  payload: { coverUrl?: string; releaseDate?: string; price?: number | null; spineUrl?: string; isbn?: string },
+  payload: { coverUrl?: string; releaseDate?: string; price?: number | null; spineUrl?: string; backCoverUrl?: string; isbn?: string },
 ): Promise<void> {
   await client.patch(`/manga/${mangaId}/volumes/${volumeId}`, payload)
+}
+
+export type VolumeFace = 'cover' | 'spine' | 'back'
+
+/** Upload a real photo of one physical face (cover / spine / back) for the 3D render. */
+export async function uploadVolumeFace(
+  mangaId: string,
+  volumeId: string,
+  face: VolumeFace,
+  image: string,
+  contentType: string,
+): Promise<void> {
+  await client.post(`/manga/${mangaId}/volumes/${volumeId}/face`, { face, image, contentType })
 }
 
 export async function addVolume(

--- a/front/src/api/shelf.ts
+++ b/front/src/api/shelf.ts
@@ -5,6 +5,7 @@ export interface ShelfVolume {
   number: number
   coverUrl: string | null
   spineUrl: string | null
+  backCoverUrl: string | null
 }
 
 export interface ShelfCollection {

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -2,8 +2,8 @@
 import { ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import { X, Search, RefreshCw, Book, ImageOff, Megaphone, Package, Star, BookOpen, Camera, Smartphone, QrCode, Info, HelpCircle, Check, Plus } from 'lucide-vue-next'
-import { searchVolumeExternal, updateVolume, createScanSession } from '@/api/manga'
-import type { CoverProvider } from '@/api/manga'
+import { searchVolumeExternal, updateVolume, createScanSession, uploadVolumeFace } from '@/api/manga'
+import type { CoverProvider, VolumeFace } from '@/api/manga'
 import { toggleVolume } from '@/api/collection'
 import { useUiStore } from '@/stores/useUiStore'
 import { useIsbnCoverSearch } from '@/composables/useIsbnCoverSearch'
@@ -287,6 +287,52 @@ const enrichMutation = useMutation({
     emit('close')
   },
 })
+
+// ── Real face photos for the 3D render ──
+const FACE_LABELS: Record<VolumeFace, string> = { cover: '1ère', spine: 'Tranche', back: '4e' }
+const uploadingFace = ref<VolumeFace | null>(null)
+
+function faceThumb(face: VolumeFace): string | null {
+  const currentVolume = props.volume
+  if (!currentVolume) return null
+  const url = face === 'cover'
+    ? currentVolume.coverUrl
+    : face === 'spine'
+      ? currentVolume.spineUrl
+      : currentVolume.backCoverUrl
+  return coverUrl(url)
+}
+
+function readAsBase64(file: File): Promise<{ base64: string; contentType: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = String(reader.result)
+      resolve({ base64: result.split(',')[1] ?? '', contentType: file.type || 'image/jpeg' })
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+async function onFaceFile(face: VolumeFace, event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file || !props.volume) return
+  uploadingFace.value = face
+  try {
+    const { base64, contentType } = await readAsBase64(file)
+    await uploadVolumeFace(props.mangaId, props.volume.volumeId, face, base64, contentType)
+    qc.invalidateQueries({ queryKey: ['collection', props.collectionEntryId] })
+    qc.invalidateQueries({ queryKey: ['collection'] })
+    ui.addToast(`Photo ${FACE_LABELS[face]} ajoutée`, 'success')
+  } catch {
+    ui.addToast("Échec de l'envoi de la photo", 'error')
+  } finally {
+    uploadingFace.value = null
+  }
+}
 
 // ── Toggle mutations ──
 // Mirrors the backend ToggleVolumeHandler rules so the optimistic cache update
@@ -599,6 +645,34 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
                     {{ volume.isOwned ? t('enrich.statusHintOwned') : t('enrich.statusHintNotOwned') }}
                   </p>
                 </div>
+              </div>
+
+              <!-- Vraies photos pour le rendu 3D -->
+              <div class="flex flex-col gap-2">
+                <p class="text-[11px] font-bold uppercase tracking-wide text-base-content/45">
+                  Photos pour le rendu 3D
+                </p>
+                <div class="grid grid-cols-3 gap-2">
+                  <label
+                    v-for="face in (['cover', 'spine', 'back'] as VolumeFace[])"
+                    :key="face"
+                    class="relative flex flex-col items-center justify-center gap-1 rounded-xl border border-base-300/70 bg-base-100 py-2 cursor-pointer hover:border-primary/40 hover:bg-base-200/40 transition-colors"
+                    :class="{ 'pointer-events-none opacity-60': uploadingFace !== null }"
+                  >
+                    <div class="w-8 h-10 rounded overflow-hidden bg-base-200 ring-1 ring-base-300 flex items-center justify-center">
+                      <img v-if="faceThumb(face)" :src="faceThumb(face)!" class="w-full h-full object-cover" :alt="FACE_LABELS[face]" />
+                      <Camera v-else class="h-4 w-4 text-base-content/30" />
+                    </div>
+                    <span class="text-[10px] font-semibold text-base-content/70">{{ FACE_LABELS[face] }}</span>
+                    <span v-if="uploadingFace === face" class="absolute inset-0 flex items-center justify-center rounded-xl bg-base-100/70">
+                      <span class="loading loading-spinner loading-xs" />
+                    </span>
+                    <input type="file" accept="image/*" capture="environment" class="hidden" @change="onFaceFile(face, $event)" />
+                  </label>
+                </div>
+                <p class="text-[11px] text-base-content/40 leading-snug px-0.5">
+                  Photographie tes vraies faces pour un rendu 3D fidèle.
+                </p>
               </div>
 
               <!-- ISBN du tome + aide (desktop) -->

--- a/front/src/components/organisms/Volume3DViewer.vue
+++ b/front/src/components/organisms/Volume3DViewer.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { ref, watch, onUnmounted, nextTick } from 'vue'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import { X } from 'lucide-vue-next'
+import { coverUrl } from '@/utils/coverUrl'
+import { seedColorInt, createSpineTexture, createBackTexture, VIEWER_BOOK } from '@/utils/bookTextures'
+
+interface ViewerVolume {
+  number: number
+  coverUrl: string | null
+  spineUrl: string | null
+  backCoverUrl: string | null
+}
+interface ViewerManga {
+  title: string
+  edition: string | null
+  coverUrl: string | null
+}
+
+const props = defineProps<{
+  open: boolean
+  volume: ViewerVolume | null
+  manga: ViewerManga | null
+}>()
+const emit = defineEmits<{ close: [] }>()
+
+const containerRef = ref<HTMLDivElement>()
+const canvasRef = ref<HTMLCanvasElement>()
+
+let renderer: THREE.WebGLRenderer | null = null
+let scene: THREE.Scene | null = null
+let camera: THREE.PerspectiveCamera | null = null
+let controls: OrbitControls | null = null
+let animFrameId = 0
+let isReady = false
+const disposables: { dispose(): void }[] = []
+
+function containerSize(): { width: number; height: number } {
+  const el = containerRef.value
+  return el
+    ? { width: el.clientWidth, height: el.clientHeight }
+    : { width: window.innerWidth, height: window.innerHeight }
+}
+
+function disposeScene(): void {
+  if (animFrameId) cancelAnimationFrame(animFrameId)
+  animFrameId = 0
+  controls?.dispose()
+  for (const d of disposables) d.dispose()
+  disposables.length = 0
+  renderer?.dispose()
+  renderer = null
+  scene = null
+  camera = null
+  controls = null
+  isReady = false
+}
+
+// Covers served through the same-origin /proxy/cover endpoint don't taint the
+// WebGL canvas; direct cross-origin hosts may, exactly as on the 3D shelf.
+function loadTexture(loader: THREE.TextureLoader, url: string | null): THREE.Texture | null {
+  const resolved = coverUrl(url)
+  if (!resolved) return null
+  const texture = loader.load(resolved)
+  texture.colorSpace = THREE.SRGBColorSpace
+  disposables.push(texture)
+  return texture
+}
+
+function buildBook(sceneObj: THREE.Scene, volume: ViewerVolume, manga: ViewerManga): void {
+  const loader = new THREE.TextureLoader()
+  const colorInt = seedColorInt(`${manga.title}-${volume.number}`)
+
+  const pagesMat = new THREE.MeshStandardMaterial({ color: 0xf0ead8, roughness: 0.95 })
+  const topMat = new THREE.MeshStandardMaterial({ color: 0xe8e0cc, roughness: 0.9 })
+
+  const coverTexture = loadTexture(loader, volume.coverUrl ?? manga.coverUrl)
+  const coverMat = coverTexture
+    ? new THREE.MeshStandardMaterial({ map: coverTexture, roughness: 0.45, metalness: 0.04 })
+    : new THREE.MeshStandardMaterial({ color: colorInt, roughness: 0.6 })
+
+  const spineTexture = volume.spineUrl ? loadTexture(loader, volume.spineUrl) : null
+  const spineMat = new THREE.MeshStandardMaterial({
+    map: spineTexture ?? createSpineTexture(manga.edition, manga.title, volume.number, colorInt),
+    roughness: 0.55,
+  })
+
+  const backTexture = volume.backCoverUrl ? loadTexture(loader, volume.backCoverUrl) : null
+  const backMat = new THREE.MeshStandardMaterial({
+    map: backTexture ?? createBackTexture(colorInt),
+    roughness: 0.6,
+  })
+
+  const { width, height, depth } = VIEWER_BOOK
+  const geometry = new THREE.BoxGeometry(width, height, depth)
+  disposables.push(geometry)
+
+  // BoxGeometry face order: +x, -x, +y, -y, +z, -z.
+  // Cover faces the camera (+z); spine on the left edge (-x); fore-edge pages (+x).
+  const materials = [pagesMat, spineMat, topMat, topMat, coverMat, backMat]
+  materials.forEach((material) => disposables.push(material))
+
+  sceneObj.add(new THREE.Mesh(geometry, materials))
+}
+
+function initScene(): void {
+  if (!canvasRef.value || !props.volume || !props.manga || isReady) return
+  disposeScene()
+
+  const { width, height } = containerSize()
+
+  renderer = new THREE.WebGLRenderer({ canvas: canvasRef.value, antialias: true, alpha: true })
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+  renderer.setSize(width, height)
+
+  scene = new THREE.Scene()
+
+  camera = new THREE.PerspectiveCamera(38, width / height, 0.1, 100)
+  camera.position.set(0.5, 0.18, 2.5)
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.9))
+  const keyLight = new THREE.DirectionalLight(0xffffff, 1.7)
+  keyLight.position.set(2.5, 3, 4)
+  scene.add(keyLight)
+  const fillLight = new THREE.DirectionalLight(0xbcd2ff, 0.5)
+  fillLight.position.set(-3, 1, 2.5)
+  scene.add(fillLight)
+  const rimLight = new THREE.DirectionalLight(0xffffff, 0.65)
+  rimLight.position.set(-1.5, 2, -4)
+  scene.add(rimLight)
+
+  buildBook(scene, props.volume, props.manga)
+
+  controls = new OrbitControls(camera, renderer.domElement)
+  controls.enableDamping = true
+  controls.dampingFactor = 0.09
+  controls.enablePan = false
+  controls.minDistance = 1.4
+  controls.maxDistance = 5
+  controls.target.set(0, 0, 0)
+  controls.update()
+
+  isReady = true
+
+  const animate = (): void => {
+    animFrameId = requestAnimationFrame(animate)
+    controls!.update()
+    renderer!.render(scene!, camera!)
+  }
+  animate()
+}
+
+function onResize(): void {
+  if (!renderer || !camera) return
+  const { width, height } = containerSize()
+  camera.aspect = width / height
+  camera.updateProjectionMatrix()
+  renderer.setSize(width, height)
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') emit('close')
+}
+
+watch(
+  () => props.open,
+  async (open) => {
+    if (open) {
+      await nextTick()
+      window.addEventListener('resize', onResize)
+      window.addEventListener('keydown', onKeydown)
+      initScene()
+    } else {
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('keydown', onKeydown)
+      disposeScene()
+    }
+  },
+)
+
+onUnmounted(() => {
+  window.removeEventListener('resize', onResize)
+  window.removeEventListener('keydown', onKeydown)
+  disposeScene()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="viewer-fade">
+      <div
+        v-if="open && volume && manga"
+        class="fixed inset-0 z-[70] flex flex-col bg-black/85 backdrop-blur-md"
+      >
+        <div class="flex items-center justify-between gap-3 px-5 py-3 text-white">
+          <div class="min-w-0">
+            <p class="truncate text-[11px] uppercase tracking-wider text-white/45">{{ manga.title }}</p>
+            <p class="font-bold leading-tight">Tome {{ volume.number }} · rendu 3D</p>
+          </div>
+          <button
+            class="btn btn-sm btn-circle btn-ghost text-white/80 hover:text-white"
+            aria-label="Fermer"
+            @click="emit('close')"
+          >
+            <X class="h-5 w-5" />
+          </button>
+        </div>
+
+        <div ref="containerRef" class="relative min-h-0 flex-1">
+          <canvas ref="canvasRef" class="absolute inset-0 h-full w-full" />
+        </div>
+
+        <p class="select-none py-3 text-center text-xs text-white/40">
+          Glisse pour tourner le tome · molette pour zoomer
+        </p>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.viewer-fade-enter-active,
+.viewer-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.viewer-fade-enter-from,
+.viewer-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
-  ArrowLeft, Star, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info, Bell, BellOff, Plus, Sparkles, HelpCircle, Languages, MoreHorizontal, ChevronDown, X,
+  ArrowLeft, Star, Book, BookOpen, Check, CheckSquare, Pencil, Trash2, Eye, Tag, Megaphone, Package, Info, Bell, BellOff, Plus, Sparkles, HelpCircle, Languages, MoreHorizontal, ChevronDown, X, Box,
 } from 'lucide-vue-next'
 import {
   getCollectionEntry,
@@ -21,6 +21,7 @@ import { useCoverBatchProgress } from '@/composables/useCoverBatchProgress'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
 import EnrichVolumeModal from '@/components/organisms/EnrichVolumeModal.vue'
+import Volume3DViewer from '@/components/organisms/Volume3DViewer.vue'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
 import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
 import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
@@ -265,6 +266,9 @@ function selectUnread() {
 function selectAnnounced() {
   selectedIds.value = new Set(sortedVolumes.value.filter((v) => v.isAnnounced && !v.isOwned).map((v) => v.id))
 }
+
+// ── 3D viewer (single volume) ──
+const viewer3dVolume = ref<VolumeEntry | null>(null)
 
 // ── Context menu ──
 const contextMenu = ref<{ ve: VolumeEntry; x: number; y: number } | null>(null)
@@ -1227,6 +1231,12 @@ function volumeOpacityClass(ve: VolumeEntry): string {
           </li>
           <div class="h-px bg-base-200 my-0.5 mx-2" />
           <li>
+            <a class="gap-2 text-sm" @click="viewer3dVolume = contextMenu.ve; closeContextMenu()">
+              <Box class="h-4 w-4" />
+              Voir en 3D
+            </a>
+          </li>
+          <li>
             <a class="gap-2 text-sm" @click="openModalFromContext">
               <Info class="h-4 w-4" />
               Détails
@@ -1344,6 +1354,18 @@ function volumeOpacityClass(ve: VolumeEntry): string {
       </div>
     </Transition>
   </Teleport>
+
+  <!-- ── 3D viewer (single volume) ── -->
+  <Volume3DViewer
+    :open="viewer3dVolume !== null"
+    :volume="viewer3dVolume
+      ? { number: viewer3dVolume.number, coverUrl: viewer3dVolume.coverUrl, spineUrl: viewer3dVolume.spineUrl, backCoverUrl: viewer3dVolume.backCoverUrl }
+      : null"
+    :manga="entry
+      ? { title: entry.manga.title, edition: entry.manga.edition, coverUrl: entry.manga.coverUrl }
+      : null"
+    @close="viewer3dVolume = null"
+  />
 </template>
 
 <style scoped>

--- a/front/src/pages/ShelfPage.vue
+++ b/front/src/pages/ShelfPage.vue
@@ -5,8 +5,10 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { useQuery } from '@tanstack/vue-query'
 import { getShelf, type ShelfCollection } from '@/api/shelf'
 import { coverUrl } from '@/utils/coverUrl'
-import { X } from 'lucide-vue-next'
+import { seedColorInt, createSpineTexture } from '@/utils/bookTextures'
+import Volume3DViewer from '@/components/organisms/Volume3DViewer.vue'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
+import { Box, X } from 'lucide-vue-next'
 
 // ── Reactive state ────────────────────────────────────────────────────────────
 
@@ -14,11 +16,15 @@ interface SelectedBook {
   mangaTitle: string
   number: number
   coverUrl: string | null
+  spineUrl: string | null
+  backCoverUrl: string | null
+  edition: string | null
 }
 
 const containerRef = ref<HTMLDivElement>()
 const canvasRef = ref<HTMLCanvasElement>()
 const selectedBook = ref<SelectedBook | null>(null)
+const show3d = ref(false)
 const isInitialized = shallowRef(false)
 
 // ── Data ──────────────────────────────────────────────────────────────────────
@@ -70,94 +76,8 @@ function disposeScene(): void {
   isInitialized.value = false
 }
 
-// ── Color helpers ─────────────────────────────────────────────────────────────
-
-function seedColorInt(str: string): number {
-  let hash = 5381
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash) ^ str.charCodeAt(i)
-    hash |= 0
-  }
-  return hslToInt((Math.abs(hash) % 360) / 360, 0.68, 0.46)
-}
-
-function hslToInt(h: number, s: number, l: number): number {
-  const a = s * Math.min(l, 1 - l)
-  const f = (n: number): number => {
-    const k = (n + h * 12) % 12
-    return l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
-  }
-  return (Math.round(f(0) * 255) << 16) | (Math.round(f(8) * 255) << 8) | Math.round(f(4) * 255)
-}
-
-// ── Spine texture ─────────────────────────────────────────────────────────────
-
-function createSpineTexture(
-  edition: string | null,
-  title: string,
-  volume: number,
-  colorInt: number,
-): THREE.CanvasTexture {
-  const W = 48
-  const H = 400
-  const canvas = document.createElement('canvas')
-  canvas.width = W
-  canvas.height = H
-  const ctx = canvas.getContext('2d')!
-
-  const r = (colorInt >> 16) & 0xff
-  const g = (colorInt >> 8) & 0xff
-  const b = colorInt & 0xff
-  const dark = `rgb(${Math.round(r * 0.45)},${Math.round(g * 0.45)},${Math.round(b * 0.45)})`
-  const mid = `rgb(${r},${g},${b})`
-  const light = `rgb(${Math.min(255, Math.round(r * 1.3))},${Math.min(255, Math.round(g * 1.3))},${Math.min(255, Math.round(b * 1.3))})`
-
-  const grad = ctx.createLinearGradient(0, 0, 0, H)
-  grad.addColorStop(0, dark)
-  grad.addColorStop(0.15, mid)
-  grad.addColorStop(0.85, mid)
-  grad.addColorStop(1, dark)
-  ctx.fillStyle = grad
-  ctx.fillRect(0, 0, W, H)
-
-  ctx.fillStyle = dark
-  ctx.fillRect(0, 0, W, 40)
-  ctx.fillRect(0, H - 50, W, 50)
-
-  ctx.fillStyle = light
-  ctx.fillRect(0, 40, W, 2)
-  ctx.fillRect(0, H - 52, W, 2)
-
-  if (edition) {
-    const short = edition.length > 8 ? edition.substring(0, 7) + '…' : edition
-    ctx.fillStyle = 'rgba(255,255,255,0.85)'
-    ctx.font = 'bold 10px sans-serif'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
-    ctx.fillText(short, W / 2, 20)
-  }
-
-  const shortTitle = title.length > 18 ? title.substring(0, 17) + '…' : title
-  ctx.save()
-  ctx.translate(W / 2, H / 2 - 10)
-  ctx.rotate(Math.PI / 2)
-  ctx.font = '12px sans-serif'
-  ctx.fillStyle = 'rgba(255,255,255,0.82)'
-  ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
-  ctx.fillText(shortTitle, 0, 0)
-  ctx.restore()
-
-  ctx.fillStyle = 'rgba(255,255,255,0.95)'
-  ctx.font = 'bold 22px sans-serif'
-  ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
-  ctx.fillText(String(volume), W / 2, H - 25)
-
-  const texture = new THREE.CanvasTexture(canvas)
-  texture.needsUpdate = true
-  return texture
-}
+// ── Synthetic spine + colour helpers live in utils/bookTextures, shared with the
+//    single-volume Volume3DViewer so both render an identical fallback look. ─────
 
 // ── Scene constants ───────────────────────────────────────────────────────────
 
@@ -1005,7 +925,9 @@ function buildBooks(sceneObj: THREE.Scene, collections: ShelfCollection[]): void
         ? loader.load(coverUrl(volume.spineUrl)!)
         : createSpineTexture(collection.manga.edition, collection.manga.title, volume.number, colorInt)
       const spineMat = new THREE.MeshLambertMaterial({ map: spineMap })
-      const backMat = new THREE.MeshLambertMaterial({ color: colorInt })
+      const backMat = volume.backCoverUrl
+        ? new THREE.MeshLambertMaterial({ map: loader.load(coverUrl(volume.backCoverUrl)!) })
+        : new THREE.MeshLambertMaterial({ color: colorInt })
 
       // BoxGeometry face order: +x (cover), -x (pages), +y (top), -y (bottom), +z (spine→camera), -z (back)
       const mesh = new THREE.Mesh(geom, [volCoverFaceMat, pagesMat, topMat, topMat, spineMat, backMat])
@@ -1016,9 +938,12 @@ function buildBooks(sceneObj: THREE.Scene, collections: ShelfCollection[]): void
 
       originalZ.set(mesh, spineZ)
       bookMap.set(mesh, {
-        mangaTitle: collection.manga.title,
-        number:     volume.number,
-        coverUrl:   volume.coverUrl ?? collection.manga.coverUrl ?? null,
+        mangaTitle:   collection.manga.title,
+        number:       volume.number,
+        coverUrl:     volume.coverUrl ?? collection.manga.coverUrl ?? null,
+        spineUrl:     volume.spineUrl,
+        backCoverUrl: volume.backCoverUrl,
+        edition:      collection.manga.edition,
       })
 
       sceneObj.add(mesh)
@@ -1278,10 +1203,25 @@ onUnmounted(() => {
 
           <div class="p-4">
             <p class="text-xs text-base-content/50 uppercase tracking-wider mb-1">{{ selectedBook.mangaTitle }}</p>
-            <p class="text-xl font-bold">Tome {{ selectedBook.number }}</p>
+            <p class="text-xl font-bold mb-3">Tome {{ selectedBook.number }}</p>
+            <button class="btn btn-primary btn-sm gap-2 w-full" @click="show3d = true">
+              <Box class="h-4 w-4" />
+              Voir en 3D
+            </button>
           </div>
         </div>
       </div>
     </Transition>
+
+    <Volume3DViewer
+      :open="show3d"
+      :volume="selectedBook
+        ? { number: selectedBook.number, coverUrl: selectedBook.coverUrl, spineUrl: selectedBook.spineUrl, backCoverUrl: selectedBook.backCoverUrl }
+        : null"
+      :manga="selectedBook
+        ? { title: selectedBook.mangaTitle, edition: selectedBook.edition, coverUrl: selectedBook.coverUrl }
+        : null"
+      @close="show3d = false"
+    />
   </div>
 </template>

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Volume {
   releaseDate: string | null
   isbn: string | null
   spineUrl: string | null
+  backCoverUrl: string | null
 }
 
 export interface Manga {
@@ -43,6 +44,7 @@ export interface VolumeEntry {
   rating: number | null
   isbn: string | null
   spineUrl: string | null
+  backCoverUrl: string | null
 }
 
 export interface CollectionEntry {

--- a/front/src/utils/__tests__/bookTextures.spec.ts
+++ b/front/src/utils/__tests__/bookTextures.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { seedColorInt, hslToInt } from '../bookTextures'
+
+describe('bookTextures colour helpers', () => {
+  it('seedColorInt is deterministic for the same input', () => {
+    expect(seedColorInt('berserk-1')).toBe(seedColorInt('berserk-1'))
+  })
+
+  it('seedColorInt stays within the 24-bit RGB range', () => {
+    for (const seed of ['a', 'manga-42', 'Lorem ipsum dolor', '']) {
+      const colour = seedColorInt(seed)
+      expect(colour).toBeGreaterThanOrEqual(0)
+      expect(colour).toBeLessThanOrEqual(0xffffff)
+      expect(Number.isInteger(colour)).toBe(true)
+    }
+  })
+
+  it('different seeds generally yield different colours', () => {
+    expect(seedColorInt('one')).not.toBe(seedColorInt('two'))
+  })
+
+  it('hslToInt returns a 24-bit integer for boundary inputs', () => {
+    const cases: [number, number, number][] = [
+      [0, 0, 0],
+      [0, 1, 0.5],
+      [1, 1, 1],
+      [0.5, 0.68, 0.46],
+    ]
+    for (const [h, s, l] of cases) {
+      const colour = hslToInt(h, s, l)
+      expect(Number.isInteger(colour)).toBe(true)
+      expect(colour).toBeGreaterThanOrEqual(0)
+      expect(colour).toBeLessThanOrEqual(0xffffff)
+    }
+  })
+})

--- a/front/src/utils/bookTextures.ts
+++ b/front/src/utils/bookTextures.ts
@@ -1,0 +1,156 @@
+import * as THREE from 'three'
+
+// Shared book-rendering helpers. The colour + synthetic-spine functions were
+// originally inline in ShelfPage; they live here so the single-volume
+// Volume3DViewer renders an identical fallback look to the 3D shelf.
+
+/** Single-volume viewer book proportions — a tankōbon ≈ 1 : 1.5, ~13 % thick. */
+export const VIEWER_BOOK = { width: 1.0, height: 1.5, depth: 0.17 } as const
+
+/** Deterministic, pleasant colour (0xRRGGBB) from an arbitrary string. */
+export function seedColorInt(str: string): number {
+  let hash = 5381
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash) ^ str.charCodeAt(i)
+    hash |= 0
+  }
+  return hslToInt((Math.abs(hash) % 360) / 360, 0.68, 0.46)
+}
+
+export function hslToInt(h: number, s: number, l: number): number {
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number): number => {
+    const k = (n + h * 12) % 12
+    return l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
+  }
+  return (Math.round(f(0) * 255) << 16) | (Math.round(f(8) * 255) << 8) | Math.round(f(4) * 255)
+}
+
+/** Synthetic spine: publisher band + vertical title + volume number. */
+export function createSpineTexture(
+  edition: string | null,
+  title: string,
+  volume: number,
+  colorInt: number,
+): THREE.CanvasTexture {
+  const W = 48
+  const H = 400
+  const canvas = document.createElement('canvas')
+  canvas.width = W
+  canvas.height = H
+  const ctx = canvas.getContext('2d')!
+
+  const r = (colorInt >> 16) & 0xff
+  const g = (colorInt >> 8) & 0xff
+  const b = colorInt & 0xff
+  const dark = `rgb(${Math.round(r * 0.45)},${Math.round(g * 0.45)},${Math.round(b * 0.45)})`
+  const mid = `rgb(${r},${g},${b})`
+  const light = `rgb(${Math.min(255, Math.round(r * 1.3))},${Math.min(255, Math.round(g * 1.3))},${Math.min(255, Math.round(b * 1.3))})`
+
+  const grad = ctx.createLinearGradient(0, 0, 0, H)
+  grad.addColorStop(0, dark)
+  grad.addColorStop(0.15, mid)
+  grad.addColorStop(0.85, mid)
+  grad.addColorStop(1, dark)
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, W, H)
+
+  ctx.fillStyle = dark
+  ctx.fillRect(0, 0, W, 40)
+  ctx.fillRect(0, H - 50, W, 50)
+
+  ctx.fillStyle = light
+  ctx.fillRect(0, 40, W, 2)
+  ctx.fillRect(0, H - 52, W, 2)
+
+  if (edition) {
+    const short = edition.length > 8 ? edition.substring(0, 7) + '…' : edition
+    ctx.fillStyle = 'rgba(255,255,255,0.85)'
+    ctx.font = 'bold 10px sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(short, W / 2, 20)
+  }
+
+  const shortTitle = title.length > 18 ? title.substring(0, 17) + '…' : title
+  ctx.save()
+  ctx.translate(W / 2, H / 2 - 10)
+  ctx.rotate(Math.PI / 2)
+  ctx.font = '12px sans-serif'
+  ctx.fillStyle = 'rgba(255,255,255,0.82)'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(shortTitle, 0, 0)
+  ctx.restore()
+
+  ctx.fillStyle = 'rgba(255,255,255,0.95)'
+  ctx.font = 'bold 22px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(String(volume), W / 2, H - 25)
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.needsUpdate = true
+  return texture
+}
+
+/**
+ * Synthetic 4th-of-cover (back) texture, used until a real back-cover photo is
+ * captured: a dark wash of the dominant colour + a faint "summary" panel + a
+ * procedural barcode, so the rear face reads as a book back, not a flat colour.
+ */
+export function createBackTexture(colorInt: number): THREE.CanvasTexture {
+  const W = 300
+  const H = 450
+  const canvas = document.createElement('canvas')
+  canvas.width = W
+  canvas.height = H
+  const ctx = canvas.getContext('2d')!
+
+  const r = (colorInt >> 16) & 0xff
+  const g = (colorInt >> 8) & 0xff
+  const b = colorInt & 0xff
+  const dark = `rgb(${Math.round(r * 0.32)},${Math.round(g * 0.32)},${Math.round(b * 0.32)})`
+  const darker = `rgb(${Math.round(r * 0.2)},${Math.round(g * 0.2)},${Math.round(b * 0.2)})`
+
+  const grad = ctx.createLinearGradient(0, 0, 0, H)
+  grad.addColorStop(0, dark)
+  grad.addColorStop(1, darker)
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, W, H)
+
+  // Publisher band at the very top.
+  ctx.fillStyle = 'rgba(255,255,255,0.14)'
+  ctx.fillRect(0, 0, W, 5)
+
+  // Faint blurb lines, like a back-cover summary.
+  ctx.fillStyle = 'rgba(255,255,255,0.10)'
+  const pad = 28
+  for (let i = 0; i < 7; i++) {
+    const lineWidth = (i === 6 ? 0.5 : 0.84) * (W - pad * 2)
+    ctx.fillRect(pad, 64 + i * 22, lineWidth, 7)
+  }
+
+  // White barcode block, bottom-right.
+  const bcW = 104
+  const bcH = 60
+  const bcX = W - bcW - 24
+  const bcY = H - bcH - 28
+  ctx.fillStyle = '#ffffff'
+  ctx.fillRect(bcX, bcY, bcW, bcH)
+  ctx.fillStyle = '#111111'
+  let x = bcX + 9
+  while (x < bcX + bcW - 9) {
+    const barWidth = 1 + Math.round((Math.sin(x * 12.9898) * 0.5 + 0.5) * 3)
+    ctx.fillRect(x, bcY + 9, barWidth, bcH - 24)
+    x += barWidth + 2
+  }
+  ctx.font = 'bold 8px monospace'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'alphabetic'
+  ctx.fillText('I S B N', bcX + bcW / 2, bcY + bcH - 6)
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.needsUpdate = true
+  return texture
+}


### PR DESCRIPTION
…verture)

Viewer Three.js mono-tome ouvrable depuis la fiche série (menu contextuel) et l'étagère 3D : un BoxGeometry rapproché, rotatable à la souris, qui assemble couverture, tranche et 4e de couverture.

- backend: champ nullable Volume.backCoverUrl (migration, sérialisation shelf + collection, écriture via PATCH /manga/{id}/volumes/{id})
- front: helpers de texture partagés extraits dans utils/bookTextures (tranche + 4e synthétiques en repli), composant Volume3DViewer
- l'étagère 3D affiche désormais la vraie 4e de couverture quand elle existe
- tests: VolumeTest, ShelfControllerTest, MangaControllerTest, bookTextures.spec