### PR TITLE
Implement MangaArticleMatcher to prevent false-positive article matches

### DIFF
--- a/back/src/Notification/Domain/Service/MangaArticleMatcher.php
+++ b/back/src/Notification/Domain/Service/MangaArticleMatcher.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain\Service;
+
+/**
+ * Decides whether a news article actually mentions a followed manga.
+ *
+ * A followed title often carries a trailing edition/variant descriptor
+ * (e.g. "Dorohedoro - Chaos edition", "Berserk - Édition collector"). Matching
+ * on individual words such as "edition" produced false positives: an article
+ * about a different series ("La Complete Edition du manga Hunt - Beast Side")
+ * was attached to "Dorohedoro" only because both contained the word "edition".
+ *
+ * The rule enforced here: the core series title — the edition descriptor
+ * stripped off — must appear as a whole, word-bounded phrase in the article
+ * text. The work must absolutely be named; a loose keyword overlap is not enough.
+ */
+final readonly class MangaArticleMatcher
+{
+    /**
+     * Words marking the trailing title segment as an edition/variant descriptor
+     * rather than part of the work's name. Compared diacritics-folded, so the
+     * accented forms ("édition", "intégrale") are covered by the ASCII entries.
+     *
+     * @var list<string>
+     */
+    private const EDITION_MARKERS = [
+        'edition',
+        'editions',
+        'collector',
+        'deluxe',
+        'integrale',
+        'coffret',
+        'ultimate',
+        'kanzenban',
+        'perfect',
+        'anniversary',
+        'hardcover',
+        'omnibus',
+    ];
+
+    /** @var array<string, string> */
+    private const DIACRITIC_MAP = [
+        'à' => 'a', 'â' => 'a', 'ä' => 'a', 'á' => 'a', 'ã' => 'a', 'å' => 'a',
+        'ç' => 'c',
+        'é' => 'e', 'è' => 'e', 'ê' => 'e', 'ë' => 'e',
+        'î' => 'i', 'ï' => 'i', 'í' => 'i', 'ì' => 'i',
+        'ô' => 'o', 'ö' => 'o', 'ó' => 'o', 'ò' => 'o', 'õ' => 'o',
+        'û' => 'u', 'ü' => 'u', 'ù' => 'u', 'ú' => 'u',
+        'ÿ' => 'y', 'ý' => 'y',
+        'ñ' => 'n',
+        'œ' => 'oe', 'æ' => 'ae', 'ß' => 'ss',
+    ];
+
+    /**
+     * True when the core series title appears, as a whole word-bounded phrase,
+     * anywhere in the supplied article text (title + description/excerpt).
+     */
+    public function mentions(string $mangaTitle, string $articleText): bool
+    {
+        $core = $this->normalize($this->coreTitle($mangaTitle));
+        if ($core === '') {
+            return false;
+        }
+
+        $haystack = $this->normalize($articleText);
+        if ($haystack === '') {
+            return false;
+        }
+
+        return str_contains(' ' . $haystack . ' ', ' ' . $core . ' ');
+    }
+
+    /**
+     * The normalized significant words of the core title, in order. Callers use
+     * them to build a relevant snippet around the first occurrence in the text.
+     *
+     * @return list<string>
+     */
+    public function coreTitleWords(string $mangaTitle): array
+    {
+        $core = $this->normalize($this->coreTitle($mangaTitle));
+
+        return $core === '' ? [] : explode(' ', $core);
+    }
+
+    /**
+     * Strips a trailing edition/variant descriptor segment from the title.
+     * "Dorohedoro - Chaos edition" → "Dorohedoro"; "Hunt - Beast Side" is kept
+     * intact because no segment looks like an edition descriptor.
+     */
+    private function coreTitle(string $mangaTitle): string
+    {
+        $segments = preg_split('/\s+[-–—]\s+|\s*:\s+/u', trim($mangaTitle)) ?: [$mangaTitle];
+
+        while (count($segments) > 1 && $this->isEditionDescriptor((string) end($segments))) {
+            array_pop($segments);
+        }
+
+        return implode(' ', $segments);
+    }
+
+    private function isEditionDescriptor(string $segment): bool
+    {
+        $normalized = $this->normalize($segment);
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (explode(' ', $normalized) as $word) {
+            if (in_array($word, self::EDITION_MARKERS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Lowercase, fold common diacritics, collapse every run of non-alphanumeric
+     * characters to a single space, then trim. The result is a space-delimited
+     * token stream so phrase matching is punctuation- and accent-insensitive.
+     */
+    private function normalize(string $value): string
+    {
+        $value = mb_strtolower(trim($value));
+        $value = strtr($value, self::DIACRITIC_MAP);
+        $value = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $value) ?? '';
+
+        return trim($value);
+    }
+}

--- a/back/src/Notification/Infrastructure/Jikan/JikanNewsClient.php
+++ b/back/src/Notification/Infrastructure/Jikan/JikanNewsClient.php
@@ -9,6 +9,7 @@ use App\Notification\Domain\Article;
 use App\Notification\Domain\ArticleRepositoryInterface;
 use App\Notification\Domain\Service\JikanFetchResult;
 use App\Notification\Domain\Service\JikanNewsClientInterface;
+use App\Notification\Domain\Service\MangaArticleMatcher;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -20,6 +21,7 @@ final readonly class JikanNewsClient implements JikanNewsClientInterface
     public function __construct(
         private HttpClientInterface $httpClient,
         private ArticleRepositoryInterface $articleRepository,
+        private MangaArticleMatcher $matcher,
     ) {
     }
 
@@ -39,6 +41,12 @@ final readonly class JikanNewsClient implements JikanNewsClientInterface
             if ($url === null) {
                 continue;
             }
+            $itemTitle   = (string) ($item['title'] ?? '');
+            $itemExcerpt = (string) ($item['excerpt'] ?? '');
+            // The work must be named in the article — MAL tags alone are not enough.
+            if (!$this->matcher->mentions($entry->manga->title, $itemTitle . ' ' . $itemExcerpt)) {
+                continue;
+            }
             if ($this->articleRepository->existsByCollectionEntryAndUrl($entry->id, $url)) {
                 continue;
             }
@@ -49,15 +57,13 @@ final readonly class JikanNewsClient implements JikanNewsClientInterface
             $article = new Article(
                 id: Uuid::v4()->toRfc4122(),
                 collectionEntry: $entry,
-                title: mb_substr((string) ($item['title'] ?? 'Jikan News'), 0, 500),
+                title: mb_substr($itemTitle !== '' ? $itemTitle : 'Jikan News', 0, 500),
                 url: $url,
                 sourceName: 'jikan-news',
                 author: $item['author_username'] ?? null,
                 imageUrl: null,
                 publishedAt: $publishedAt,
-                snippet: isset($item['excerpt']) && $item['excerpt'] !== ''
-                    ? mb_substr((string) $item['excerpt'], 0, 500)
-                    : null,
+                snippet: $itemExcerpt !== '' ? mb_substr($itemExcerpt, 0, 500) : null,
             );
             $article->owner = $entry->owner;
             $this->articleRepository->save($article);

--- a/back/src/Notification/Infrastructure/Rss/RssFeedParser.php
+++ b/back/src/Notification/Infrastructure/Rss/RssFeedParser.php
@@ -7,6 +7,7 @@ namespace App\Notification\Infrastructure\Rss;
 use App\Collection\Domain\CollectionEntry;
 use App\Notification\Domain\Article;
 use App\Notification\Domain\ArticleRepositoryInterface;
+use App\Notification\Domain\Service\MangaArticleMatcher;
 use App\Notification\Domain\Service\RssFeedParserException;
 use App\Notification\Domain\Service\RssFeedParserInterface;
 use App\Notification\Domain\Service\RssFetchResult;
@@ -21,6 +22,7 @@ final readonly class RssFeedParser implements RssFeedParserInterface
     public function __construct(
         private HttpClientInterface $httpClient,
         private ArticleRepositoryInterface $articleRepository,
+        private MangaArticleMatcher $matcher,
     ) {
     }
 
@@ -67,12 +69,8 @@ final readonly class RssFeedParser implements RssFeedParserInterface
     {
         $newCount        = 0;
         $itemsScanned    = 0;
-        $normalizedTitle = mb_strtolower($mangaTitle);
-        $keywords        = array_filter(
-            array_map('trim', explode(' ', $normalizedTitle)),
-            static fn (string $k) => mb_strlen($k) >= 3,
-        );
-        $channel = $xml->channel ?? $xml;
+        $snippetKeywords = $this->matcher->coreTitleWords($mangaTitle);
+        $channel         = $xml->channel ?? $xml;
 
         foreach ($channel->item ?? [] as $item) {
             ++$itemsScanned;
@@ -86,13 +84,8 @@ final readonly class RssFeedParser implements RssFeedParserInterface
             $itemUrl  = (string) ($item->link ?? $item->guid ?? '');
             $itemDate = (string) ($item->pubDate ?? $item->children('dc', true)->date ?? '');
 
-            $haystack   = mb_strtolower($itemTitle . ' ' . $itemDesc);
-            $titleMatch = str_contains($haystack, $normalizedTitle);
-            $matches    = $titleMatch
-                ? [$normalizedTitle]
-                : array_filter($keywords, static fn (string $k) => str_contains($haystack, $k));
-
-            if (empty($matches) || $itemUrl === '') {
+            // The work must be named in the article — a loose keyword overlap is not enough.
+            if ($itemUrl === '' || !$this->matcher->mentions($mangaTitle, $itemTitle . ' ' . $itemDesc)) {
                 continue;
             }
 
@@ -117,7 +110,7 @@ final readonly class RssFeedParser implements RssFeedParserInterface
                 author: null,
                 imageUrl: $this->extractImage($item),
                 publishedAt: $publishedAt ?: null,
-                snippet: $this->extractSnippet($itemDesc, array_values($matches)),
+                snippet: $this->extractSnippet($itemDesc, $snippetKeywords),
             );
             $article->owner = $entry->owner;
             $this->articleRepository->save($article);

--- a/back/tests/Unit/Notification/Domain/Service/MangaArticleMatcherTest.php
+++ b/back/tests/Unit/Notification/Domain/Service/MangaArticleMatcherTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Domain\Service;
+
+use App\Notification\Domain\Service\MangaArticleMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class MangaArticleMatcherTest extends TestCase
+{
+    private MangaArticleMatcher $matcher;
+
+    protected function setUp(): void
+    {
+        $this->matcher = new MangaArticleMatcher();
+    }
+
+    /**
+     * The reported bug: an article about a different series was attached to
+     * "Dorohedoro - Chaos edition" only because both contained "edition".
+     */
+    public function testRejectsArticleThatDoesNotNameTheWork(): void
+    {
+        $this->assertFalse($this->matcher->mentions(
+            'Dorohedoro - Chaos edition',
+            'La Complete Edition du manga Hunt - Beast Side se précise',
+        ));
+    }
+
+    public function testMatchesWhenTheCoreTitleIsNamed(): void
+    {
+        $this->assertTrue($this->matcher->mentions(
+            'Dorohedoro - Chaos edition',
+            'Dorohedoro : la Chaos Edition repoussée au printemps 2027',
+        ));
+    }
+
+    public function testMatchesAgainstTheDescriptionNotOnlyTheTitle(): void
+    {
+        $this->assertTrue($this->matcher->mentions(
+            'Berserk',
+            'Nouveautés du mois — au programme, un nouveau tome de Berserk attendu',
+        ));
+    }
+
+    #[DataProvider('editionDescriptorTitles')]
+    public function testStripsTrailingEditionDescriptor(string $title, string $expectedCore): void
+    {
+        // The bare series name is enough to match…
+        $this->assertTrue($this->matcher->mentions($title, $expectedCore . ' : annonce officielle'));
+        // …while a generic edition headline naming another work is not.
+        $this->assertFalse($this->matcher->mentions(
+            $title,
+            'La nouvelle édition collector deluxe du manga One Piece arrive',
+        ));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function editionDescriptorTitles(): iterable
+    {
+        yield 'chaos edition'      => ['Dorohedoro - Chaos edition', 'Dorohedoro'];
+        yield 'accented edition'   => ['Berserk - Édition collector', 'Berserk'];
+        yield 'colon separator'    => ['Vinland Saga : Édition originale', 'Vinland Saga'];
+        yield 'deluxe alone'       => ['Gunnm - Deluxe', 'Gunnm'];
+        yield 'integrale accented' => ['Akira - Intégrale', 'Akira'];
+        yield 'perfect edition'    => ['Slam Dunk - Perfect Edition', 'Slam Dunk'];
+    }
+
+    public function testKeepsDashedTitleWhenSuffixIsNotAnEdition(): void
+    {
+        // "Hunt - Beast Side" is a real title, not an edition variant.
+        $this->assertTrue($this->matcher->mentions(
+            'Hunt - Beast Side',
+            'La Complete Edition du manga Hunt - Beast Side se précise',
+        ));
+    }
+
+    public function testDashedTitleStillRequiresTheWholePhrase(): void
+    {
+        // A single shared word is not enough — the whole core phrase must appear.
+        $this->assertFalse($this->matcher->mentions(
+            'Hunt - Beast Side',
+            'Une chasse au trésor (treasure hunt) dans ce nouveau shonen',
+        ));
+    }
+
+    #[DataProvider('accentInsensitiveCases')]
+    public function testMatchingIsAccentInsensitive(string $title, string $articleText): void
+    {
+        $this->assertTrue($this->matcher->mentions($title, $articleText));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function accentInsensitiveCases(): iterable
+    {
+        yield 'accent in title only'   => ['Pokémon', 'Le nouveau tome de Pokemon est disponible'];
+        yield 'accent in article only' => ['Pokemon', 'Le nouveau tome de Pokémon est disponible'];
+    }
+
+    #[DataProvider('wordBoundaryCases')]
+    public function testRespectsWordBoundaries(string $title, string $articleText, bool $expected): void
+    {
+        $this->assertSame($expected, $this->matcher->mentions($title, $articleText));
+    }
+
+    /** @return iterable<string, array{string, string, bool}> */
+    public static function wordBoundaryCases(): iterable
+    {
+        yield 'exact word matches'        => ['Naruto', 'Le retour de Naruto annoncé', true];
+        yield 'prefix does not match'     => ['Naruto', 'Bienvenue dans le Narutoverse', false];
+        yield 'plural does not match'     => ['Dorohedoro', 'Tous les Dorohedoros réunis', false];
+        yield 'multi-word phrase matches' => ['One Piece', 'Un nouvel arc pour One Piece', true];
+        yield 'split phrase no match'     => ['One Piece', 'Une pièce maîtresse, the one', false];
+    }
+
+    #[DataProvider('emptyCases')]
+    public function testEmptyInputsNeverMatch(string $title, string $articleText): void
+    {
+        $this->assertFalse($this->matcher->mentions($title, $articleText));
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function emptyCases(): iterable
+    {
+        yield 'empty title'       => ['', 'Un article quelconque sur un manga'];
+        yield 'empty article'     => ['Dorohedoro', ''];
+        yield 'whitespace title'  => ['   ', 'Dorohedoro arrive'];
+        yield 'punctuation title' => ['---', 'Dorohedoro arrive'];
+    }
+
+    #[DataProvider('coreTitleWordsCases')]
+    public function testCoreTitleWordsExposesNormalizedTokens(string $title, array $expected): void
+    {
+        $this->assertSame($expected, $this->matcher->coreTitleWords($title));
+    }
+
+    /**
+     * @return iterable<string, array{string, list<string>}>
+     */
+    public static function coreTitleWordsCases(): iterable
+    {
+        yield 'edition stripped' => ['Dorohedoro - Chaos edition', ['dorohedoro']];
+        yield 'dashed title kept' => ['Hunt - Beast Side', ['hunt', 'beast', 'side']];
+        yield 'accents folded'   => ['Pokémon', ['pokemon']];
+        yield 'empty'            => ['', []];
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a new domain service `MangaArticleMatcher` to fix false-positive article matching in RSS and Jikan news feeds. Previously, articles were matched based on loose keyword overlap (e.g., "edition"), causing unrelated manga articles to be incorrectly attached to followed titles. The matcher now enforces that the core series name must appear as a whole, word-bounded phrase in the article text.

## Key Changes

- **New domain service: `MangaArticleMatcher`**
  - Strips trailing edition/variant descriptors ("Chaos edition", "Édition collector", etc.) from manga titles to extract the core series name
  - Matches the core name as a complete word-bounded phrase in article text (title + description)
  - Normalizes text by folding diacritics, lowercasing, and collapsing punctuation to handle accent-insensitive and punctuation-insensitive matching
  - Exposes `coreTitleWords()` for building relevant snippets around first occurrence
  - Comprehensive unit test suite covering edge cases: edition stripping, dashed titles, accent handling, word boundaries, and empty inputs

- **Updated `RssFeedParser`**
  - Replaced ad-hoc keyword matching logic with `MangaArticleMatcher::mentions()` call
  - Uses `coreTitleWords()` to extract snippet keywords instead of manual filtering
  - Enforces that the work must be explicitly named in the article

- **Updated `JikanNewsClient`**
  - Added `MangaArticleMatcher::mentions()` check to filter articles
  - Prevents MAL tags alone from triggering false matches; the article text must actually mention the manga title

## Implementation Details

- Edition markers include common variants: edition, collector, deluxe, intégrale, coffret, ultimate, kanzenban, perfect, anniversary, hardcover, omnibus
- Diacritic folding map covers French, Spanish, German, and other common accented characters
- Word boundary enforcement uses space-padding trick: `' ' . $haystack . ' '` to match ` core ` as a phrase
- Normalization pipeline: lowercase → diacritic folding → collapse non-alphanumeric to spaces → trim
- Handles multi-word titles ("One Piece") and dashed titles that are not edition variants ("Hunt - Beast Side")

https://claude.ai/code/session_01HsQV4ZZn4odGorrHb1E2xq