### PR TITLE
Replace filter buttons with searchable dropdown for followed works

### DIFF
--- a/back/src/Notification/Application/GetFollowedEntries/GetFollowedEntriesHandler.php
+++ b/back/src/Notification/Application/GetFollowedEntries/GetFollowedEntriesHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\GetFollowedEntries;
+
+use App\Collection\Domain\CollectionEntry;
+use App\Collection\Domain\CollectionRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(bus: 'query.bus')]
+final readonly class GetFollowedEntriesHandler
+{
+    public function __construct(private CollectionRepositoryInterface $repository)
+    {
+    }
+
+    /**
+     * Every followed entry (notificationsEnabled = true) for the current owner,
+     * sorted by title. This is the source of truth for the Actualités filter, so
+     * it is never truncated by collection pagination — it scales to any number of
+     * followed works.
+     *
+     * @return list<array{id: string, manga: array{id: string, title: string, coverUrl: string|null}}>
+     */
+    public function __invoke(GetFollowedEntriesQuery $query): array
+    {
+        $entries = $this->repository->findFollowed();
+
+        usort(
+            $entries,
+            static fn (CollectionEntry $first, CollectionEntry $second): int
+                => strcasecmp($first->manga->title, $second->manga->title),
+        );
+
+        return array_map(
+            static fn (CollectionEntry $entry): array => [
+                'id'    => $entry->id,
+                'manga' => [
+                    'id'       => $entry->manga->id,
+                    'title'    => $entry->manga->title,
+                    'coverUrl' => $entry->manga->coverUrl,
+                ],
+            ],
+            $entries,
+        );
+    }
+}

--- a/back/src/Notification/Application/GetFollowedEntries/GetFollowedEntriesQuery.php
+++ b/back/src/Notification/Application/GetFollowedEntries/GetFollowedEntriesQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\GetFollowedEntries;
+
+final readonly class GetFollowedEntriesQuery
+{
+}

--- a/back/src/Notification/Infrastructure/Http/ArticleController.php
+++ b/back/src/Notification/Infrastructure/Http/ArticleController.php
@@ -6,6 +6,7 @@ namespace App\Notification\Infrastructure\Http;
 
 use App\Notification\Application\GetActivityLogs\GetActivityLogsQuery;
 use App\Notification\Application\GetArticles\GetArticlesQuery;
+use App\Notification\Application\GetFollowedEntries\GetFollowedEntriesQuery;
 use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,6 +29,16 @@ final readonly class ArticleController
         return new JsonResponse(
             $this->queryBus->ask(new GetArticlesQuery($page, $limit, $collectionEntryId)),
         );
+    }
+
+    /**
+     * Every followed work for the current account — the full set the Actualités
+     * filter needs, regardless of how large the collection is.
+     */
+    #[Route('/followed', methods: ['GET'])]
+    public function followed(): JsonResponse
+    {
+        return new JsonResponse($this->queryBus->ask(new GetFollowedEntriesQuery()));
     }
 
     #[Route('/activity-logs', methods: ['GET'])]

--- a/back/tests/Functional/Notification/ArticleControllerTest.php
+++ b/back/tests/Functional/Notification/ArticleControllerTest.php
@@ -104,6 +104,63 @@ final class ArticleControllerTest extends AbstractApiTestCase
         $this->assertSame(0, $otherData['total']);
     }
 
