### PR TITLE
feat(front): loader BaseLoader unifié et adapté au thème

### DIFF
--- a/front/src/components/atoms/BaseLoader.vue
+++ b/front/src/components/atoms/BaseLoader.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+  import { computed } from 'vue'
+  import { useI18n } from 'vue-i18n'
+
+  const props = withDefaults(
+    defineProps<{
+      /** Outer diameter of the spinner. xs fits inside buttons, xl is a full-page loader. */
+      size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+      /** Optional caption shown beneath the spinner and used as the accessible name. */
+      label?: string
+    }>(),
+    {
+      size: 'md',
+      label: undefined,
+    },
+  )
+
+  const { t } = useI18n()
+
+  // xs is sized to line up with DaisyUI's loading-xs inside buttons; lg/xl are for full-page loaders.
+  const DIMENSIONS = {
+    xs: { box: '1rem', thickness: '2px' },
+    sm: { box: '1.75rem', thickness: '2px' },
+    md: { box: '2.75rem', thickness: '3px' },
+    lg: { box: '4rem', thickness: '3px' },
+    xl: { box: '5.5rem', thickness: '4px' },
+  } as const
+
+  const accessibleLabel = computed(() => props.label ?? t('common.loading'))
+
+  const styleVars = computed(() => ({
+    '--zig-loader-size': DIMENSIONS[props.size].box,
+    '--zig-loader-thickness': DIMENSIONS[props.size].thickness,
+  }))
+</script>
+
+<template>
+  <div
+    class="zig-loader inline-flex flex-col items-center justify-center gap-3 text-current"
+    role="status"
+    :aria-label="accessibleLabel"
+    :style="styleVars"
+  >
+    <span class="zig-loader__spinner" aria-hidden="true">
+      <span class="zig-loader__track" />
+      <span class="zig-loader__comet" />
+    </span>
+
+    <span v-if="label" class="text-sm text-base-content/60">{{ label }}</span>
+  </div>
+</template>
+
+<style scoped>
+  .zig-loader__spinner {
+    position: relative;
+    display: inline-block;
+    width: var(--zig-loader-size);
+    height: var(--zig-loader-size);
+  }
+
+  /*
+    The whole loader paints in currentColor, so the caller picks the colour with a text-*
+    utility and it stays legible on every light/dark theme — no baked-in colours, no logo.
+  */
+
+  /* Faint full ring that stays put, giving the comet something to sweep over. */
+  .zig-loader__track {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: var(--zig-loader-thickness) solid currentColor;
+    opacity: 0.15;
+  }
+
+  /* A conic-gradient comet masked into the same ring band, sweeping smoothly on top. */
+  .zig-loader__comet {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: conic-gradient(from 0deg, transparent, currentColor);
+    -webkit-mask: radial-gradient(
+      farthest-side,
+      transparent calc(100% - var(--zig-loader-thickness)),
+      #000 calc(100% - var(--zig-loader-thickness))
+    );
+    mask: radial-gradient(
+      farthest-side,
+      transparent calc(100% - var(--zig-loader-thickness)),
+      #000 calc(100% - var(--zig-loader-thickness))
+    );
+    will-change: transform;
+    animation: zig-loader-spin 0.7s linear infinite;
+  }
+
+  @keyframes zig-loader-spin {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+
+  /* Respect users who asked for less motion: slow the sweep right down. */
+  @media (prefers-reduced-motion: reduce) {
+    .zig-loader__comet {
+      animation-duration: 2.4s;
+    }
+  }
+</style>

--- a/front/src/components/atoms/BaseToast.vue
+++ b/front/src/components/atoms/BaseToast.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Toast } from '@/stores/useUiStore'
+import BaseLoader from './BaseLoader.vue'
 
 defineProps<{
   toast: Toast
@@ -16,7 +17,7 @@ defineProps<{
     }"
   >
     <template v-if="toast.type === 'progress'">
-      <span class="loading loading-spinner loading-xs" />
+      <BaseLoader size="xs" />
       <div class="flex flex-col gap-0.5 min-w-0">
         <span>{{ toast.message }}</span>
         <progress

--- a/front/src/components/atoms/__tests__/BaseLoader.spec.ts
+++ b/front/src/components/atoms/__tests__/BaseLoader.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import BaseLoader from '../BaseLoader.vue'
+import fr from '@/i18n/fr.json'
+import en from '@/i18n/en.json'
+
+function mountLoader(
+  props: { size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'; label?: string } = {},
+  attrs: Record<string, unknown> = {},
+) {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'fr',
+    fallbackLocale: 'en',
+    messages: { en, fr },
+  })
+  return mount(BaseLoader, { props, attrs, global: { plugins: [i18n] } })
+}
+
+describe('BaseLoader', () => {
+  it('exposes an accessible status role with the localized default label', () => {
+    const wrapper = mountLoader()
+
+    expect(wrapper.attributes('role')).toBe('status')
+    expect(wrapper.attributes('aria-label')).toBe(fr.common.loading)
+  })
+
+  it('renders the smooth ring as a faint track with a sweeping comet', () => {
+    const wrapper = mountLoader()
+
+    expect(wrapper.find('.zig-loader__track').exists()).toBe(true)
+    expect(wrapper.find('.zig-loader__comet').exists()).toBe(true)
+  })
+
+  it('drives its dimensions from the size prop via CSS variables', () => {
+    expect(mountLoader().attributes('style')).toContain('--zig-loader-size: 2.75rem')
+    expect(mountLoader({ size: 'xs' }).attributes('style')).toContain('--zig-loader-size: 1rem')
+    expect(mountLoader({ size: 'lg' }).attributes('style')).toContain('--zig-loader-size: 4rem')
+  })
+
+  it('shows a caption and uses it as the accessible name when label is provided', () => {
+    const wrapper = mountLoader({ label: 'Chargement de la bibliothèque…' })
+
+    expect(wrapper.text()).toContain('Chargement de la bibliothèque…')
+    expect(wrapper.attributes('aria-label')).toBe('Chargement de la bibliothèque…')
+  })
+
+  it('forwards utility classes onto the root so callers can theme the colour', () => {
+    const wrapper = mountLoader({ size: 'md' }, { class: 'text-primary' })
+
+    expect(wrapper.classes()).toContain('zig-loader')
+    expect(wrapper.classes()).toContain('text-primary')
+  })
+})

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -16,6 +16,7 @@ import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vu
 import { useI18n } from 'vue-i18n'
 import type { CollectionEntryDetail, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const { t } = useI18n()
 
@@ -673,7 +674,7 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
                         class="grow text-sm"
                         :placeholder="t('enrich.coverSearchPlaceholder')"
                       />
-                      <span v-if="isSearching" class="loading loading-spinner loading-xs opacity-40" />
+                      <BaseLoader v-if="isSearching" size="xs" class="opacity-40" />
                     </label>
                     <button class="btn btn-square btn-outline btn-sm shrink-0" :class="{ loading: isSearching }" :disabled="isSearching || searchQuery.trim().length < 2" title="Relancer" @click="runSearch(searchQuery)">
                       <RefreshCw v-if="!isSearching" class="h-4 w-4" />
@@ -710,7 +711,7 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
                     </button>
                   </TransitionGroup>
                   <div v-if="isLoadingMore || hasMore" class="py-3 flex items-center justify-center gap-2 text-xs text-base-content/40">
-                    <span v-if="isLoadingMore" class="loading loading-spinner loading-xs" />
+                    <BaseLoader v-if="isLoadingMore" size="xs" />
                     <span v-else>Défiler pour plus</span>
                   </div>
                 </template>

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -204,7 +204,8 @@
     "remove": "Remove",
     "next": "Next",
     "close": "Close",
-    "noData": "No data"
+    "noData": "No data",
+    "loading": "Loading…"
   },
   "share": {
     "button": "Share",

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -204,7 +204,8 @@
     "remove": "Retirer",
     "next": "Suivant",
     "close": "Fermer",
-    "noData": "Aucune donnée"
+    "noData": "Aucune donnée",
+    "loading": "Chargement…"
   },
   "share": {
     "button": "Partager",

--- a/front/src/pages/AddMangaPage.vue
+++ b/front/src/pages/AddMangaPage.vue
@@ -13,6 +13,7 @@
   import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
   import BaseProviderLogo from '@/components/atoms/BaseProviderLogo.vue'
   import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
+  import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
   const router = useRouter()
   const qc = useQueryClient()
@@ -220,7 +221,7 @@
             :placeholder="t('add.searchPlaceholder')"
             autocomplete="off"
           />
-          <span v-if="searchLoading" class="loading loading-spinner loading-xs opacity-50" />
+          <BaseLoader v-if="searchLoading" size="xs" class="opacity-50" />
         </label>
         <button
           v-if="query.trim().length >= 2"
@@ -284,7 +285,7 @@
           v-if="isLoadingMore || hasMore"
           class="py-3 flex items-center justify-center gap-2 text-xs text-base-content/40 border-t border-base-200"
         >
-          <span v-if="isLoadingMore" class="loading loading-spinner loading-xs" />
+          <BaseLoader v-if="isLoadingMore" size="xs" />
           <span v-else>Faites défiler pour en voir plus</span>
         </div>
       </div>

--- a/front/src/pages/AdminUsersPage.vue
+++ b/front/src/pages/AdminUsersPage.vue
@@ -12,6 +12,7 @@ import {
 import type { User } from '@/api/auth'
 import { useUiStore } from '@/stores/useUiStore'
 import { X } from 'lucide-vue-next'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const ui = useUiStore()
 const queryClient = useQueryClient()
@@ -160,7 +161,7 @@ async function copyResetLink(user: User): Promise<void> {
 
     <!-- Table -->
     <div v-if="isPending" class="flex justify-center py-12">
-      <span class="loading loading-spinner loading-lg" />
+      <BaseLoader size="lg" class="text-primary" />
     </div>
 
     <div v-else-if="(data?.items.length ?? 0) === 0" class="text-center py-12 text-base-content/60">
@@ -306,7 +307,7 @@ async function copyResetLink(user: User): Promise<void> {
         <div class="flex justify-end gap-2 px-5 py-4 border-t border-base-200 bg-base-200/40">
           <button class="btn btn-ghost btn-sm" :disabled="saving" @click="closeEdit">Annuler</button>
           <button class="btn btn-primary btn-sm" :disabled="saving" @click="saveEdit">
-            <span v-if="saving" class="loading loading-spinner loading-xs" />
+            <BaseLoader v-if="saving" size="xs" />
             Enregistrer
           </button>
         </div>

--- a/front/src/pages/CollectionPage.vue
+++ b/front/src/pages/CollectionPage.vue
@@ -10,6 +10,7 @@ import { getCollection, type CollectionFilters } from '@/api/collection'
 import { useI18n } from 'vue-i18n'
 import MangaCard from '@/components/organisms/MangaCard.vue'
 import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const showGuide = ref(false)
 
@@ -447,7 +448,7 @@ onUnmounted(() => {
       <!-- Infinite scroll sentinel + loading indicator -->
       <div ref="sentinel" class="h-4 mt-4" />
       <div v-if="isFetchingNextPage" class="flex justify-center py-6">
-        <span class="loading loading-spinner loading-md text-primary" />
+        <BaseLoader size="md" class="text-primary" />
       </div>
     </div>
 

--- a/front/src/pages/DashboardPage.vue
+++ b/front/src/pages/DashboardPage.vue
@@ -11,6 +11,7 @@ import MonthlyAdditionsChart from '@/components/molecules/MonthlyAdditionsChart.
 import ReadingStatusBar from '@/components/molecules/ReadingStatusBar.vue'
 import TopAuthorsList from '@/components/molecules/TopAuthorsList.vue'
 import ShareModal from '@/components/organisms/ShareModal.vue'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 import { coverUrl } from '@/utils/coverUrl'
 
 const { t, locale } = useI18n()
@@ -63,7 +64,7 @@ const today = computed(() =>
     </div>
 
     <div v-if="isPending" class="flex justify-center py-20">
-      <span class="loading loading-dots loading-lg text-primary" />
+      <BaseLoader size="lg" class="text-primary" />
     </div>
 
     <template v-else-if="stats">

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -21,6 +21,7 @@ import { useCoverBatchProgress } from '@/composables/useCoverBatchProgress'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
 import EnrichVolumeModal from '@/components/organisms/EnrichVolumeModal.vue'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
 import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
 import { FRENCH_EDITIONS } from '@/data/editions'
@@ -514,7 +515,7 @@ function volumeOpacityClass(ve: VolumeEntry): string {
 <template>
   <div class="min-h-screen" @click="closeContextMenu(); cancelEditCover(); closeActionMenus()">
     <div v-if="isPending" class="flex justify-center py-20">
-      <span class="loading loading-spinner loading-lg" />
+      <BaseLoader size="lg" class="text-primary" />
     </div>
 
     <template v-else-if="entry">
@@ -722,7 +723,7 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   >
                     <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="currentStatusOption.dot" />
                     <span>{{ currentStatusOption.label }}</span>
-                    <span v-if="statusMutation.isPending.value" class="loading loading-spinner w-3 h-3" />
+                    <BaseLoader v-if="statusMutation.isPending.value" size="xs" />
                     <ChevronDown v-else class="h-3.5 w-3.5 text-base-content/40 transition-transform" :class="statusMenuOpen ? 'rotate-180' : ''" />
                   </button>
                   <Transition name="menu-pop">

--- a/front/src/pages/NotificationPreferencesPage.vue
+++ b/front/src/pages/NotificationPreferencesPage.vue
@@ -6,6 +6,7 @@ import { patchNotificationPreferences, postNotificationTest } from '@/api/auth'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { useUiStore } from '@/stores/useUiStore'
 import { useI18n } from 'vue-i18n'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const { t } = useI18n()
 const auth = useAuthStore()
@@ -199,7 +200,7 @@ const { data: unread } = useQuery({
               :disabled="!canTest || testing || saving"
               @click="sendTest"
             >
-              <span v-if="testing" class="loading loading-spinner loading-xs" />
+              <BaseLoader v-if="testing" size="xs" />
               <svg v-else xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="22" y1="2" x2="11" y2="13"/>
                 <polygon points="22 2 15 22 11 13 2 9 22 2"/>
@@ -212,7 +213,7 @@ const { data: unread } = useQuery({
               :disabled="saving || testing"
               @click="savePreferences"
             >
-              <span v-if="saving" class="loading loading-spinner loading-xs" />
+              <BaseLoader v-if="saving" size="xs" />
               <svg v-else xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="20 6 9 17 4 12"/>
               </svg>

--- a/front/src/pages/ScanPage.vue
+++ b/front/src/pages/ScanPage.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useBarcodeScanner } from '@/composables/useBarcodeScanner'
 import { submitScan } from '@/api/manga'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -91,7 +92,7 @@ onMounted(() => {
           </div>
 
           <div v-if="isScanning && !cameraError" class="flex items-center gap-2 text-sm text-base-content/50 justify-center">
-            <span class="loading loading-spinner loading-xs" />
+            <BaseLoader size="xs" />
             Recherche du code-barres…
           </div>
         </template>

--- a/front/src/pages/SharePage.vue
+++ b/front/src/pages/SharePage.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { BookMarked, Layers, BookOpen, Heart, ArrowRight, Library } from 'lucide-vue-next'
 import { getShare } from '@/api/share'
 import AppLogo from '@/components/atoms/AppLogo.vue'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 import GenrePieChart from '@/components/molecules/GenrePieChart.vue'
 
 const route = useRoute()
@@ -62,7 +63,7 @@ const tiles = computed(() => {
     <main class="mx-auto max-w-3xl px-5 py-8 sm:py-12">
       <!-- Loading -->
       <div v-if="isPending" class="flex justify-center py-24">
-        <span class="loading loading-dots loading-lg text-primary" />
+        <BaseLoader size="lg" class="text-primary" />
       </div>
 
       <!-- Not found -->

--- a/front/src/pages/ShelfPage.vue
+++ b/front/src/pages/ShelfPage.vue
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/vue-query'
 import { getShelf, type ShelfCollection } from '@/api/shelf'
 import { coverUrl } from '@/utils/coverUrl'
 import { X } from 'lucide-vue-next'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 // ── Reactive state ────────────────────────────────────────────────────────────
 
@@ -1211,7 +1212,7 @@ onUnmounted(() => {
   >
     <div v-if="isLoading" class="absolute inset-0 flex items-center justify-center z-10">
       <div class="text-center text-white/60">
-        <div class="loading loading-dots loading-lg mb-3" />
+        <BaseLoader size="lg" class="mb-3" />
         <p class="text-sm">Chargement de la bibliothèque…</p>
       </div>
     </div>

--- a/front/src/pages/VerifyEmailPage.vue
+++ b/front/src/pages/VerifyEmailPage.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { postVerifyEmail } from '@/api/auth'
 import { useThemeStore } from '@/stores/useThemeStore'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -36,7 +37,7 @@ onMounted(async () => {
         <img :src="logoSrc" alt="Ziggytheque" class="h-28 w-auto object-contain" />
 
         <template v-if="status === 'loading'">
-          <span class="loading loading-spinner loading-lg" />
+          <BaseLoader size="lg" class="text-primary" />
           <p class="text-base-content/70 text-sm">Vérification de votre email…</p>
         </template>
 

--- a/front/src/pages/WishlistPage.vue
+++ b/front/src/pages/WishlistPage.vue
@@ -8,6 +8,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import type { WishlistEntry, VolumeEntry } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
+import BaseLoader from '@/components/atoms/BaseLoader.vue'
 
 const qc = useQueryClient()
 const ui = useUiStore()
@@ -394,7 +395,7 @@ onUnmounted(() => {
       <!-- Infinite scroll sentinel + loading indicator -->
       <div ref="sentinel" class="h-4" />
       <div v-if="isFetchingNextPage" class="flex justify-center py-6">
-        <span class="loading loading-spinner loading-md text-warning" />
+        <BaseLoader size="md" class="text-warning" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remplace les loaders DaisyUI éparpillés (loading-dots / loading-spinner) par un composant atom unique <BaseLoader>, réutilisé partout.

- anneau lisse (piste légère + comète en dégradé conique), animation GPU
- aucun logo : tout est peint en currentColor, donc lisible sur chaque thème clair/sombre sans couleur figée
- tailles xs→xl (xs s'aligne sur les boutons, lg/xl pour le plein écran)
- label optionnel + role="status"/aria-label (clé i18n common.loading)
- respecte prefers-reduced-motion
- bascule les 18 loaders éparpillés (13 fichiers : pages + BaseToast
  + EnrichVolumeModal) ; les skeletons animate-pulse restent inchangés

Test : spec Vitest du composant (rôle a11y, structure, tailles, label, couleur héritée).