### PR TITLE
Persist collection filters to sessionStorage via Pinia store

### DIFF
--- a/front/src/pages/CollectionPage.vue
+++ b/front/src/pages/CollectionPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onMounted, onUnmounted, type Component } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, type Component } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useInfiniteQuery } from '@tanstack/vue-query'
 import {
   Search, Plus, Book, X, RotateCcw, SlidersHorizontal, ChevronDown,
@@ -7,6 +8,7 @@ import {
   Library, BookCheck, Gift, HelpCircle,
 } from 'lucide-vue-next'
 import { getCollection, type CollectionFilters } from '@/api/collection'
+import { useCollectionFiltersStore } from '@/stores/useCollectionFiltersStore'
 import { useI18n } from 'vue-i18n'
 import MangaCard from '@/components/organisms/MangaCard.vue'
 import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
@@ -22,20 +24,12 @@ const GENRES = [
 ] as const
 
 // ── Filter state ──────────────────────────────────────────────────────────────
+// Persisted in a store (sessionStorage-backed) so filters are remembered across
+// navigation — e.g. opening a series and coming back to the list.
 
-const searchInput = ref('')
-
-const filters = reactive<CollectionFilters>({
-  search:        undefined,
-  genre:         undefined,
-  edition:       undefined,
-  readingStatus: undefined,
-  sort:          undefined,
-  followed:      false,
-  hasOwned:      false,
-  hasRead:       false,
-  hasWished:     false,
-})
+const filtersStore = useCollectionFiltersStore()
+const { searchInput } = storeToRefs(filtersStore)
+const filters = filtersStore.filters
 
 // Debounce search input (300 ms)
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -55,16 +49,7 @@ const hasActiveFilters = computed(
 
 function resetFilters() {
   if (debounceTimer) clearTimeout(debounceTimer)
-  searchInput.value     = ''
-  filters.search        = undefined
-  filters.genre         = undefined
-  filters.edition       = undefined
-  filters.readingStatus = undefined
-  filters.sort          = undefined
-  filters.followed      = false
-  filters.hasOwned      = false
-  filters.hasRead       = false
-  filters.hasWished     = false
+  filtersStore.reset()
 }
 
 // ── Preset filters (quick-access chips) ───────────────────────────────────────

--- a/front/src/stores/__tests__/useCollectionFiltersStore.spec.ts
+++ b/front/src/stores/__tests__/useCollectionFiltersStore.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useCollectionFiltersStore } from '../useCollectionFiltersStore'
+
+const STORAGE_KEY = 'collection-filters'
+
+describe('useCollectionFiltersStore', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('starts with empty defaults when nothing is persisted', () => {
+    const store = useCollectionFiltersStore()
+
+    expect(store.searchInput).toBe('')
+    expect(store.filters.genre).toBeUndefined()
+    expect(store.filters.search).toBeUndefined()
+    expect(store.filters.followed).toBe(false)
+    expect(store.filters.hasOwned).toBe(false)
+    expect(store.filters.hasRead).toBe(false)
+    expect(store.filters.hasWished).toBe(false)
+  })
+
+  it('persists search and filter changes to sessionStorage', async () => {
+    const store = useCollectionFiltersStore()
+
+    store.searchInput = 'naruto'
+    store.filters.genre = 'shonen'
+    store.filters.hasOwned = true
+    await nextTick()
+
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.searchInput).toBe('naruto')
+    expect(parsed.filters.genre).toBe('shonen')
+    expect(parsed.filters.hasOwned).toBe(true)
+  })
+
+  it('restores persisted filters on a fresh store instance', () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ searchInput: 'one piece', filters: { genre: 'seinen', hasRead: true } }),
+    )
+    setActivePinia(createPinia())
+
+    const store = useCollectionFiltersStore()
+    expect(store.searchInput).toBe('one piece')
+    expect(store.filters.genre).toBe('seinen')
+    expect(store.filters.hasRead).toBe(true)
+    // search is reconciled from the raw input so the list matches what is typed
+    expect(store.filters.search).toBe('one piece')
+    // unspecified booleans fall back to their defaults
+    expect(store.filters.hasOwned).toBe(false)
+  })
+
+  it('reset() clears search and every filter back to defaults', () => {
+    const store = useCollectionFiltersStore()
+    store.searchInput = 'bleach'
+    store.filters.genre = 'shojo'
+    store.filters.followed = true
+    store.filters.hasWished = true
+
+    store.reset()
+
+    expect(store.searchInput).toBe('')
+    expect(store.filters.genre).toBeUndefined()
+    expect(store.filters.followed).toBe(false)
+    expect(store.filters.hasWished).toBe(false)
+  })
+
+  it('falls back to defaults when the persisted payload is corrupt', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'not valid json {{{')
+    setActivePinia(createPinia())
+
+    const store = useCollectionFiltersStore()
+    expect(store.searchInput).toBe('')
+    expect(store.filters.genre).toBeUndefined()
+  })
+})