+    // ── GET /api/articles/followed ───────────────────────────────────────────
+
+    public function testFollowedRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/articles/followed', auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testFollowedReturnsEveryFollowedEntrySortedByTitle(): void
+    {
+        // Three series in the collection: two followed, one not.
+        $followedZeta  = $this->createFollowedEntry('Zeta Chronicles');
+        $followedAlpha = $this->createFollowedEntry('Alpha Tales');
+        $unfollowed    = $this->createCollectionEntry('Beta Unfollowed');
+
+        /** @var list<array{id: string, manga: array{id: string, title: string, coverUrl: string|null}}> $data */
+        $data = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/articles/followed'));
+
+        // Regression: every followed work comes back, never capped to one …
+        $this->assertCount(2, $data);
+        $ids = array_column($data, 'id');
+        $this->assertContains($followedAlpha, $ids);
+        $this->assertContains($followedZeta, $ids);
+        $this->assertNotContains($unfollowed, $ids);
+
+        // … sorted by title, carrying the lightweight manga shape the selector renders.
+        $this->assertSame('Alpha Tales', $data[0]['manga']['title']);
+        $this->assertSame('Zeta Chronicles', $data[1]['manga']['title']);
+        $this->assertArrayHasKey('id', $data[0]['manga']);
+        $this->assertArrayHasKey('coverUrl', $data[0]['manga']);
+    }
+
+    public function testFollowedReturnsEmptyWhenNothingFollowed(): void
+    {
+        $this->createCollectionEntry('Untracked Series');
+
+        $data = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/articles/followed'));
+
+        $this->assertSame([], $data);
+    }
+
+    public function testFollowedIsScopedToOwnerAccount(): void
+    {
+        $this->createFollowedEntry('Owner Only Series');
+
+        // A different account follows nothing of its own and must not see the owner's.
+        UserFixtureFactory::createActiveUser(static::getContainer(), email: 'reader-followed@test.local');
+        $this->client->request('GET', '/api/articles/followed', [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $this->tokenForUser('reader-followed@test.local'),
+            'HTTP_ACCEPT'        => 'application/json',
+        ]);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $otherData = (array) json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertSame([], $otherData);
+    }
+
     // ── GET /api/articles/activity-logs ──────────────────────────────────────
 
     public function testActivityLogsRequiresAuth(): void
@@ -139,5 +196,31 @@ final class ArticleControllerTest extends AbstractApiTestCase
 
         $this->assertSame(1, $data['page']);
         $this->assertSame(10, $data['limit']);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** Creates a manga + collection entry for the admin account and returns the entry id. */
+    private function createCollectionEntry(string $title): string
+    {
+        $mangaResponse = $this->jsonRequest('POST', '/api/manga', [
+            'title'        => $title,
+            'language'     => 'fr',
+            'totalVolumes' => null,
+        ]);
+        $mangaId = (string) ((array) json_decode((string) $mangaResponse->getContent(), true))['id'];
+
+        $entryResponse = $this->jsonRequest('POST', '/api/collection', ['mangaId' => $mangaId]);
+
+        return (string) ((array) json_decode((string) $entryResponse->getContent(), true))['id'];
+    }
+
+    /** Same as createCollectionEntry but also enables follow (notificationsEnabled). */
+    private function createFollowedEntry(string $title): string
+    {
+        $entryId = $this->createCollectionEntry($title);
+        $this->jsonRequest('PATCH', '/api/collection/' . $entryId . '/follow');
+
+        return $entryId;
     }
 }