--- a/front/src/stores/useCollectionFiltersStore.ts
+++ b/front/src/stores/useCollectionFiltersStore.ts
@@ -1,0 +1,65 @@
+import { defineStore } from 'pinia'
+import { reactive, ref, watch } from 'vue'
+import type { CollectionFilters } from '@/api/collection'
+
+const STORAGE_KEY = 'collection-filters'
+
+interface PersistedCollectionFilters {
+  searchInput: string
+  filters: CollectionFilters
+}
+
+function createDefaultFilters(): CollectionFilters {
+  return {
+    search: undefined,
+    genre: undefined,
+    edition: undefined,
+    readingStatus: undefined,
+    sort: undefined,
+    followed: false,
+    hasOwned: false,
+    hasRead: false,
+    hasWished: false,
+  }
+}
+
+function loadPersisted(): PersistedCollectionFilters | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as PersistedCollectionFilters) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Holds the collection page's filter state outside the component so it survives
+ * navigating away and back (e.g. opening a series, then returning to the list).
+ * Backed by sessionStorage: filters also survive a reload but reset when the tab
+ * is closed — matching the auth token's session scope.
+ */
+export const useCollectionFiltersStore = defineStore('collectionFilters', () => {
+  const persisted = loadPersisted()
+
+  const searchInput = ref(persisted?.searchInput ?? '')
+  const filters = reactive<CollectionFilters>({ ...createDefaultFilters(), ...persisted?.filters })
+
+  // The raw search box is the source of truth for the search term; keep the
+  // (debounced) query value aligned with it on restore so the list and the
+  // input never disagree after a reload mid-typing.
+  filters.search = searchInput.value.trim() || undefined
+
+  watch(
+    () => ({ searchInput: searchInput.value, filters: { ...filters } }),
+    (snapshot) => {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+    },
+  )
+
+  function reset(): void {
+    searchInput.value = ''
+    Object.assign(filters, createDefaultFilters())
+  }
+
+  return { searchInput, filters, reset }
+})


### PR DESCRIPTION
## Summary
Extracted collection page filter state into a dedicated Pinia store backed by sessionStorage, allowing filters to survive navigation away and back (e.g. opening a series then returning to the list) while resetting when the tab closes.

## Changes
- **New store**: `useCollectionFiltersStore` manages `searchInput` and `filters` state with automatic sessionStorage persistence
  - Watches for changes and syncs to sessionStorage in real-time
  - Restores persisted state on store initialization with graceful fallback to defaults on corrupt data
  - Keeps `filters.search` aligned with `searchInput` on restore so the list and input never disagree after reload
  - Provides `reset()` method to clear all filters back to defaults
- **CollectionPage.vue**: Refactored to use the store instead of local `ref`/`reactive` state
  - Removed manual filter state declarations
  - Simplified `resetFilters()` to call `filtersStore.reset()`
  - Uses `storeToRefs()` for reactive `searchInput` binding
- **Test coverage**: Added comprehensive unit tests covering initialization, persistence, restoration, reset, and error handling

## Implementation Details
- Filters are persisted to sessionStorage under the key `'collection-filters'` as a JSON snapshot
- The store reconciles `filters.search` from `searchInput` on restore to ensure the debounced query value matches what the user typed before reload
- Boolean filters fall back to their defaults (false) if not present in persisted data, allowing safe schema evolution
- Corrupt sessionStorage data is caught and ignored, falling back to clean defaults

https://claude.ai/code/session_01JPL4jqDSc2xTKoQwxZkxWe