--- a/back/tests/Unit/Notification/Application/GetFollowedEntries/GetFollowedEntriesHandlerTest.php
+++ b/back/tests/Unit/Notification/Application/GetFollowedEntries/GetFollowedEntriesHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Application\GetFollowedEntries;
+
+use App\Collection\Application\Get\GetCollectionQuery;
+use App\Collection\Application\GetWishlist\GetWishlistQuery;
+use App\Collection\Domain\CollectionEntry;
+use App\Collection\Domain\CollectionRepositoryInterface;
+use App\Manga\Domain\Manga;
+use App\Notification\Application\GetFollowedEntries\GetFollowedEntriesHandler;
+use App\Notification\Application\GetFollowedEntries\GetFollowedEntriesQuery;
+use PHPUnit\Framework\TestCase;
+
+final class GetFollowedEntriesHandlerTest extends TestCase
+{
+    /** @param list<CollectionEntry> $followed */
+    private function handlerWith(array $followed): GetFollowedEntriesHandler
+    {
+        $repository = new class ($followed) implements CollectionRepositoryInterface {
+            /** @param list<CollectionEntry> $followed */
+            public function __construct(private array $followed)
+            {
+            }
+
+            public function findById(string $id): ?CollectionEntry
+            {
+                return null;
+            }
+
+            public function findByMangaId(string $mangaId): ?CollectionEntry
+            {
+                return null;
+            }
+
+            public function findAll(): array
+            {
+                return [];
+            }
+
+            public function findFiltered(GetCollectionQuery $query): array
+            {
+                return ['items' => [], 'total' => 0];
+            }
+
+            public function findWishedFiltered(GetWishlistQuery $query): array
+            {
+                return ['items' => [], 'total' => 0];
+            }
+
+            public function findFollowed(): array
+            {
+                return $this->followed;
+            }
+
+            public function save(CollectionEntry $entry): void
+            {
+            }
+
+            public function delete(CollectionEntry $entry): void
+            {
+            }
+        };
+
+        return new GetFollowedEntriesHandler($repository);
+    }
+
+    private function entry(string $id, string $title, ?string $coverUrl = null): CollectionEntry
+    {
+        $manga = new Manga(id: 'm-' . $id, title: $title, edition: null, language: 'fr', coverUrl: $coverUrl);
+
+        return new CollectionEntry(id: $id, manga: $manga);
+    }
+
+    public function testReturnsEmptyArrayWhenNothingFollowed(): void
+    {
+        $result = ($this->handlerWith([]))(new GetFollowedEntriesQuery());
+
+        $this->assertSame([], $result);
+    }
+
+    public function testMapsEntryToLightweightShape(): void
+    {
+        $handler = $this->handlerWith([
+            $this->entry('ce-1', 'Naruto', 'https://example.test/naruto.jpg'),
+        ]);
+
+        $result = $handler(new GetFollowedEntriesQuery());
+
+        $this->assertSame([
+            [
+                'id'    => 'ce-1',
+                'manga' => [
+                    'id'       => 'm-ce-1',
+                    'title'    => 'Naruto',
+                    'coverUrl' => 'https://example.test/naruto.jpg',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function testReturnsAllFollowedEntriesSortedByTitleCaseInsensitively(): void
+    {
+        $handler = $this->handlerWith([
+            $this->entry('ce-z', 'Zatch Bell'),
+            $this->entry('ce-a', 'Akira'),
+            $this->entry('ce-m', 'monster'),
+        ]);
+
+        $result = $handler(new GetFollowedEntriesQuery());
+
+        // Every followed entry is returned (regression: never truncated to one) …
+        $this->assertCount(3, $result);
+
+        // … case-insensitively sorted by title.
+        $titles = array_column(array_column($result, 'manga'), 'title');
+        $this->assertSame(['Akira', 'monster', 'Zatch Bell'], $titles);
+    }
+}

--- a/front/src/api/notification.ts
+++ b/front/src/api/notification.ts
@@ -1,8 +1,14 @@
 import client from './client'
-import type { ArticlePage, ActivityLogPage, Notification } from '@/types'
+import type { ArticlePage, ActivityLogPage, ArticleCollectionEntry, Notification } from '@/types'
 
 export async function getNotifications(): Promise<Notification[]> {
   const res = await client.get('/notifications')
+  return res.data
+}
+
+/** Every followed work for the current account, sorted by title — not paginated. */
+export async function getFollowedEntries(): Promise<ArticleCollectionEntry[]> {
+  const res = await client.get('/articles/followed')
   return res.data
 }
 

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -101,6 +101,8 @@
     "filterBy": "Filter by",
     "allMangas": "All",
     "noFollowed": "Enable notifications on a series to see its news",
+    "searchFollowed": "Search a series…",
+    "noFollowedMatch": "No series match",
     "follow": "Follow",
     "following": "Following ✓",
     "followOn": "You're following this series — we'll let you know about new releases.",

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -101,6 +101,8 @@
     "filterBy": "Filtrer par",
     "allMangas": "Tous",
     "noFollowed": "Activez le suivi sur une série pour voir ses actualités",
+    "searchFollowed": "Rechercher une œuvre…",
+    "noFollowedMatch": "Aucune œuvre ne correspond",
     "follow": "Suivre",
     "following": "Suivi ✓",
     "followOn": "Tu suis cette série — on te préviendra des nouvelles sorties.",

--- a/front/src/pages/NotificationsPage.vue
+++ b/front/src/pages/NotificationsPage.vue
@@ -1,27 +1,37 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useQuery } from '@tanstack/vue-query'
-import { getArticles } from '@/api/notification'
-import { getCollection } from '@/api/collection'
+import { getArticles, getFollowedEntries } from '@/api/notification'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
+import { ChevronDown, Check, Search } from 'lucide-vue-next'
 import ArticleCard from '@/components/molecules/ArticleCard.vue'
-import type { CollectionEntry } from '@/types'
+import type { ArticleCollectionEntry } from '@/types'
 
 const { t } = useI18n()
 
 const page = ref(1)
 const limit = 12
 const selectedCollectionId = ref<string | undefined>(undefined)
+const followedSearch = ref('')
 
-const { data: collection } = useQuery({
-  queryKey: ['collection'],
-  queryFn: () => getCollection(),
+// Source of truth for the filter: ALL followed works, never truncated by
+// collection pagination — so the selector holds up whatever the count.
+const { data: followedEntries } = useQuery({
+  queryKey: ['followed-entries'],
+  queryFn: () => getFollowedEntries(),
+  initialData: [] as ArticleCollectionEntry[],
 })
 
-const followedEntries = computed<CollectionEntry[]>(
-  () => collection.value?.items.filter((entry) => entry.notificationsEnabled) ?? [],
+const selectedEntry = computed<ArticleCollectionEntry | undefined>(
+  () => followedEntries.value.find((entry) => entry.id === selectedCollectionId.value),
 )
+
+const filteredFollowed = computed<ArticleCollectionEntry[]>(() => {
+  const term = followedSearch.value.trim().toLowerCase()
+  if (!term) return followedEntries.value
+  return followedEntries.value.filter((entry) => entry.manga.title.toLowerCase().includes(term))
+})
 
 const { data: articlePage, isPending } = useQuery({
   queryKey: computed(() => ['articles', page.value, selectedCollectionId.value]),
@@ -29,6 +39,20 @@ const { data: articlePage, isPending } = useQuery({
 })
 
 watch(selectedCollectionId, () => { page.value = 1 })
+
+// Reset to "All" if the active selection is no longer followed (unfollowed elsewhere).
+watch(followedEntries, (entries) => {
+  if (selectedCollectionId.value && !entries.some((entry) => entry.id === selectedCollectionId.value)) {
+    selectedCollectionId.value = undefined
+  }
+})
+
+function selectEntry(id: string | undefined): void {
+  selectedCollectionId.value = id
+  followedSearch.value = ''
+  // Close the DaisyUI focus-based dropdown after picking.
+  ;(document.activeElement as HTMLElement | null)?.blur()
+}
 </script>
 
 <template>
@@ -48,33 +72,81 @@ watch(selectedCollectionId, () => { page.value = 1 })
     </div>
 
     <div class="max-w-4xl mx-auto px-6 py-8 space-y-8">
-      <!-- Filter bar -->
+      <!-- Filter bar — a single dropdown that scales to any number of followed works -->
       <div class="flex items-center gap-3 flex-wrap">
         <span class="text-sm text-base-content/60 shrink-0">{{ t('notifications.filterBy') }}</span>
-        <button
-          class="btn btn-sm"
-          :class="selectedCollectionId === undefined ? 'btn-primary' : 'btn-ghost'"
-          @click="selectedCollectionId = undefined"
-        >
-          {{ t('notifications.allMangas') }}
-        </button>
-        <button
-          v-for="entry in followedEntries"
-          :key="entry.id"
-          class="btn btn-sm gap-1.5"
-          :class="selectedCollectionId === entry.id ? 'btn-primary' : 'btn-ghost'"
-          @click="selectedCollectionId = entry.id"
-        >
-          <img
-            v-if="entry.manga.coverUrl"
-            :src="entry.manga.coverUrl"
-            :alt="entry.manga.title"
-            class="w-4 h-5 object-cover rounded-sm"
-          />
-          <span class="truncate max-w-28">{{ entry.manga.title }}</span>
-        </button>
 
-        <p v-if="followedEntries.length === 0" class="text-sm text-base-content/40 italic">
+        <div v-if="followedEntries.length" class="dropdown">
+          <button tabindex="0" class="btn btn-sm gap-2 normal-case max-w-full">
+            <template v-if="selectedEntry">
+              <img
+                v-if="selectedEntry.manga.coverUrl"
+                :src="selectedEntry.manga.coverUrl"
+                :alt="selectedEntry.manga.title"
+                class="w-4 h-5 object-cover rounded-sm shrink-0"
+              />
+              <span class="truncate max-w-40">{{ selectedEntry.manga.title }}</span>
+            </template>
+            <span v-else>{{ t('notifications.allMangas') }}</span>
+            <ChevronDown class="w-4 h-4 shrink-0 opacity-60" />
+          </button>
+
+          <div
+            tabindex="0"
+            class="dropdown-content bg-base-200 rounded-box shadow-lg z-50 mt-1 w-72 max-w-[calc(100vw-3rem)] p-2"
+          >
+            <!-- Search appears only once the list is long enough to need it -->
+            <label
+              v-if="followedEntries.length > 8"
+              class="input input-sm input-bordered flex items-center gap-2 mb-2"
+            >
+              <Search class="w-4 h-4 opacity-50" />
+              <input
+                v-model="followedSearch"
+                type="text"
+                class="grow"
+                :placeholder="t('notifications.searchFollowed')"
+              />
+            </label>
+
+            <ul class="max-h-72 overflow-y-auto space-y-0.5">
+              <li>
+                <button
+                  class="btn btn-ghost btn-sm w-full justify-between font-normal"
+                  :class="{ 'btn-active text-primary': selectedCollectionId === undefined }"
+                  @click="selectEntry(undefined)"
+                >
+                  <span>{{ t('notifications.allMangas') }}</span>
+                  <Check v-if="selectedCollectionId === undefined" class="w-4 h-4 shrink-0" />
+                </button>
+              </li>
+              <li v-for="entry in filteredFollowed" :key="entry.id">
+                <button
+                  class="btn btn-ghost btn-sm w-full justify-start gap-2 font-normal"
+                  :class="{ 'btn-active text-primary': selectedCollectionId === entry.id }"
+                  @click="selectEntry(entry.id)"
+                >
+                  <img
+                    v-if="entry.manga.coverUrl"
+                    :src="entry.manga.coverUrl"
+                    :alt="entry.manga.title"
+                    class="w-4 h-5 object-cover rounded-sm shrink-0"
+                  />
+                  <span class="truncate flex-1 text-left">{{ entry.manga.title }}</span>
+                  <Check v-if="selectedCollectionId === entry.id" class="w-4 h-4 shrink-0" />
+                </button>
+              </li>
+              <li
+                v-if="filteredFollowed.length === 0"
+                class="px-2 py-3 text-center text-sm text-base-content/40"
+              >
+                {{ t('notifications.noFollowedMatch') }}
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <p v-else class="text-sm text-base-content/40 italic">
           {{ t('notifications.noFollowed') }}
         </p>
       </div>


### PR DESCRIPTION
## Summary
Refactors the Notifications page filter UI from individual buttons to a single searchable dropdown that scales to any number of followed works. Adds a new backend endpoint to fetch all followed entries as the source of truth for the filter, ensuring the selector never truncates results regardless of collection size.

## Changes

**Backend:**
- New `GetFollowedEntriesQuery` and `GetFollowedEntriesHandler` to fetch all followed collection entries sorted by title (case-insensitive)
- New `GET /api/articles/followed` endpoint returning lightweight manga shape (id, title, coverUrl)
- Full functional test coverage: auth requirement, sorting, pagination regression, account scoping
- Unit test for handler covering empty state, mapping, and sorting logic

**Frontend:**
- Replaced horizontal button row with DaisyUI dropdown component
- Added search input (appears only when list exceeds 8 items) to filter followed works by title
- Integrated `getFollowedEntries()` API call as source of truth for filter options
- Added watcher to reset selection to "All" if a followed work is unfollowed elsewhere
- Updated i18n with new search placeholder and no-match message keys
- Improved UX: dropdown closes after selection, check marks indicate active choice, truncation handled gracefully

## Implementation Details
- The dropdown uses `filteredFollowed` computed property for client-side search, keeping the full list in `followedEntries` as the authoritative source
- Backend sorts case-insensitively using `strcasecmp` to match frontend expectations
- Regression test ensures all followed entries are returned (never capped to one) regardless of collection pagination
- Dropdown respects DaisyUI focus-based behavior with explicit blur on selection

https://claude.ai/code/session_012KLbjPaJ7gQ49FKRsuyQE9