### PR TITLE
Refonte activity logs, éditions exhaustives, prix multi-boutiques, ISBN auto-save et passe mobile

### DIFF
--- a/back/config/packages/doctrine.yaml
+++ b/back/config/packages/doctrine.yaml
@@ -10,6 +10,9 @@ doctrine:
             isbn: App\Manga\Infrastructure\Doctrine\Type\IsbnType
     orm:
         naming_strategy: doctrine.orm.naming_strategy.underscore
+        dql:
+            string_functions:
+                JSON_GET_TEXT: App\Shared\Infrastructure\Doctrine\Query\JsonGetTextFunction
         identity_generation_preferences:
             Doctrine\DBAL\Platforms\PostgreSQLPlatform: identity
         auto_mapping: false

--- a/back/config/services.yaml
+++ b/back/config/services.yaml
@@ -57,6 +57,10 @@ services:
     App\Shared\Domain\Security\CurrentUserProviderInterface:
         alias: App\Auth\Infrastructure\Security\SymfonyCurrentUserProvider
 
+    # ActivityLog owner attribution (security token in HTTP, null in worker)
+    App\Notification\Domain\ActivityLogOwnerResolverInterface:
+        alias: App\Auth\Infrastructure\Security\ActivityLogOwnerResolver
+
     # Gate auth (second factor admin)
     App\Auth\Application\Gate\GateHandler:
         arguments:

--- a/back/src/Auth/Application/Gate/GateHandler.php
+++ b/back/src/Auth/Application/Gate/GateHandler.php
@@ -38,7 +38,7 @@ final readonly class GateHandler
 
             $this->eventBus->publish(new GateSucceededEvent(
                 correlationId: $started->correlationId,
-                token: $token,
+                userId: $command->user->id,
             ));
 
             return $token;

--- a/back/src/Auth/Application/Login/LoginHandler.php
+++ b/back/src/Auth/Application/Login/LoginHandler.php
@@ -8,9 +8,14 @@ use App\Auth\Domain\Exception\AccountNotActivatedException;
 use App\Auth\Domain\Exception\InvalidCredentialsException;
 use App\Auth\Domain\UserRepositoryInterface;
 use App\Auth\Domain\UserStatusEnum;
+use App\Auth\Shared\Event\LoginFailedEvent;
+use App\Auth\Shared\Event\LoginStartedEvent;
+use App\Auth\Shared\Event\LoginSucceededEvent;
+use App\Shared\Application\Bus\EventBusInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Throwable;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class LoginHandler
@@ -19,24 +24,46 @@ final readonly class LoginHandler
         private UserRepositoryInterface $userRepository,
         private UserPasswordHasherInterface $passwordHasher,
         private JWTTokenManagerInterface $jwtManager,
+        private EventBusInterface $eventBus,
     ) {
     }
 
     public function __invoke(LoginCommand $command): string
     {
-        $user = $this->userRepository->findByEmail($command->email);
+        $started = new LoginStartedEvent();
+        $this->eventBus->publish($started);
 
-        if ($user === null || !$this->passwordHasher->isPasswordValid($user, $command->password)) {
-            throw new InvalidCredentialsException();
+        try {
+            $user = $this->userRepository->findByEmail($command->email);
+
+            if ($user === null || !$this->passwordHasher->isPasswordValid($user, $command->password)) {
+                throw new InvalidCredentialsException();
+            }
+
+            if ($user->status !== UserStatusEnum::Active) {
+                throw new AccountNotActivatedException($user->status);
+            }
+
+            $user->recordLogin();
+            $this->userRepository->save($user);
+
+            $token = $this->jwtManager->create($user);
+
+            $this->eventBus->publish(new LoginSucceededEvent(
+                correlationId: $started->correlationId,
+                userId: $user->id,
+                email: $user->email,
+            ));
+
+            return $token;
+        } catch (Throwable $exception) {
+            $this->eventBus->publish(new LoginFailedEvent(
+                correlationId: $started->correlationId,
+                error: $exception->getMessage(),
+                exceptionClass: $exception::class,
+                email: $command->email,
+            ));
+            throw $exception;
         }
-
-        if ($user->status !== UserStatusEnum::Active) {
-            throw new AccountNotActivatedException($user->status);
-        }
-
-        $user->recordLogin();
-        $this->userRepository->save($user);
-
-        return $this->jwtManager->create($user);
     }
 }

--- a/back/src/Auth/Application/Register/RegisterUserHandler.php
+++ b/back/src/Auth/Application/Register/RegisterUserHandler.php
@@ -11,12 +11,16 @@ use App\Auth\Domain\Exception\EmailAlreadyTakenException;
 use App\Auth\Domain\Service\TokenGeneratorInterface;
 use App\Auth\Domain\User;
 use App\Auth\Domain\UserRepositoryInterface;
+use App\Auth\Shared\Event\RegisterFailedEvent;
+use App\Auth\Shared\Event\RegisterStartedEvent;
+use App\Auth\Shared\Event\RegisterSucceededEvent;
 use App\Auth\Shared\Event\UserRegisteredEvent;
 use App\Shared\Application\Bus\EventBusInterface;
 use DateTimeImmutable;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class RegisterUserHandler
@@ -32,38 +36,58 @@ final readonly class RegisterUserHandler
 
     public function __invoke(RegisterUserCommand $command): void
     {
-        if ($this->userRepository->findByEmail($command->email) !== null) {
-            throw new EmailAlreadyTakenException();
+        $started = new RegisterStartedEvent();
+        $this->eventBus->publish($started);
+
+        try {
+            if ($this->userRepository->findByEmail($command->email) !== null) {
+                throw new EmailAlreadyTakenException();
+            }
+
+            $user = new User(
+                id: Uuid::v4()->toRfc4122(),
+                email: strtolower($command->email),
+                passwordHash: '',
+                displayName: $command->displayName,
+            );
+
+            $user->passwordHash = $this->passwordHasher->hashPassword($user, $command->password);
+
+            $this->userRepository->save($user);
+
+            $plainToken  = $this->tokenGenerator->generate();
+            $tokenHash   = $this->tokenGenerator->hash($plainToken);
+            $authToken   = new AuthToken(
+                id: Uuid::v4()->toRfc4122(),
+                user: $user,
+                type: AuthTokenTypeEnum::EmailVerification,
+                tokenHash: $tokenHash,
+                expiresAt: new DateTimeImmutable('+7 days'),
+            );
+
+            $this->tokenRepository->save($authToken);
+
+            $this->eventBus->publish(new UserRegisteredEvent(
+                userId: $user->id,
+                email: $user->email,
+                displayName: $user->displayName,
+                verificationTokenPlain: $plainToken,
+            ));
+
+            $this->eventBus->publish(new RegisterSucceededEvent(
+                correlationId: $started->correlationId,
+                userId: $user->id,
+                email: $user->email,
+                displayName: $user->displayName,
+            ));
+        } catch (Throwable $exception) {
+            $this->eventBus->publish(new RegisterFailedEvent(
+                correlationId: $started->correlationId,
+                error: $exception->getMessage(),
+                exceptionClass: $exception::class,
+                email: $command->email,
+            ));
+            throw $exception;
         }
-
-        $user = new User(
-            id: Uuid::v4()->toRfc4122(),
-            email: strtolower($command->email),
-            passwordHash: '',
-            displayName: $command->displayName,
-        );
-
-        $user->passwordHash = $this->passwordHasher->hashPassword($user, $command->password);
-
-        $this->userRepository->save($user);
-
-        $plainToken  = $this->tokenGenerator->generate();
-        $tokenHash   = $this->tokenGenerator->hash($plainToken);
-        $authToken   = new AuthToken(
-            id: Uuid::v4()->toRfc4122(),
-            user: $user,
-            type: AuthTokenTypeEnum::EmailVerification,
-            tokenHash: $tokenHash,
-            expiresAt: new DateTimeImmutable('+7 days'),
-        );
-
-        $this->tokenRepository->save($authToken);
-
-        $this->eventBus->publish(new UserRegisteredEvent(
-            userId: $user->id,
-            email: $user->email,
-            displayName: $user->displayName,
-            verificationTokenPlain: $plainToken,
-        ));
     }
 }

--- a/back/src/Auth/Infrastructure/Security/ActivityLogOwnerResolver.php
+++ b/back/src/Auth/Infrastructure/Security/ActivityLogOwnerResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Infrastructure\Security;
+
+use App\Auth\Domain\User;
+use App\Auth\Domain\UserRepositoryInterface;
+use App\Notification\Domain\ActivityLogOwnerResolverInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Resolves the ActivityLog owner from the Symfony security token (HTTP
+ * context) or by id (domain events carrying a userId). In worker / scheduler
+ * contexts there is no token, so currentOwner() returns null.
+ */
+final readonly class ActivityLogOwnerResolver implements ActivityLogOwnerResolverInterface
+{
+    public function __construct(
+        private Security $security,
+        private UserRepositoryInterface $userRepository,
+    ) {
+    }
+
+    public function currentOwner(): ?User
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User ? $user : null;
+    }
+
+    public function findById(string $userId): ?User
+    {
+        return $this->userRepository->findById($userId);
+    }
+}

--- a/back/src/Auth/Shared/Event/GateStartedEvent.php
+++ b/back/src/Auth/Shared/Event/GateStartedEvent.php
@@ -10,10 +10,12 @@ use App\Shared\Domain\Event\StartedEventInterface;
 final readonly class GateStartedEvent implements StartedEventInterface
 {
     public string $correlationId;
+    public string $sourceName;
 
     public function __construct(
         ?string $correlationId = null,
     ) {
         $this->correlationId = $correlationId ?? Uuid::v4()->toRfc4122();
+        $this->sourceName    = 'gate';
     }
 }

--- a/back/src/Auth/Shared/Event/GateSucceededEvent.php
+++ b/back/src/Auth/Shared/Event/GateSucceededEvent.php
@@ -6,11 +6,15 @@ namespace App\Auth\Shared\Event;
 
 use App\Shared\Domain\Event\SucceededEventInterface;
 
+/**
+ * The issued JWT is deliberately NOT carried by this event: activity-log
+ * metadata is built from event properties and must never contain credentials.
+ */
 final readonly class GateSucceededEvent implements SucceededEventInterface
 {
     public function __construct(
         public string $correlationId,
-        public string $token,
+        public ?string $userId = null,
     ) {
     }
 }

--- a/back/src/Auth/Shared/Event/LoginFailedEvent.php
+++ b/back/src/Auth/Shared/Event/LoginFailedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\FailedEventInterface;
+
+final readonly class LoginFailedEvent implements FailedEventInterface
+{
+    public function __construct(
+        public string $correlationId,
+        public string $error,
+        public string $exceptionClass,
+        public string $email,
+    ) {
+    }
+}

--- a/back/src/Auth/Shared/Event/LoginStartedEvent.php
+++ b/back/src/Auth/Shared/Event/LoginStartedEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\StartedEventInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class LoginStartedEvent implements StartedEventInterface
+{
+    public string $correlationId;
+    public string $sourceName;
+
+    public function __construct(
+        ?string $correlationId = null,
+    ) {
+        $this->correlationId = $correlationId ?? Uuid::v4()->toRfc4122();
+        $this->sourceName    = 'login';
+    }
+}

--- a/back/src/Auth/Shared/Event/LoginSucceededEvent.php
+++ b/back/src/Auth/Shared/Event/LoginSucceededEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\SucceededEventInterface;
+
+final readonly class LoginSucceededEvent implements SucceededEventInterface
+{
+    public function __construct(
+        public string $correlationId,
+        public string $userId,
+        public string $email,
+    ) {
+    }
+}

--- a/back/src/Auth/Shared/Event/RegisterFailedEvent.php
+++ b/back/src/Auth/Shared/Event/RegisterFailedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\FailedEventInterface;
+
+final readonly class RegisterFailedEvent implements FailedEventInterface
+{
+    public function __construct(
+        public string $correlationId,
+        public string $error,
+        public string $exceptionClass,
+        public string $email,
+    ) {
+    }
+}

--- a/back/src/Auth/Shared/Event/RegisterStartedEvent.php
+++ b/back/src/Auth/Shared/Event/RegisterStartedEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\StartedEventInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class RegisterStartedEvent implements StartedEventInterface
+{
+    public string $correlationId;
+    public string $sourceName;
+
+    public function __construct(
+        ?string $correlationId = null,
+    ) {
+        $this->correlationId = $correlationId ?? Uuid::v4()->toRfc4122();
+        $this->sourceName    = 'register';
+    }
+}

--- a/back/src/Auth/Shared/Event/RegisterSucceededEvent.php
+++ b/back/src/Auth/Shared/Event/RegisterSucceededEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shared\Event;
+
+use App\Shared\Domain\Event\SucceededEventInterface;
+
+/**
+ * Carries no verification token: activity-log metadata is built from event
+ * properties and must never contain credentials (see UserRegisteredEvent for
+ * the email-sending flow, which never reaches the journal).
+ */
+final readonly class RegisterSucceededEvent implements SucceededEventInterface
+{
+    public function __construct(
+        public string $correlationId,
+        public string $userId,
+        public string $email,
+        public string $displayName,
+    ) {
+    }
+}

--- a/back/src/Manga/Application/GetVolumePrices/GetVolumePricesHandler.php
+++ b/back/src/Manga/Application/GetVolumePrices/GetVolumePricesHandler.php
@@ -9,6 +9,7 @@ use App\Manga\Domain\MangaRepositoryInterface;
 use App\Manga\Domain\PriceOfferCacheInterface;
 use App\Manga\Domain\PriceOfferDto;
 use App\Manga\Domain\Service\PriceOfferSorter;
+use App\Manga\Domain\Service\RetailerOfferResolver;
 use App\Manga\Domain\VolumePriceProviderInterface;
 use App\Shared\Domain\Exception\NotFoundException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -21,6 +22,7 @@ final readonly class GetVolumePricesHandler
         private VolumePriceProviderInterface $priceProvider,
         private PriceOfferCacheInterface $cache,
         private PriceOfferSorter $sorter,
+        private RetailerOfferResolver $retailerOfferResolver,
     ) {
     }
 
@@ -45,7 +47,12 @@ final readonly class GetVolumePricesHandler
         }
 
         if ($volume->isbn === null) {
-            return ['offers' => [], 'hasIsbn' => false, 'marketplace' => null];
+            return [
+                'offers'      => [],
+                'retailers'   => $this->retailerOfferResolver->resolve([]),
+                'hasIsbn'     => false,
+                'marketplace' => null,
+            ];
         }
 
         $marketplace = $query->marketplace !== null
@@ -54,7 +61,12 @@ final readonly class GetVolumePricesHandler
 
         $cachedOffers = $this->cache->get($volume->isbn, $marketplace);
         if ($cachedOffers !== null) {
-            return ['offers' => $cachedOffers, 'hasIsbn' => true, 'marketplace' => $marketplace->value];
+            return [
+                'offers'      => $cachedOffers,
+                'retailers'   => $this->retailerOfferResolver->resolve($cachedOffers),
+                'hasIsbn'     => true,
+                'marketplace' => $marketplace->value,
+            ];
         }
 
         $offers = $this->sorter->sort($this->priceProvider->findOffers($volume->isbn, $marketplace));
@@ -66,6 +78,11 @@ final readonly class GetVolumePricesHandler
 
         $this->cache->put($volume->isbn, $marketplace, $offersArray);
 
-        return ['offers' => $offersArray, 'hasIsbn' => true, 'marketplace' => $marketplace->value];
+        return [
+            'offers'      => $offersArray,
+            'retailers'   => $this->retailerOfferResolver->resolve($offersArray),
+            'hasIsbn'     => true,
+            'marketplace' => $marketplace->value,
+        ];
     }
 }

--- a/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
+++ b/back/src/Manga/Application/UpdateVolume/UpdateVolumeHandler.php
@@ -12,7 +12,6 @@ use App\Shared\Application\Bus\EventBusInterface;
 use App\Shared\Domain\Exception\NotFoundException;
 use DateTimeImmutable;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Throwable;
 
 #[AsMessageHandler(bus: 'command.bus')]
 final readonly class UpdateVolumeHandler
@@ -25,49 +24,45 @@ final readonly class UpdateVolumeHandler
 
     public function __invoke(UpdateVolumeCommand $command): void
     {
-        try {
-            $manga = $this->mangaRepository->findById($command->mangaId);
+        $manga = $this->mangaRepository->findById($command->mangaId);
 
-            if ($manga === null) {
-                throw new NotFoundException('Manga', $command->mangaId);
-            }
-
-            $volume = $manga->volumes
-                ->filter(fn (Volume $volume) => $volume->id === $command->volumeId)
-                ->first();
-
-            if ($volume === false) {
-                throw new NotFoundException('Volume', $command->volumeId);
-            }
-
-            if ($command->coverUrl !== null) {
-                $volume->coverUrl = $command->coverUrl;
-            }
-
-            if ($command->releaseDate !== null) {
-                $volume->releaseDate = new DateTimeImmutable($command->releaseDate);
-            }
-
-            if ($command->price !== null) {
-                $volume->price = $command->price;
-            }
-
-            if ($command->spineUrl !== null) {
-                $volume->spineUrl = $command->spineUrl;
-            }
-
-            if ($command->isbn !== null) {
-                $volume->isbn = Isbn::fromString($command->isbn);
-            }
-
-            $this->mangaRepository->save($manga);
-
-            $this->eventBus->publish(new UpdateVolumeSucceededEvent(
-                mangaId: $manga->id,
-                volumeId: $volume->id,
-            ));
-        } catch (Throwable $throwable) {
-            throw $throwable;
+        if ($manga === null) {
+            throw new NotFoundException('Manga', $command->mangaId);
         }
+
+        $volume = $manga->volumes
+            ->filter(fn (Volume $volume) => $volume->id === $command->volumeId)
+            ->first();
+
+        if ($volume === false) {
+            throw new NotFoundException('Volume', $command->volumeId);
+        }
+
+        if ($command->coverUrl !== null) {
+            $volume->coverUrl = $command->coverUrl;
+        }
+
+        if ($command->releaseDate !== null) {
+            $volume->releaseDate = new DateTimeImmutable($command->releaseDate);
+        }
+
+        if ($command->price !== null) {
+            $volume->price = $command->price;
+        }
+
+        if ($command->spineUrl !== null) {
+            $volume->spineUrl = $command->spineUrl;
+        }
+
+        if ($command->isbn !== null) {
+            $volume->isbn = Isbn::fromString($command->isbn);
+        }
+
+        $this->mangaRepository->save($manga);
+
+        $this->eventBus->publish(new UpdateVolumeSucceededEvent(
+            mangaId: $manga->id,
+            volumeId: $volume->id,
+        ));
     }
 }

--- a/back/src/Manga/Domain/EditionFormatEnum.php
+++ b/back/src/Manga/Domain/EditionFormatEnum.php
@@ -11,6 +11,7 @@ enum EditionFormatEnum: string
     case Coffret = 'coffret';
     case Deluxe = 'deluxe';
     case Omnibus = 'omnibus';
+    case Artbook = 'artbook';
     case Unknown = 'unknown';
 
     public static function fromRawLabel(?string $raw): self
@@ -20,6 +21,18 @@ enum EditionFormatEnum: string
         }
 
         $normalized = mb_strtolower($raw);
+
+        // Companion print: artbooks, guidebooks, fanbooks, databooks (and their
+        // Japanese markers) — a dedicated shelf format, checked before everything else.
+        if (
+            preg_match(
+                '/art\s?book|artworks?|art\s+of|illustrations?|画集|イラスト集'
+                . '|guide\s?book|ガイドブック|fan\s?book|ファンブック|data\s?book/iu',
+                $normalized,
+            )
+        ) {
+            return self::Artbook;
+        }
 
         if (preg_match('/omnibus|int[eé]grale|3.?in.?1|3-en-1|mook/iu', $normalized)) {
             return self::Omnibus;

--- a/back/src/Manga/Domain/Isbn.php
+++ b/back/src/Manga/Domain/Isbn.php
@@ -86,6 +86,12 @@ final readonly class Isbn
             );
         }
 
+        // Barcode scanners may append an EAN-2 or EAN-5 add-on (price / issue code)
+        // after the 13 ISBN digits — keep the ISBN part and drop the add-on.
+        if (preg_match('/^(97[89][0-9]{10})[0-9]{2}(?:[0-9]{3})?$/', $stripped, $matches) === 1) {
+            return $matches[1];
+        }
+
         return $stripped;
     }
 

--- a/back/src/Manga/Domain/RetailerEnum.php
+++ b/back/src/Manga/Domain/RetailerEnum.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain;
+
+/**
+ * The target shops the price screen always reports on — found or honestly "not found".
+ * Merchant names scraped or returned by APIs are mapped onto these via
+ * {@see self::fromMerchant} (case- and accent-insensitive prefix match).
+ */
+enum RetailerEnum: string
+{
+    case Amazon = 'amazon';
+    case Fnac   = 'fnac';
+    case Ebay   = 'ebay';
+
+    /** @return list<self> */
+    public static function targets(): array
+    {
+        return [self::Amazon, self::Fnac, self::Ebay];
+    }
+
+    /** Maps a raw merchant name ("Amazon.fr", "la Fnac", "eBay FR"…) onto a target retailer. */
+    public static function fromMerchant(string $merchant): ?self
+    {
+        $normalized = self::normalizeMerchant($merchant);
+
+        foreach (self::cases() as $retailer) {
+            if (str_starts_with($normalized, $retailer->value)) {
+                return $retailer;
+            }
+        }
+
+        return null;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Amazon => 'Amazon',
+            self::Fnac   => 'Fnac',
+            self::Ebay   => 'eBay',
+        };
+    }
+
+    /** Deterministic accent folding (iconv//TRANSLIT is locale-dependent, so not used). */
+    private const array ACCENT_MAP = [
+        'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' => 'a',
+        'ç' => 'c',
+        'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+        'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i',
+        'ò' => 'o', 'ó' => 'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o',
+        'ù' => 'u', 'ú' => 'u', 'û' => 'u', 'ü' => 'u',
+        'ÿ' => 'y', 'ñ' => 'n',
+    ];
+
+    private static function normalizeMerchant(string $merchant): string
+    {
+        $folded = strtr(mb_strtolower(trim($merchant)), self::ACCENT_MAP);
+
+        // "La Fnac", "the amazon store"… — drop leading articles so the prefix match holds.
+        return (string) preg_replace('/^(la|le|les|the)\s+/', '', $folded);
+    }
+}

--- a/back/src/Manga/Domain/Service/EditionGrouper.php
+++ b/back/src/Manga/Domain/Service/EditionGrouper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Manga\Domain\Service;
 
 use App\Manga\Domain\ExternalEditionDto;
+use App\Manga\Domain\Isbn;
 
 final readonly class EditionGrouper
 {
@@ -13,11 +14,17 @@ final readonly class EditionGrouper
     }
 
     /**
-     * Deduplicates a flat list of edition DTOs by (canonical publisher, language,
-     * edition line, format), merging best cover / isbn sample and keeping the maximum
-     * volume count. Publishers are normalised first, so "Glénat (Grenoble)" and
-     * "Glénat" — or the five Viz aliases — collapse into one entry, and each entry is
-     * relabelled with its clean publisher + edition line.
+     * Deduplicates a flat list of edition DTOs by (publisher imprint, language, edition
+     * line, format), merging best cover / isbn sample and keeping the maximum volume
+     * count. Publishers are normalised first, so "Glénat (Grenoble)" and "Glénat" — or
+     * the five Viz aliases — collapse into one entry, and each entry is relabelled with
+     * its clean publisher + edition line.
+     *
+     * Two guards keep genuinely distinct editions apart:
+     * - the grouping key uses {@see PublisherNormalizer::imprintKey()}, so imprints that
+     *   merely share a display name (Tonkam vs Delcourt) do not merge;
+     * - inside one key, records whose ISBN registration groups disagree (a 978-2 French
+     *   run vs a 978-4 Japanese one mislabelled with the same language) stay separate.
      *
      * Returns a sorted list: by country (FR first, then US, then others), then by label.
      *
@@ -26,36 +33,20 @@ final readonly class EditionGrouper
      */
     public function group(array $dtos): array
     {
-        /** @var array<string, ExternalEditionDto> $grouped */
-        $grouped = [];
-
+        /** @var array<string, non-empty-list<ExternalEditionDto>> $buckets */
+        $buckets = [];
         foreach ($dtos as $dto) {
-            $normalized = $this->relabel($dto);
-            $key        = $this->keyFor($normalized);
-
-            if (!array_key_exists($key, $grouped)) {
-                $grouped[$key] = $normalized;
-                continue;
-            }
-
-            $existing      = $grouped[$key];
-            $grouped[$key] = new ExternalEditionDto(
-                workTitle:    $existing->workTitle,
-                editionLabel: $existing->editionLabel,
-                publisher:    $existing->publisher,
-                language:     $existing->language,
-                country:      $existing->country,
-                format:       $existing->format,
-                volumeCount:  $this->maxVolumeCount($existing->volumeCount, $normalized->volumeCount),
-                isbnSample:   $existing->isbnSample ?? $normalized->isbnSample,
-                coverUrl:     $existing->coverUrl ?? $normalized->coverUrl,
-                source:       $existing->source,
-                externalId:   $existing->externalId ?? $normalized->externalId,
-                editionLine:  $existing->editionLine,
-            );
+            // Key from the RAW publisher: relabel() collapses imprints into one display
+            // name (Delcourt/Tonkam), which must not leak into the grouping key.
+            $buckets[$this->keyFor($dto)][] = $this->relabel($dto);
         }
 
-        $editions = array_values($grouped);
+        $editions = [];
+        foreach ($buckets as $bucket) {
+            foreach ($this->partitionByIsbnGroup($bucket) as $partition) {
+                $editions[] = $this->mergePartition($partition);
+            }
+        }
 
         usort($editions, static function (ExternalEditionDto $alpha, ExternalEditionDto $bravo): int {
             $countryOrder = ['FR' => 0, 'US' => 1];
@@ -70,6 +61,96 @@ final readonly class EditionGrouper
         });
 
         return $editions;
+    }
+
+    /**
+     * Splits one key bucket by ISBN registration group (digit after the 978/979 prefix:
+     * 0/1 English, 2 French, 3 German, 4 Japanese…). Records without an ISBN carry no
+     * evidence and never force a split: they join the first partition.
+     *
+     * @param  non-empty-list<ExternalEditionDto> $bucket
+     * @return non-empty-list<non-empty-list<ExternalEditionDto>>
+     */
+    private function partitionByIsbnGroup(array $bucket): array
+    {
+        /** @var list<non-empty-list<ExternalEditionDto>> $partitions */
+        $partitions = [];
+        /** @var array<string, int> $partitionIndexByGroup */
+        $partitionIndexByGroup = [];
+        $unclaimedIndex        = null;
+
+        foreach ($bucket as $dto) {
+            $registrationGroup = $this->isbnRegistrationGroup($dto->isbnSample);
+
+            if ($registrationGroup === null) {
+                if ($partitions === []) {
+                    $partitions[]   = [$dto];
+                    $unclaimedIndex = 0;
+                    continue;
+                }
+                $partitions[0][] = $dto;
+                continue;
+            }
+
+            if (isset($partitionIndexByGroup[$registrationGroup])) {
+                $partitions[$partitionIndexByGroup[$registrationGroup]][] = $dto;
+                continue;
+            }
+
+            if ($unclaimedIndex !== null) {
+                $partitions[$unclaimedIndex][]                  = $dto;
+                $partitionIndexByGroup[$registrationGroup]      = $unclaimedIndex;
+                $unclaimedIndex                                 = null;
+                continue;
+            }
+
+            $partitions[]                              = [$dto];
+            $partitionIndexByGroup[$registrationGroup] = count($partitions) - 1;
+        }
+
+        return $partitions;
+    }
+
+    /**
+     * ISBN registration group as a coarse market signal. Groups 0 and 1 are both the
+     * English-speaking area, so they map to one value — a US line printing under both
+     * must not be split in two.
+     */
+    private function isbnRegistrationGroup(?string $isbnSample): ?string
+    {
+        $isbn = Isbn::tryFrom($isbnSample);
+        if ($isbn === null) {
+            return null;
+        }
+
+        $group = $isbn->groupIdentifier();
+
+        return ($group === '0' || $group === '1') ? '0/1' : $group;
+    }
+
+    /** @param non-empty-list<ExternalEditionDto> $partition */
+    private function mergePartition(array $partition): ExternalEditionDto
+    {
+        $merged = $partition[0];
+
+        foreach (array_slice($partition, 1) as $candidate) {
+            $merged = new ExternalEditionDto(
+                workTitle:    $merged->workTitle,
+                editionLabel: $merged->editionLabel,
+                publisher:    $merged->publisher,
+                language:     $merged->language,
+                country:      $merged->country,
+                format:       $merged->format,
+                volumeCount:  $this->maxVolumeCount($merged->volumeCount, $candidate->volumeCount),
+                isbnSample:   $merged->isbnSample ?? $candidate->isbnSample,
+                coverUrl:     $merged->coverUrl ?? $candidate->coverUrl,
+                source:       $merged->source,
+                externalId:   $merged->externalId ?? $candidate->externalId,
+                editionLine:  $merged->editionLine,
+            );
+        }
+
+        return $merged;
     }
 
     /** Replaces the raw publisher + label with the canonical publisher and a clean label. */
@@ -105,7 +186,7 @@ final readonly class EditionGrouper
     private function keyFor(ExternalEditionDto $dto): string
     {
         return implode('|', [
-            $this->publisherNormalizer->canonicalKey($dto->publisher),
+            $this->publisherNormalizer->imprintKey($dto->publisher),
             $dto->language,
             mb_strtolower($dto->editionLine ?? ''),
             $dto->format->value,

--- a/back/src/Manga/Domain/Service/EditionLineExtractor.php
+++ b/back/src/Manga/Domain/Service/EditionLineExtractor.php
@@ -23,7 +23,17 @@ final readonly class EditionLineExtractor
      * @var array<string, string>
      */
     private const array PATTERNS = [
-        // Japanese edition markers (NDL records are titled in kanji).
+        // Companion volumes a collector shelves next to the run — detected first so an
+        // "Art of … Deluxe" resolves to Artbook, not Deluxe.
+        '/画集|イラスト集|原画集/u'                                              => 'Artbook',
+        '/\bart\s?books?\b|\bartworks?\b|\bart\s+of\b|\bl\'?art\s+de\s|\billustrations?\b/iu' => 'Artbook',
+        '/ガイドブック|公式ガイド/u'                                              => 'Guidebook',
+        '/\bguide\s?books?\b|\bofficial\s+guide\b|\bguide\s+officiel\b/iu'    => 'Guidebook',
+        '/ファンブック/u'                                                       => 'Fanbook',
+        '/\bfan\s?books?\b/iu'                                                => 'Fanbook',
+        '/\bdata\s?books?\b|\bcharacter\s?books?\b/iu'                        => 'Databook',
+        // Japanese edition markers (NDL records are titled in kanji), with their
+        // transliterated (romaji) counterparts used by western catalogues.
         '/完全版/u'                                                           => 'Perfect Edition',
         '/愛蔵版/u'                                                           => 'Deluxe',
         '/新装版/u'                                                           => 'Nouvelle édition',
@@ -32,14 +42,21 @@ final readonly class EditionLineExtractor
         '/総集編/u'                                                           => 'Intégrale',
         '/perfect\s*edition/iu'                                              => 'Perfect Edition',
         '/kanzenban/iu'                                                      => 'Perfect Edition',
+        '/\baizoban\b/iu'                                                    => 'Deluxe',
+        '/\bshinso\s?ban\b/iu'                                               => 'Nouvelle édition',
+        '/\bbunko\b/iu'                                                      => 'Bunko',
         '/(?:é|e)dition\s+originale|sens\s+de\s+lecture\s+original/iu'       => 'Édition originale',
         '/(?:é|e)dition\s+double|\bdouble\s+edition\b|\bdouble\b(?=.*tome)/iu' => 'Édition double',
+        '/(?:é|e)dition\s+pilote|\bpilot\s+edition\b/iu'                      => 'Édition pilote',
+        '/\bblack\s+edition\b/iu'                                             => 'Black Edition',
         '/\bprestige\b/iu'                                                    => 'Prestige',
         '/\bmaximum\b/iu'                                                     => 'Maximum',
         '/\bultimate\b/iu'                                                    => 'Ultimate',
         '/\bcollector\b/iu'                                                   => 'Collector',
         '/(?:é|e)dition\s+de\s+luxe|\bdeluxe\b|de\s+luxe/iu'                  => 'Deluxe',
         '/\bcoffret\b|box\s*set|\bbox\b/iu'                                   => 'Coffret',
+        // "20 ans", "20th anniversary", "édition anniversaire", 周年記念…
+        '/anniversair\w*|\banniversary\b|(?:é|e)dition\s+\d+\s*ans|\b\d+\s*ans\s+d|周年/iu' => 'Anniversaire',
         '/(?:é|e)dition\s+couleur|\bcolou?r\s+edition\b|\ben\s+couleur\b/iu'  => 'Édition couleur',
         '/\bint(?:é|e)grale\b|\bomnibus\b|\d\s*[-]?in[-]?\s*\d|\bvizbig\b/iu' => 'Intégrale',
     ];

--- a/back/src/Manga/Domain/Service/EditionRelevanceFilter.php
+++ b/back/src/Manga/Domain/Service/EditionRelevanceFilter.php
@@ -5,21 +5,32 @@ declare(strict_types=1);
 namespace App\Manga\Domain\Service;
 
 /**
- * Keeps only catalogue records that are an actual manga edition, by requiring a
- * recognised manga publisher. A broad title search drags in video releases, figurine
- * partworks, guides, artbooks and novels — denylisting that endless tail never ends,
- * so instead we ALLOWLIST the real manga publishers per market and drop everything
- * else. Curated on purpose: extend {@see self::PUBLISHER_ALLOWLIST} for a new house.
+ * Keeps only catalogue records that belong to the searched work, without shrinking the
+ * result to "known publishers only". Discovery must be exhaustive per country: classic
+ * runs, prestige/perfect/deluxe lines, coffrets, intégrales, collectors AND companion
+ * volumes a collector shelves next to the manga (artbooks, guidebooks, fanbooks).
  *
- * A record is kept only when its publisher is a known manga house AND it is not a
- * video/sound carrier AND its title is not a derivative work (guide, artbook, novel…).
+ * Relevance is therefore title-driven: a record is kept when its title actually matches
+ * the searched work (every significant word of the work title appears in the record
+ * title), whatever its publisher — unknown or missing publishers are no longer dropped.
+ * The publisher allowlist survives only as a rescue signal for records whose title is a
+ * translation of the work title (e.g. a Japanese edition surfacing under an English
+ * work) and as a trust hint for ranking.
+ *
+ * What is still rejected as real noise for a manga médiathèque:
+ * - video / sound carriers (dc:type),
+ * - partwork, video and unofficial-essay publishers ({@see self::PUBLISHER_DENYLIST}),
+ * - derivative print that is not a collectible edition: coloriages, agendas,
+ *   calendriers, stickers, figurines, unofficial reading guides, novels, argus…
  */
 final readonly class EditionRelevanceFilter
 {
     /**
      * Recognised manga publishers, as folded (accent-free, lower-case) prefixes matched
-     * against the normalised publisher key. One token covers a house across markets
-     * (e.g. "panini" → Panini Manga FR/DE/ES, Planet Manga IT).
+     * against the normalised publisher key. No longer a hard gate: it rescues records
+     * whose title does not literally match (translated titles) and marks trustworthy
+     * sources. One token covers a house across markets (e.g. "panini" → Panini Manga
+     * FR/DE/ES, Planet Manga IT).
      *
      * @var list<string>
      */
@@ -43,57 +54,137 @@ final readonly class EditionRelevanceFilter
     ];
 
     /**
-     * Video / partwork arms that share a manga house's name prefix and would otherwise
-     * sneak past the allowlist (e.g. "Kazé Video" vs "Kazé Manga").
+     * Publishers whose output is never a manga edition: video arms sharing a manga
+     * house's prefix ("Kazé Video" vs "Kazé Manga"), figurine/fascicle partworks, and
+     * unofficial-essay houses. This stays a hard reject.
      *
      * @var list<string>
      */
     private const array PUBLISHER_DENYLIST = [
         'kana home video', 'kaze video', 'kaze anime', 'ab video', 'panini video',
-        'deagostini', 'de agostini', 'altaya',
+        'deagostini', 'de agostini', 'altaya', 'hachette collections', 'atlas',
+        'third editions', 'ynnis',
     ];
 
-    /** Folded (accent-free, lower-case) title fragments that mark derivative / non-manga print. */
+    /**
+     * Folded (accent-free, lower-case) title fragments that mark non-collectible noise.
+     * Artbooks / guidebooks / fanbooks are deliberately NOT here anymore — they are
+     * legitimate editions surfaced with the Artbook format.
+     */
     private const string TITLE_DENY_REGEX =
-        '/\b(guides?|art\s?books?|art\s+of|data\s?books?|fan\s?books?|anime\s+comics?'
-        . '|novels?|encyclop|making\s+of|decryptage|cote\s+des|argus|dvd|blu[\s-]?ray'
-        . '|coloriages?|stickers?|autocollants?|calendriers?|agendas?|figurines?|artworks?)\b'
-        . '|the\s+world\s+of|l\'?univers\s+d/iu';
+        '/\b(coloriages?|colou?ring|stickers?|autocollants?|calendriers?|calendars?'
+        . '|agendas?|figurines?|puzzles?|dvd|blu[\s-]?ray|making\s+of|decryptages?'
+        . '|cote\s+des|argus|novels?|romans?)\b'
+        . '|guide\s+de\s+lecture|non\s+officiel|unofficial|encyclop/iu';
 
     /** Record types (Dublin Core dc:type and friends) that are not printed books. */
     private const string TYPE_DENY_REGEX =
         '/\b(vid(?:é|e)o|son|sound|dvd|blu[\s-]?ray|movie|film)\b|image\s+anim/iu';
 
+    /**
+     * Words too generic to prove a title match on their own — dropped before requiring
+     * every remaining work-title word to appear in the record title.
+     *
+     * @var list<string>
+     */
+    private const array TITLE_STOPWORDS = [
+        'the', 'an', 'of', 'and', 'on', 'in', 'at', 'to',
+        'le', 'la', 'les', 'un', 'une', 'des', 'de', 'du', 'et',
+        'no', 'na', 'wa', 'ni', 'ga', 'die', 'der', 'das', 'und',
+    ];
+
     public function __construct(private PublisherNormalizer $publisherNormalizer)
     {
     }
 
-    public function isRelevant(string $title, ?string $publisher, ?string $type = null): bool
-    {
-        $publisherKey = $this->publisherNormalizer->canonicalKey($publisher);
-        if ($publisherKey === '') {
-            return false;
-        }
-
-        foreach (self::PUBLISHER_DENYLIST as $denied) {
-            if (str_starts_with($publisherKey, $denied)) {
-                return false;
-            }
-        }
-
+    public function isRelevant(
+        string $workTitle,
+        string $recordTitle,
+        ?string $publisher,
+        ?string $type = null,
+    ): bool {
         if ($type !== null && $type !== '' && preg_match(self::TYPE_DENY_REGEX, $type) === 1) {
             return false;
         }
 
-        if (preg_match(self::TITLE_DENY_REGEX, $this->fold($title)) === 1) {
+        $publisherKey = $this->publisherNormalizer->canonicalKey($publisher);
+        foreach (self::PUBLISHER_DENYLIST as $denied) {
+            if ($publisherKey !== '' && str_starts_with($publisherKey, $denied)) {
+                return false;
+            }
+        }
+
+        if (preg_match(self::TITLE_DENY_REGEX, $this->fold($recordTitle)) === 1) {
             return false;
         }
 
+        // A title that matches the work is enough — the publisher may be unknown, tiny
+        // or missing (artbooks, coffrets and one-shot collectors often are).
+        if ($this->titleMatchesWork($workTitle, $recordTitle)) {
+            return true;
+        }
+
+        // Translated / renamed record titles: trust a recognised manga house.
         return $this->isKnownMangaPublisher($publisherKey);
+    }
+
+    /**
+     * True when every significant word of the work title appears in the record title
+     * (position-independent, accent/case-insensitive). Whole-string containment covers
+     * CJK titles, which have no word boundaries.
+     */
+    private function titleMatchesWork(string $workTitle, string $recordTitle): bool
+    {
+        $foldedWork   = $this->fold($workTitle);
+        $foldedRecord = $this->fold($recordTitle);
+
+        if ($foldedWork === '' || $foldedRecord === '') {
+            return false;
+        }
+
+        if (str_contains($foldedRecord, $foldedWork)) {
+            return true;
+        }
+
+        $significantWords = $this->significantWords($foldedWork);
+        if ($significantWords === []) {
+            return false;
+        }
+
+        foreach ($significantWords as $word) {
+            if (!str_contains($foldedRecord, $word)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return list<string> */
+    private function significantWords(string $foldedTitle): array
+    {
+        $words = preg_split('/[^\p{L}\p{N}]+/u', $foldedTitle, -1, PREG_SPLIT_NO_EMPTY);
+        if ($words === false) {
+            return [];
+        }
+
+        $significant = [];
+        foreach ($words as $word) {
+            if (mb_strlen($word) < 2 || in_array($word, self::TITLE_STOPWORDS, true)) {
+                continue;
+            }
+            $significant[] = $word;
+        }
+
+        return $significant;
     }
 
     private function isKnownMangaPublisher(string $publisherKey): bool
     {
+        if ($publisherKey === '') {
+            return false;
+        }
+
         foreach (self::PUBLISHER_ALLOWLIST as $known) {
             if (str_starts_with($publisherKey, $known)) {
                 return true;

--- a/back/src/Manga/Domain/Service/PublisherNormalizer.php
+++ b/back/src/Manga/Domain/Service/PublisherNormalizer.php
@@ -52,6 +52,19 @@ final readonly class PublisherNormalizer
         'スクウェア'         => 'Square Enix',
     ];
 
+    /**
+     * Imprints that must NOT collapse when grouping editions, even though they display
+     * under one roof: Tonkam's Berserk run and a Delcourt run are distinct editorial
+     * lines a collector tells apart. Checked before {@see self::ALIASES} by
+     * {@see self::imprintKey()} only — display names still merge.
+     *
+     * @var array<string, string>
+     */
+    private const array IMPRINT_ALIASES = [
+        'tonkam'   => 'Tonkam',
+        'delcourt' => 'Delcourt',
+    ];
+
     /** Legal / corporate suffixes stripped from the tail of a publisher name. */
     private const array LEGAL_SUFFIXES = [
         'llc', 'inc', 'ltd', 'sa', 'sarl', 'gmbh', 'co', 'publishing', 'publications', 'media',
@@ -81,6 +94,29 @@ final readonly class PublisherNormalizer
         $display = $this->displayName($raw);
 
         return $display === null ? '' : $this->fold($display);
+    }
+
+    /**
+     * Like {@see canonicalKey} but preserves editorially distinct imprints sharing a
+     * display name ({@see self::IMPRINT_ALIASES}): "Tonkam" and "Delcourt" both display
+     * as "Delcourt/Tonkam" yet group separately, while pure spelling variants of one
+     * house (Viz Media / VIZ Media LLC, Glénat / Glénat (Grenoble)) still collapse.
+     */
+    public function imprintKey(?string $raw): string
+    {
+        $cleaned = $this->clean($raw ?? '');
+        if ($cleaned === '') {
+            return '';
+        }
+
+        $folded = $this->fold($cleaned);
+        foreach (self::IMPRINT_ALIASES as $needle => $imprint) {
+            if (str_contains($folded, $needle)) {
+                return $this->fold($imprint);
+            }
+        }
+
+        return $this->canonicalKey($raw);
     }
 
     /** Strips parenthetical/bracketed city suffixes and "Éd./Éditions" prefixes. */

--- a/back/src/Manga/Domain/Service/RetailerOfferResolver.php
+++ b/back/src/Manga/Domain/Service/RetailerOfferResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Domain\Service;
+
+use App\Manga\Domain\PriceKindEnum;
+use App\Manga\Domain\RetailerEnum;
+
+/**
+ * Builds the per-retailer summary out of the flat offers list: each target shop
+ * (Amazon, Fnac, eBay) reports its cheapest live offer, or an honest "not_found".
+ *
+ * Works on the serialized offer arrays (the exact shape stored in the price cache),
+ * so cached and fresh results go through the same code path.
+ */
+final readonly class RetailerOfferResolver
+{
+    public const string STATUS_FOUND     = 'found';
+    public const string STATUS_NOT_FOUND = 'not_found';
+
+    /**
+     * @param  list<array<string, mixed>> $offers serialized PriceOfferDto entries
+     * @return list<array{retailer: string, label: string, status: string, bestOffer: array<string, mixed>|null}>
+     */
+    public function resolve(array $offers): array
+    {
+        /** @var array<string, array<string, mixed>> $bestOfferByRetailer */
+        $bestOfferByRetailer = [];
+
+        foreach ($offers as $offer) {
+            // Publisher reference prices (e.g. Google Play) never feed the retailer blocks.
+            if (($offer['kind'] ?? null) !== PriceKindEnum::MerchantLive->value) {
+                continue;
+            }
+
+            $retailer = RetailerEnum::fromMerchant((string) ($offer['merchant'] ?? ''));
+            if ($retailer === null) {
+                continue;
+            }
+
+            $currentBest = $bestOfferByRetailer[$retailer->value] ?? null;
+            if ($currentBest === null || (float) ($offer['amount'] ?? 0.0) < (float) ($currentBest['amount'] ?? 0.0)) {
+                $bestOfferByRetailer[$retailer->value] = $offer;
+            }
+        }
+
+        $retailerBlocks = [];
+        foreach (RetailerEnum::targets() as $retailer) {
+            $bestOffer = $bestOfferByRetailer[$retailer->value] ?? null;
+
+            $retailerBlocks[] = [
+                'retailer'  => $retailer->value,
+                'label'     => $retailer->label(),
+                'status'    => $bestOffer !== null ? self::STATUS_FOUND : self::STATUS_NOT_FOUND,
+                'bestOffer' => $bestOffer,
+            ];
+        }
+
+        return $retailerBlocks;
+    }
+}

--- a/back/src/Manga/Infrastructure/ExternalApi/BnfEditionProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/BnfEditionProvider.php
@@ -19,6 +19,10 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
 {
     private const string LOG_PREFIX = 'BNF EDITIONS : ';
 
+    /** SRU pagination: up to 3 pages of 100 records (BnF caps maximumRecords at 100). */
+    private const int PAGE_SIZE = 100;
+    private const int MAX_PAGES = 3;
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private string $baseUrl,
@@ -51,18 +55,78 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
     /** @return list<ExternalEditionDto> */
     private function doFindEditions(string $workTitle, ?string $author): array
     {
+        $cqlQueries = [$this->buildCql($workTitle, $author)];
+
+        // Artbooks, coffrets and companion volumes are often catalogued under another
+        // creator (illustrator, studio) — sweep once more without the author restriction
+        // so they are not silently excluded. Results are deduplicated by ISBN below.
+        if ($author !== null && $author !== '') {
+            $cqlQueries[] = $this->buildCql($workTitle, null);
+        }
+
+        /** @var array<string, true> $seenKeys */
+        $seenKeys = [];
+        $editions = [];
+        foreach ($cqlQueries as $cqlQuery) {
+            foreach ($this->fetchAllPages($cqlQuery, $workTitle) as $edition) {
+                $dedupeKey = $edition->isbnSample
+                    ?? mb_strtolower($edition->editionLabel . '|' . $edition->format->value);
+                if (isset($seenKeys[$dedupeKey])) {
+                    continue;
+                }
+                $seenKeys[$dedupeKey] = true;
+                $editions[]           = $edition;
+            }
+        }
+
+        return $editions;
+    }
+
+    private function buildCql(string $workTitle, ?string $author): string
+    {
         $cqlQuery = sprintf('bib.title all "%s"', $this->escapeCql($workTitle));
         if ($author !== null && $author !== '') {
             $cqlQuery .= sprintf(' and bib.author all "%s"', $this->escapeCql($author));
         }
 
+        return $cqlQuery;
+    }
+
+    /** @return list<ExternalEditionDto> */
+    private function fetchAllPages(string $cqlQuery, string $workTitle): array
+    {
+        $editions    = [];
+        $startRecord = 1;
+
+        for ($pageIndex = 0; $pageIndex < self::MAX_PAGES; $pageIndex++) {
+            $page = $this->fetchPage($cqlQuery, $workTitle, $startRecord);
+            if ($page === null) {
+                break;
+            }
+
+            foreach ($page['editions'] as $edition) {
+                $editions[] = $edition;
+            }
+
+            $startRecord += self::PAGE_SIZE;
+            if ($page['recordCount'] === 0 || $startRecord > $page['numberOfRecords']) {
+                break;
+            }
+        }
+
+        return $editions;
+    }
+
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function fetchPage(string $cqlQuery, string $workTitle, int $startRecord): ?array
+    {
         $sruParams = http_build_query([
             'version'        => '1.2',
             'operation'      => 'searchRetrieve',
             'query'          => $cqlQuery,
             'recordSchema'   => 'dublincore',
-            'maximumRecords' => '100',
-            'startRecord'    => '1',
+            'maximumRecords' => (string) self::PAGE_SIZE,
+            'startRecord'    => (string) $startRecord,
         ]);
         $url = sprintf('%s/api/SRU?%s', $this->baseUrl, $sruParams);
 
@@ -72,17 +136,17 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
                 'status' => $response->getStatusCode(),
             ]);
 
-            return [];
+            return null;
         }
 
         return $this->parseResponse($response->getContent(), $workTitle);
     }
 
-    /** @return list<ExternalEditionDto> */
-    private function parseResponse(string $xmlContent, string $workTitle): array
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function parseResponse(string $xmlContent, string $workTitle): ?array
     {
         if ($xmlContent === '') {
-            return [];
+            return null;
         }
 
         libxml_use_internal_errors(true);
@@ -91,10 +155,16 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
         $xml->registerXPathNamespace('srw', 'http://www.loc.gov/zing/srw/');
         $xml->registerXPathNamespace('dc', 'http://purl.org/dc/elements/1.1/');
 
+        /** @var array<SimpleXMLElement>|false $totalNodes */
+        $totalNodes      = $xml->xpath('//srw:numberOfRecords');
+        $numberOfRecords = $totalNodes !== false && $totalNodes !== []
+            ? (int) ($totalNodes[0] ?? 0)
+            : 0;
+
         /** @var array<SimpleXMLElement>|false $records */
         $records = $xml->xpath('//srw:record/srw:recordData');
         if ($records === false || $records === []) {
-            return [];
+            return ['editions' => [], 'numberOfRecords' => $numberOfRecords, 'recordCount' => 0];
         }
 
         $editions = [];
@@ -105,7 +175,11 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
             }
         }
 
-        return $editions;
+        return [
+            'editions'        => $editions,
+            'numberOfRecords' => $numberOfRecords,
+            'recordCount'     => count($records),
+        ];
     }
 
     private function parseRecord(SimpleXMLElement $record, string $workTitle): ?ExternalEditionDto
@@ -134,8 +208,9 @@ final readonly class BnfEditionProvider implements EditionProviderInterface
         $dcFormat    = $formatNodes !== false && $formatNodes !== [] ? (string) ($formatNodes[0] ?? '') : '';
         $dcType      = $typeNodes !== false && $typeNodes !== [] ? (string) ($typeNodes[0] ?? '') : '';
 
-        // Drop video releases, figurine partworks, guides/artbooks/novels — keep manga.
-        if (!$this->relevanceFilter->isRelevant($recordTitle, $publisher, $dcType)) {
+        // Drop video releases, figurine partworks and derivative noise — keep every
+        // print edition whose title matches the work, artbooks included.
+        if (!$this->relevanceFilter->isRelevant($workTitle, $recordTitle, $publisher, $dcType)) {
             return null;
         }
 

--- a/back/src/Manga/Infrastructure/ExternalApi/ChasseAuxLivresPriceProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/ChasseAuxLivresPriceProvider.php
@@ -18,22 +18,52 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Chasse aux livres (chasse-aux-livres.fr) — French book price comparator. One page per
- * ISBN (/prix/{isbn}) lists live offers from many FR merchants (Amazon, Fnac, Rakuten,
- * momox…), which makes it the richest keyless price source for French volumes.
+ * ISBN (/prix/{isbn}) lists live offers from many FR merchants (Amazon, Fnac, eBay,
+ * Rakuten, momox…), which makes it the richest keyless price source for French volumes.
  *
- * No public API is documented, so this reads the comparison page's HTML. The parser is
- * deliberately tolerant (any row-like block holding a link and a € amount) because the
- * exact markup could not be verified from the development sandbox — if offers come back
- * empty against the real site, only {@see self::parseOffers} needs tuning. Failures of
- * any kind degrade to []. The GetVolumePrices handler caches results for 24h per ISBN,
- * so the site is hit at most once per volume per day. Set CHASSE_AUX_LIVRES_BASE_URL=""
- * to disable the provider entirely.
+ * No public API is documented, so this reads the comparison page's HTML through several
+ * independent strategies, tried in order until one yields offers:
+ *   1. JSON-LD — a schema.org Product/Offer block embedded in the page;
+ *   2. DOM rows — table rows, data-merchant/seller/vendor attributes, "offer"-classed
+ *      blocks, then list items — each holding a merchant, a € amount and a link;
+ *   3. tolerant text fallback — a known merchant name followed closely by "xx,xx €".
+ *
+ * A 200 response that still parses to 0 offers logs a WARNING (prod diagnostic: the
+ * page layout changed and the strategies need tuning). Failures of any kind degrade
+ * to []. The GetVolumePrices handler caches results for 24h per ISBN, so the site is
+ * hit at most once per volume per day. Set CHASSE_AUX_LIVRES_BASE_URL="" to disable
+ * the provider entirely.
  */
 final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProviderInterface
 {
     private const string LOG_PREFIX = 'CHASSE_AUX_LIVRES PRICES : ';
     private const string USER_AGENT = 'Ziggytheque/1.0 (+https://www.ziggytheque.fr)';
     private const int MAX_OFFERS = 10;
+
+    /** Row-selection strategies, tried in order until one produces at least one offer. */
+    private const array ROW_XPATH_STRATEGIES = [
+        '//tr[.//a]',
+        '//*[@data-merchant or @data-seller or @data-vendor]',
+        "//*[contains(@class, 'offer')][.//a]",
+        '//li[.//a]',
+    ];
+
+    /** Attributes that may carry the merchant name directly on a row or a descendant. */
+    private const array MERCHANT_DATA_ATTRIBUTES = ['data-merchant', 'data-seller', 'data-vendor'];
+
+    /** Merchant names the tolerant text fallback recognizes next to a "xx,xx €" amount. */
+    private const array KNOWN_MERCHANTS = [
+        'amazon',
+        'fnac',
+        'ebay',
+        'rakuten',
+        'momox',
+        'cultura',
+        'decitre',
+        'leslibraires',
+        'recyclivre',
+        'gibert',
+    ];
 
     public function __construct(
         private HttpClientInterface $httpClient,
@@ -83,7 +113,17 @@ final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProvider
             return [];
         }
 
-        return $this->parseOffers($response->getContent());
+        $offers = $this->parseOffers($response->getContent());
+
+        if ($offers === []) {
+            // Prod diagnostic: reachable page but nothing parsed — layout probably changed.
+            $this->logger->warning(self::LOG_PREFIX . 'findOffers; 200 OK BUT 0 OFFER PARSED.', [
+                'isbn' => $isbn->value,
+                'url'  => $url,
+            ]);
+        }
+
+        return $offers;
     }
 
     /** @return list<PriceOfferDto> */
@@ -93,36 +133,159 @@ final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProvider
             return [];
         }
 
+        $offers = $this->parseJsonLdOffers($html);
+
+        if ($offers === []) {
+            $offers = $this->parseDomOffers($html);
+        }
+
+        if ($offers === []) {
+            $offers = $this->parseTextOffers($html);
+        }
+
+        return array_slice($offers, 0, self::MAX_OFFERS);
+    }
+
+    // ── Strategy 1 : JSON-LD (schema.org Product / Offer) ────────────────────
+
+    /** @return list<PriceOfferDto> */
+    private function parseJsonLdOffers(string $html): array
+    {
+        $matchCount = preg_match_all(
+            '#<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>#si',
+            $html,
+            $matches,
+        );
+
+        if ($matchCount === false || $matchCount === 0) {
+            return [];
+        }
+
+        $offers = [];
+        foreach ($matches[1] as $jsonBlock) {
+            $decoded = json_decode(trim($jsonBlock), true);
+            if (!is_array($decoded)) {
+                continue;
+            }
+
+            foreach ($this->collectJsonLdOfferNodes($decoded) as $offerNode) {
+                $offer = $this->buildJsonLdOffer($offerNode);
+                if ($offer !== null) {
+                    $offers[] = $offer;
+                }
+            }
+        }
+
+        return $offers;
+    }
+
+    /**
+     * Walks a decoded JSON-LD document ("@graph" included) and collects every node
+     * found under an "offers" key, normalized to a list.
+     *
+     * @param  array<mixed> $node
+     * @return list<array<string, mixed>>
+     */
+    private function collectJsonLdOfferNodes(array $node): array
+    {
+        $offerNodes = [];
+
+        $rawOffers = $node['offers'] ?? null;
+        if (is_array($rawOffers)) {
+            // Either a single offer object or a list of offers.
+            $offerList = array_is_list($rawOffers) ? $rawOffers : [$rawOffers];
+            foreach ($offerList as $offerCandidate) {
+                if (is_array($offerCandidate)) {
+                    $offerNodes[] = $offerCandidate;
+                }
+            }
+        }
+
+        foreach (['@graph', 'itemListElement', 'item'] as $childKey) {
+            $children = $node[$childKey] ?? null;
+            if (!is_array($children)) {
+                continue;
+            }
+            $childList = array_is_list($children) ? $children : [$children];
+            foreach ($childList as $child) {
+                if (is_array($child)) {
+                    $offerNodes = array_merge($offerNodes, $this->collectJsonLdOfferNodes($child));
+                }
+            }
+        }
+
+        return $offerNodes;
+    }
+
+    /** @param array<string, mixed> $offerNode */
+    private function buildJsonLdOffer(array $offerNode): ?PriceOfferDto
+    {
+        $rawPrice = $offerNode['price'] ?? ($offerNode['priceSpecification']['price'] ?? null);
+        if (!is_string($rawPrice) && !is_int($rawPrice) && !is_float($rawPrice)) {
+            return null;
+        }
+
+        $amount = (float) str_replace(',', '.', (string) $rawPrice);
+        if ($amount <= 0.0) {
+            return null;
+        }
+
+        $sellerName = $offerNode['seller']['name'] ?? null;
+        if (!is_string($sellerName) || trim($sellerName) === '') {
+            return null;
+        }
+
+        $currency = $offerNode['priceCurrency'] ?? 'EUR';
+        $offerUrl = $offerNode['url'] ?? null;
+
+        return new PriceOfferDto(
+            kind:         PriceKindEnum::MerchantLive,
+            merchant:     mb_substr(trim($sellerName), 0, 60),
+            merchantLogo: 'chasseauxlivres',
+            amount:       round($amount, 2),
+            currency:     is_string($currency) && $currency !== '' ? $currency : 'EUR',
+            url:          is_string($offerUrl) ? $this->absolutizeUrl($offerUrl) : null,
+            imageUrl:     null,
+            source:       'chasse_aux_livres',
+        );
+    }
+
+    // ── Strategy 2 : DOM rows (tables, data-attributes, offer blocks, lists) ──
+
+    /** @return list<PriceOfferDto> */
+    private function parseDomOffers(string $html): array
+    {
         $dom = new DOMDocument();
         libxml_use_internal_errors(true);
         $dom->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($dom);
 
-        // Comparison rows: a table row holding a merchant link and a € amount. Falls
-        // back to any "offer"-classed block for a non-table layout.
-        $rows = $xpath->query('//tr[.//a]');
-        if ($rows === false || $rows->length === 0) {
-            $rows = $xpath->query("//*[contains(@class, 'offer')][.//a]");
-        }
-        if ($rows === false) {
-            return [];
-        }
-
-        $offers = [];
-        foreach ($rows as $row) {
-            if (!$row instanceof DOMElement) {
+        foreach (self::ROW_XPATH_STRATEGIES as $rowExpression) {
+            $rows = $xpath->query($rowExpression);
+            if ($rows === false || $rows->length === 0) {
                 continue;
             }
-            $offer = $this->parseRow($row, $xpath);
-            if ($offer !== null) {
-                $offers[] = $offer;
+
+            $offers = [];
+            foreach ($rows as $row) {
+                if (!$row instanceof DOMElement) {
+                    continue;
+                }
+                $offer = $this->parseRow($row, $xpath);
+                if ($offer !== null) {
+                    $offers[] = $offer;
+                }
+                if (count($offers) >= self::MAX_OFFERS) {
+                    break;
+                }
             }
-            if (count($offers) >= self::MAX_OFFERS) {
-                break;
+
+            if ($offers !== []) {
+                return $offers;
             }
         }
 
-        return $offers;
+        return [];
     }
 
     private function parseRow(DOMElement $row, DOMXPath $xpath): ?PriceOfferDto
@@ -161,6 +324,12 @@ final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProvider
 
     private function extractMerchant(DOMElement $row, DOMXPath $xpath): ?string
     {
+        // Highest-fidelity source: an explicit data attribute on the row or a descendant.
+        $dataAttributeMerchant = $this->extractMerchantFromDataAttributes($row, $xpath);
+        if ($dataAttributeMerchant !== null) {
+            return $dataAttributeMerchant;
+        }
+
         // Merchants are usually shown as a logo — the alt text names them.
         $images = $xpath->query('.//img[@alt]', $row);
         if ($images !== false) {
@@ -182,6 +351,35 @@ final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProvider
         return ($firstChunk !== '' && mb_strlen($firstChunk) <= 60) ? $firstChunk : null;
     }
 
+    private function extractMerchantFromDataAttributes(DOMElement $row, DOMXPath $xpath): ?string
+    {
+        foreach (self::MERCHANT_DATA_ATTRIBUTES as $attributeName) {
+            $attributeValue = trim($row->getAttribute($attributeName));
+            if ($attributeValue !== '') {
+                return mb_substr($attributeValue, 0, 60);
+            }
+        }
+
+        $descendants = $xpath->query('.//*[@data-merchant or @data-seller or @data-vendor]', $row);
+        if ($descendants === false) {
+            return null;
+        }
+
+        foreach ($descendants as $descendant) {
+            if (!$descendant instanceof DOMElement) {
+                continue;
+            }
+            foreach (self::MERCHANT_DATA_ATTRIBUTES as $attributeName) {
+                $attributeValue = trim($descendant->getAttribute($attributeName));
+                if ($attributeValue !== '') {
+                    return mb_substr($attributeValue, 0, 60);
+                }
+            }
+        }
+
+        return null;
+    }
+
     private function extractUrl(DOMElement $row, DOMXPath $xpath): ?string
     {
         $links = $xpath->query('.//a[@href]', $row);
@@ -197,16 +395,55 @@ final readonly class ChasseAuxLivresPriceProvider implements VolumePriceProvider
             if ($href === '' || str_starts_with($href, '#') || str_starts_with($href, 'javascript:')) {
                 continue;
             }
-            if (str_starts_with($href, '//')) {
-                return 'https:' . $href;
-            }
-            if (str_starts_with($href, '/')) {
-                return $this->baseUrl . $href;
-            }
 
-            return $href;
+            return $this->absolutizeUrl($href);
         }
 
         return null;
+    }
+
+    private function absolutizeUrl(string $href): string
+    {
+        if (str_starts_with($href, '//')) {
+            return 'https:' . $href;
+        }
+        if (str_starts_with($href, '/')) {
+            return $this->baseUrl . $href;
+        }
+
+        return $href;
+    }
+
+    // ── Strategy 3 : tolerant text fallback (known merchant near "xx,xx €") ──
+
+    /** @return list<PriceOfferDto> */
+    private function parseTextOffers(string $html): array
+    {
+        $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5);
+
+        $offers = [];
+        foreach (self::KNOWN_MERCHANTS as $merchantName) {
+            $pattern = sprintf(
+                '/(%s)[^€]{0,160}?(\d{1,4})[,.](\d{2})\s*€/iu',
+                preg_quote($merchantName, '/'),
+            );
+
+            if (preg_match($pattern, $text, $matches) !== 1) {
+                continue;
+            }
+
+            $offers[] = new PriceOfferDto(
+                kind:         PriceKindEnum::MerchantLive,
+                merchant:     $matches[1],
+                merchantLogo: 'chasseauxlivres',
+                amount:       (float) ($matches[2] . '.' . $matches[3]),
+                currency:     'EUR',
+                url:          null,
+                imageUrl:     null,
+                source:       'chasse_aux_livres',
+            );
+        }
+
+        return $offers;
     }
 }

--- a/back/src/Manga/Infrastructure/ExternalApi/DnbEditionProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/DnbEditionProvider.php
@@ -24,6 +24,10 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
 {
     private const string LOG_PREFIX = 'DNB EDITIONS : ';
 
+    /** SRU pagination: up to 3 pages of 100 records. */
+    private const int PAGE_SIZE = 100;
+    private const int MAX_PAGES = 3;
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private string $baseUrl,
@@ -66,12 +70,38 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
             $cqlQuery .= sprintf(' and PER=%s', $author);
         }
 
+        $editions    = [];
+        $startRecord = 1;
+
+        for ($pageIndex = 0; $pageIndex < self::MAX_PAGES; $pageIndex++) {
+            $page = $this->fetchPage($cqlQuery, $workTitle, $startRecord);
+            if ($page === null) {
+                break;
+            }
+
+            foreach ($page['editions'] as $edition) {
+                $editions[] = $edition;
+            }
+
+            $startRecord += self::PAGE_SIZE;
+            if ($page['recordCount'] === 0 || $startRecord > $page['numberOfRecords']) {
+                break;
+            }
+        }
+
+        return $editions;
+    }
+
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function fetchPage(string $cqlQuery, string $workTitle, int $startRecord): ?array
+    {
         $sruParams = http_build_query([
             'version'        => '1.1',
             'operation'      => 'searchRetrieve',
             'query'          => $cqlQuery,
             'recordSchema'   => 'oai_dc',
-            'maximumRecords' => '100',
+            'maximumRecords' => (string) self::PAGE_SIZE,
+            'startRecord'    => (string) $startRecord,
         ]);
         $url = sprintf('%s?%s', $this->baseUrl, $sruParams);
 
@@ -81,17 +111,17 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
                 'status' => $response->getStatusCode(),
             ]);
 
-            return [];
+            return null;
         }
 
         return $this->parseResponse($response->getContent(), $workTitle);
     }
 
-    /** @return list<ExternalEditionDto> */
-    private function parseResponse(string $xmlContent, string $workTitle): array
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function parseResponse(string $xmlContent, string $workTitle): ?array
     {
         if ($xmlContent === '') {
-            return [];
+            return null;
         }
 
         libxml_use_internal_errors(true);
@@ -100,10 +130,16 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
         $xml->registerXPathNamespace('srw', 'http://www.loc.gov/zing/srw/');
         $xml->registerXPathNamespace('dc', 'http://purl.org/dc/elements/1.1/');
 
+        /** @var array<SimpleXMLElement>|false $totalNodes */
+        $totalNodes      = $xml->xpath('//srw:numberOfRecords');
+        $numberOfRecords = $totalNodes !== false && $totalNodes !== []
+            ? (int) ($totalNodes[0] ?? 0)
+            : 0;
+
         /** @var array<SimpleXMLElement>|false $records */
         $records = $xml->xpath('//srw:record/srw:recordData');
         if ($records === false || $records === []) {
-            return [];
+            return ['editions' => [], 'numberOfRecords' => $numberOfRecords, 'recordCount' => 0];
         }
 
         $editions = [];
@@ -114,7 +150,11 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
             }
         }
 
-        return $editions;
+        return [
+            'editions'        => $editions,
+            'numberOfRecords' => $numberOfRecords,
+            'recordCount'     => count($records),
+        ];
     }
 
     private function parseRecord(SimpleXMLElement $record, string $workTitle): ?ExternalEditionDto
@@ -143,7 +183,7 @@ final readonly class DnbEditionProvider implements EditionProviderInterface
         $dcFormat    = $formatNodes !== false && $formatNodes !== [] ? (string) ($formatNodes[0] ?? '') : '';
         $dcType      = $typeNodes !== false && $typeNodes !== [] ? (string) ($typeNodes[0] ?? '') : '';
 
-        if (!$this->relevanceFilter->isRelevant($recordTitle, $publisher, $dcType)) {
+        if (!$this->relevanceFilter->isRelevant($workTitle, $recordTitle, $publisher, $dcType)) {
             return null;
         }
 

--- a/back/src/Manga/Infrastructure/ExternalApi/EbayBrowsePriceProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/EbayBrowsePriceProvider.php
@@ -22,7 +22,7 @@ final readonly class EbayBrowsePriceProvider implements VolumePriceProviderInter
         private HttpClientInterface $httpClient,
         private EbayOAuthTokenProvider $tokenProvider,
         private string $baseUrl,
-        private string $campaignId,
+        private ?string $campaignId,
         private LoggerInterface $logger,
     ) {
     }
@@ -65,7 +65,7 @@ final readonly class EbayBrowsePriceProvider implements VolumePriceProviderInter
             'X-EBAY-C-MARKETPLACE-ID'  => $marketplace->ebayId(),
         ];
 
-        if ($this->campaignId !== '') {
+        if ($this->campaignId !== null && $this->campaignId !== '') {
             $headers['X-EBAY-C-ENDUSERCTX'] = sprintf('affiliateCampaignId=%s', $this->campaignId);
         }
 

--- a/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksEditionProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksEditionProvider.php
@@ -22,6 +22,18 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
     /** Markets swept when no specific language is requested (broad discovery). */
     private const array DISCOVERY_LOCALES = ['fr', 'en', 'ja', 'de', 'es', 'it'];
 
+    /** Google Books caps maxResults at 40; up to 2 pages are fetched per locale. */
+    private const int PAGE_SIZE = 40;
+    private const int MAX_PAGES_PER_LOCALE = 2;
+
+    /**
+     * Sentinel values the env-sync tooling (and back/.env defaults) leave in place of a
+     * real key — sending them yields silent 403s, so treat them as "no key configured".
+     *
+     * @var list<string>
+     */
+    private const array PLACEHOLDER_API_KEYS = ['change_me', 'changeme'];
+
     private const array COUNTRY_MAP = [
         'fr' => 'FR',
         'en' => 'US',
@@ -48,7 +60,7 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
 
     public function findEditions(string $workTitle, ?string $author, ?string $language): array
     {
-        if ($this->apiKey === '') {
+        if (!$this->isApiKeyConfigured()) {
             return [];
         }
 
@@ -91,8 +103,38 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
         return array_values($byId);
     }
 
+    private function isApiKeyConfigured(): bool
+    {
+        return $this->apiKey !== ''
+            && !in_array(strtolower($this->apiKey), self::PLACEHOLDER_API_KEYS, true);
+    }
+
     /** @return list<ExternalEditionDto> */
     private function fetchLocale(string $workTitle, ?string $author, string $language): array
+    {
+        $editions = [];
+
+        for ($pageIndex = 0; $pageIndex < self::MAX_PAGES_PER_LOCALE; $pageIndex++) {
+            $items = $this->fetchPage($workTitle, $author, $language, $pageIndex * self::PAGE_SIZE);
+
+            foreach ($items as $item) {
+                $edition = $this->buildEditionDto($item, $workTitle, $language);
+                if ($edition !== null) {
+                    $editions[] = $edition;
+                }
+            }
+
+            // A short page means the result set is exhausted — no further page exists.
+            if (count($items) < self::PAGE_SIZE) {
+                break;
+            }
+        }
+
+        return $editions;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function fetchPage(string $workTitle, ?string $author, string $language, int $startIndex): array
     {
         $query = sprintf('intitle:%s', rawurlencode($workTitle));
         if ($author !== null && $author !== '') {
@@ -100,10 +142,12 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
         }
 
         $url = sprintf(
-            '%s/volumes?q=%s&langRestrict=%s&maxResults=40&key=%s',
+            '%s/volumes?q=%s&langRestrict=%s&maxResults=%d&startIndex=%d&key=%s',
             self::BASE_URL,
             $query,
             $language,
+            self::PAGE_SIZE,
+            $startIndex,
             $this->apiKey,
         );
 
@@ -118,18 +162,9 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
         }
 
         /** @var array{items?: list<array<string, mixed>>} $data */
-        $data  = json_decode($response->getContent(), true);
-        $items = $data['items'] ?? [];
+        $data = json_decode($response->getContent(), true);
 
-        $editions = [];
-        foreach ($items as $item) {
-            $edition = $this->buildEditionDto($item, $workTitle, $language);
-            if ($edition !== null) {
-                $editions[] = $edition;
-            }
-        }
-
-        return $editions;
+        return $data['items'] ?? [];
     }
 
     /** @param array<string, mixed> $item */
@@ -142,7 +177,8 @@ final readonly class GoogleBooksEditionProvider implements EditionProviderInterf
 
         $volumeTitle = (string) ($volumeInfo['title'] ?? '');
         $subtitle    = (string) ($volumeInfo['subtitle'] ?? '');
-        if (!$this->relevanceFilter->isRelevant($volumeTitle !== '' ? $volumeTitle : $workTitle, $publisher)) {
+        $titleToCheck = $volumeTitle !== '' ? $volumeTitle : $workTitle;
+        if (!$this->relevanceFilter->isRelevant($workTitle, $titleToCheck, $publisher)) {
             return null;
         }
         $editionLine = $this->lineExtractor->extract($volumeTitle, $subtitle);

--- a/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksPriceProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/GoogleBooksPriceProvider.php
@@ -18,6 +18,15 @@ final readonly class GoogleBooksPriceProvider implements VolumePriceProviderInte
     private const string BASE_URL   = 'https://www.googleapis.com/books/v1';
     private const string LOG_PREFIX = 'GOOGLE BOOKS PRICES : ';
 
+    /**
+     * Sentinel values the env-sync tooling (and back/.env defaults) leave in place of a
+     * real key — sending them yields silent 403s, so treat them as "no key configured".
+     * Same pattern as {@see GoogleBooksEditionProvider}.
+     *
+     * @var list<string>
+     */
+    private const array PLACEHOLDER_API_KEYS = ['change_me', 'changeme'];
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private string $apiKey,
@@ -27,7 +36,7 @@ final readonly class GoogleBooksPriceProvider implements VolumePriceProviderInte
 
     public function findOffers(Isbn $isbn, Marketplace $marketplace): array
     {
-        if ($this->apiKey === '') {
+        if (!$this->isApiKeyConfigured()) {
             return [];
         }
 
@@ -46,6 +55,12 @@ final readonly class GoogleBooksPriceProvider implements VolumePriceProviderInte
 
             return [];
         }
+    }
+
+    private function isApiKeyConfigured(): bool
+    {
+        return $this->apiKey !== ''
+            && !in_array(strtolower($this->apiKey), self::PLACEHOLDER_API_KEYS, true);
     }
 
     /** @return list<PriceOfferDto> */

--- a/back/src/Manga/Infrastructure/ExternalApi/NdlEditionProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/NdlEditionProvider.php
@@ -28,6 +28,10 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
 {
     private const string LOG_PREFIX = 'NDL EDITIONS : ';
 
+    /** SRU pagination: up to 3 pages of 100 records. */
+    private const int PAGE_SIZE = 100;
+    private const int MAX_PAGES = 3;
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private string $baseUrl,
@@ -69,13 +73,39 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
             $cqlQuery .= sprintf(' AND creator="%s"', str_replace('"', '', $author));
         }
 
+        $editions    = [];
+        $startRecord = 1;
+
+        for ($pageIndex = 0; $pageIndex < self::MAX_PAGES; $pageIndex++) {
+            $page = $this->fetchPage($cqlQuery, $workTitle, $startRecord);
+            if ($page === null) {
+                break;
+            }
+
+            foreach ($page['editions'] as $edition) {
+                $editions[] = $edition;
+            }
+
+            $startRecord += self::PAGE_SIZE;
+            if ($page['recordCount'] === 0 || $startRecord > $page['numberOfRecords']) {
+                break;
+            }
+        }
+
+        return $editions;
+    }
+
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function fetchPage(string $cqlQuery, string $workTitle, int $startRecord): ?array
+    {
         $sruParams = http_build_query([
             'operation'      => 'searchRetrieve',
             'version'        => '1.2',
             'recordSchema'   => 'dcndl_simple',
             'recordPacking'  => 'xml',
             'query'          => $cqlQuery,
-            'maximumRecords' => '100',
+            'maximumRecords' => (string) self::PAGE_SIZE,
+            'startRecord'    => (string) $startRecord,
         ]);
         $url = sprintf('%s?%s', $this->baseUrl, $sruParams);
 
@@ -85,17 +115,17 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
                 'status' => $response->getStatusCode(),
             ]);
 
-            return [];
+            return null;
         }
 
         return $this->parseResponse($response->getContent(), $workTitle);
     }
 
-    /** @return list<ExternalEditionDto> */
-    private function parseResponse(string $xmlContent, string $workTitle): array
+    /** @return array{editions: list<ExternalEditionDto>, numberOfRecords: int, recordCount: int}|null */
+    private function parseResponse(string $xmlContent, string $workTitle): ?array
     {
         if ($xmlContent === '') {
-            return [];
+            return null;
         }
 
         libxml_use_internal_errors(true);
@@ -103,10 +133,16 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
 
         $xml->registerXPathNamespace('srw', 'http://www.loc.gov/zing/srw/');
 
+        /** @var array<SimpleXMLElement>|false $totalNodes */
+        $totalNodes      = $xml->xpath('//srw:numberOfRecords');
+        $numberOfRecords = $totalNodes !== false && $totalNodes !== []
+            ? (int) ($totalNodes[0] ?? 0)
+            : 0;
+
         /** @var array<SimpleXMLElement>|false $records */
         $records = $xml->xpath('//srw:record/srw:recordData');
         if ($records === false || $records === []) {
-            return [];
+            return ['editions' => [], 'numberOfRecords' => $numberOfRecords, 'recordCount' => 0];
         }
 
         $editions = [];
@@ -117,7 +153,11 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
             }
         }
 
-        return $editions;
+        return [
+            'editions'        => $editions,
+            'numberOfRecords' => $numberOfRecords,
+            'recordCount'     => count($records),
+        ];
     }
 
     private function parseRecord(SimpleXMLElement $record, string $workTitle): ?ExternalEditionDto
@@ -142,7 +182,7 @@ final readonly class NdlEditionProvider implements EditionProviderInterface
         $publisher   = ($publisher !== null && $publisher !== '') ? $publisher : null;
         $dcType      = $typeNodes !== false && $typeNodes !== [] ? (string) ($typeNodes[0] ?? '') : '';
 
-        if (!$this->relevanceFilter->isRelevant($recordTitle, $publisher, $dcType)) {
+        if (!$this->relevanceFilter->isRelevant($workTitle, $recordTitle, $publisher, $dcType)) {
             return null;
         }
 

--- a/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryCoversApiClient.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryCoversApiClient.php
@@ -41,7 +41,7 @@ final readonly class OpenLibraryCoversApiClient implements MangaCoverProviderInt
                 return null;
             }
 
-            $contentLength = (int) ($response->getHeaders()['content-length'][0] ?? 0);
+            $contentLength = $this->resolveContentLength($response->getHeaders(), $coverUrl);
             if ($contentLength < self::MIN_COVER_CONTENT_LENGTH) {
                 $this->logger->info(self::PREFIX_LOGGER . 'find by ISBN; IMAGE TOO SMALL.', [
                     'isbn' => $isbn->value,
@@ -65,6 +65,30 @@ final readonly class OpenLibraryCoversApiClient implements MangaCoverProviderInt
             ]);
             return null;
         }
+    }
+
+    /**
+     * Reads the content-length announced by the HEAD response. Some responses omit the
+     * header entirely — treating that as 0 would wrongly reject a perfectly valid
+     * cover, so fall back to a real GET and measure the actual body instead.
+     *
+     * @param array<string, list<string>> $headers
+     */
+    private function resolveContentLength(array $headers, string $coverUrl): int
+    {
+        $rawContentLength = $headers['content-length'][0] ?? null;
+        if ($rawContentLength !== null && is_numeric($rawContentLength) && (int) $rawContentLength > 0) {
+            return (int) $rawContentLength;
+        }
+
+        $this->logger->info(self::PREFIX_LOGGER . 'find by ISBN; NO CONTENT-LENGTH ON HEAD, FALLING BACK TO GET.');
+
+        $getResponse = $this->httpClient->request('GET', $coverUrl);
+        if ($getResponse->getStatusCode() !== 200) {
+            return 0;
+        }
+
+        return strlen($getResponse->getContent());
     }
 
     public function findByContext(

--- a/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryEditionProvider.php
+++ b/back/src/Manga/Infrastructure/ExternalApi/OpenLibraryEditionProvider.php
@@ -18,6 +18,9 @@ final readonly class OpenLibraryEditionProvider implements EditionProviderInterf
 {
     private const string LOG_PREFIX = 'OPEN_LIBRARY EDITIONS : ';
 
+    /** Open Library splits one manga across several Work records — merge up to 3 of them. */
+    private const int MAX_WORKS = 3;
+
     private const array LANGUAGE_MAP = [
         '/languages/fre' => 'fr',
         '/languages/eng' => 'en',
@@ -77,17 +80,41 @@ final readonly class OpenLibraryEditionProvider implements EditionProviderInterf
     /** @return list<ExternalEditionDto> */
     private function doFindEditions(string $workTitle, ?string $author, ?string $language): array
     {
-        $workKey = $this->resolveWorkKey($workTitle, $author);
-        if ($workKey === null) {
+        $workKeys = $this->resolveWorkKeys($workTitle, $author);
+        if ($workKeys === []) {
             $this->logger->info(self::LOG_PREFIX . 'findEditions; no work found.', ['title' => $workTitle]);
 
             return [];
         }
 
-        return $this->fetchEditions($workKey, $workTitle, $language);
+        /** @var array<string, true> $seenKeys */
+        $seenKeys = [];
+        $editions = [];
+        foreach ($workKeys as $workKey) {
+            foreach ($this->fetchEditions($workKey, $workTitle, $language) as $edition) {
+                $dedupeKey = $edition->externalId ?? $edition->isbnSample;
+                if ($dedupeKey !== null) {
+                    if (isset($seenKeys[$dedupeKey])) {
+                        continue;
+                    }
+                    $seenKeys[$dedupeKey] = true;
+                }
+                $editions[] = $edition;
+            }
+        }
+
+        return $editions;
     }
 
-    private function resolveWorkKey(string $workTitle, ?string $author): ?string
+    /**
+     * The searched work can be split across several Open Library Work records (the main
+     * run, a deluxe re-release, an artbook…). Every doc whose title matches the searched
+     * title is a candidate; author-matching docs are preferred, and up to
+     * {@see self::MAX_WORKS} works contribute their editions.
+     *
+     * @return list<string>
+     */
+    private function resolveWorkKeys(string $workTitle, ?string $author): array
     {
         $url = sprintf(
             '%s/search.json?q=%s&fields=key,title,author_name,edition_count&limit=5',
@@ -100,7 +127,7 @@ final readonly class OpenLibraryEditionProvider implements EditionProviderInterf
         ]);
 
         if ($response->getStatusCode() !== 200) {
-            return null;
+            return [];
         }
 
         /** @var array{docs?: list<array{key: string, title: string, author_name?: list<string>}>} $data */
@@ -108,21 +135,54 @@ final readonly class OpenLibraryEditionProvider implements EditionProviderInterf
         $docs = $data['docs'] ?? [];
 
         if ($docs === []) {
-            return null;
+            return [];
         }
 
-        if ($author !== null && $author !== '') {
-            foreach ($docs as $doc) {
-                $authors = $doc['author_name'] ?? [];
-                foreach ($authors as $authorName) {
-                    if (stripos($authorName, $author) !== false) {
-                        return $doc['key'];
-                    }
-                }
+        $authorMatches = [];
+        $titleMatches  = [];
+        foreach ($docs as $doc) {
+            if (!$this->titleMatches($workTitle, $doc['title'])) {
+                continue;
+            }
+
+            if ($author !== null && $author !== '' && $this->hasAuthor($doc['author_name'] ?? [], $author)) {
+                $authorMatches[] = $doc['key'];
+                continue;
+            }
+
+            $titleMatches[] = $doc['key'];
+        }
+
+        $candidates = array_merge($authorMatches, $titleMatches);
+        if ($candidates === []) {
+            $candidates = [$docs[0]['key']];
+        }
+
+        return array_slice(array_values(array_unique($candidates)), 0, self::MAX_WORKS);
+    }
+
+    /** @param list<string> $authorNames */
+    private function hasAuthor(array $authorNames, string $author): bool
+    {
+        foreach ($authorNames as $authorName) {
+            if (stripos($authorName, $author) !== false) {
+                return true;
             }
         }
 
-        return $docs[0]['key'];
+        return false;
+    }
+
+    private function titleMatches(string $workTitle, string $docTitle): bool
+    {
+        $foldedWork = mb_strtolower(trim($workTitle));
+        $foldedDoc  = mb_strtolower(trim($docTitle));
+
+        if ($foldedWork === '' || $foldedDoc === '') {
+            return false;
+        }
+
+        return str_contains($foldedDoc, $foldedWork) || str_contains($foldedWork, $foldedDoc);
     }
 
     /** @return list<ExternalEditionDto> */
@@ -174,8 +234,9 @@ final readonly class OpenLibraryEditionProvider implements EditionProviderInterf
         $publisher  = $publishers !== [] ? (string) ($publishers[0] ?? '') : null;
         $publisher  = ($publisher !== '' && $publisher !== null) ? $publisher : null;
 
-        $entryTitle = (string) ($entry['title'] ?? '');
-        if (!$this->relevanceFilter->isRelevant($entryTitle !== '' ? $entryTitle : $workTitle, $publisher)) {
+        $entryTitle   = (string) ($entry['title'] ?? '');
+        $titleToCheck = $entryTitle !== '' ? $entryTitle : $workTitle;
+        if (!$this->relevanceFilter->isRelevant($workTitle, $titleToCheck, $publisher)) {
             return null;
         }
         $editionLine = $this->lineExtractor->extract($entryTitle);

--- a/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
+++ b/back/src/Manga/Infrastructure/Http/UpdateVolumeRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Manga\Infrastructure\Http;
 
+use App\Manga\Infrastructure\Validator\ValidIsbn;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final readonly class UpdateVolumeRequest
@@ -14,6 +15,7 @@ final readonly class UpdateVolumeRequest
         #[Assert\PositiveOrZero]
         public ?float $price = null,
         public ?string $spineUrl = null,
+        #[ValidIsbn]
         public ?string $isbn = null,
     ) {
     }

--- a/back/src/Manga/Infrastructure/Validator/ValidIsbn.php
+++ b/back/src/Manga/Infrastructure/Validator/ValidIsbn.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Validator;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates a request field as an ISBN-10 or ISBN-13 (separators and EAN add-on
+ * tolerated) via {@see \App\Manga\Domain\Isbn}. Null / blank values are skipped.
+ *
+ * Used on request DTOs so an invalid ISBN fails the payload mapping with a 422
+ * violation scoped to the field, before any command reaches the transaction.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ValidIsbn extends Constraint
+{
+    public string $message = 'This value is not a valid ISBN-10 or ISBN-13.';
+}

--- a/back/src/Manga/Infrastructure/Validator/ValidIsbnValidator.php
+++ b/back/src/Manga/Infrastructure/Validator/ValidIsbnValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manga\Infrastructure\Validator;
+
+use App\Manga\Domain\Isbn;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidIsbnValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidIsbn) {
+            throw new UnexpectedTypeException($constraint, ValidIsbn::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        if (Isbn::tryFrom($value) === null) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}

--- a/back/src/Notification/Application/GetActivityLogs/ActivityLogPaginatedResult.php
+++ b/back/src/Notification/Application/GetActivityLogs/ActivityLogPaginatedResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\GetActivityLogs;
+
+use App\Notification\Domain\ActivityLog;
+use App\Shared\Application\Pagination\PaginatedResult;
+
+/**
+ * @extends PaginatedResult<ActivityLog>
+ */
+final class ActivityLogPaginatedResult extends PaginatedResult
+{
+    protected function serializeItems(): array
+    {
+        return array_map(
+            static fn (ActivityLog $log) => $log->toArray(),
+            $this->items,
+        );
+    }
+}

--- a/back/src/Notification/Application/GetActivityLogs/GetActivityLogsHandler.php
+++ b/back/src/Notification/Application/GetActivityLogs/GetActivityLogsHandler.php
@@ -14,23 +14,26 @@ final readonly class GetActivityLogsHandler
     {
     }
 
-    /** @return array<string, mixed> */
+    /** @return array{items: list<array<string, mixed>>, total: int, page: int, limit: int} */
     public function __invoke(GetActivityLogsQuery $query): array
     {
         $filters = array_filter([
             'eventType'         => $query->eventType,
             'status'            => $query->status,
             'collectionEntryId' => $query->collectionEntryId,
+            'ownerId'           => $query->ownerId,
+            'from'              => $query->from,
+            'to'                => $query->to,
+            'search'            => $query->search,
         ]);
 
         $result = $this->repository->findPaginated($query->page, $query->limit, $filters);
 
-        return [
-            'items'      => array_map(static fn ($l) => $l->toArray(), $result['items']),
-            'total'      => $result['total'],
-            'page'       => $query->page,
-            'limit'      => $query->limit,
-            'totalPages' => (int) ceil($result['total'] / $query->limit),
-        ];
+        return (new ActivityLogPaginatedResult(
+            items: $result['items'],
+            total: $result['total'],
+            page:  $query->page,
+            limit: $query->limit,
+        ))->toArray();
     }
 }

--- a/back/src/Notification/Application/GetActivityLogs/GetActivityLogsQuery.php
+++ b/back/src/Notification/Application/GetActivityLogs/GetActivityLogsQuery.php
@@ -4,14 +4,43 @@ declare(strict_types=1);
 
 namespace App\Notification\Application\GetActivityLogs;
 
-final readonly class GetActivityLogsQuery
+use App\Shared\Application\Pagination\AbstractPaginatedQuery;
+use DateTimeImmutable;
+use Exception;
+
+final readonly class GetActivityLogsQuery extends AbstractPaginatedQuery
 {
+    public ?DateTimeImmutable $from;
+    public ?DateTimeImmutable $to;
+
     public function __construct(
-        public int $page = 1,
-        public int $limit = 50,
         public ?string $eventType = null,
         public ?string $status = null,
         public ?string $collectionEntryId = null,
+        public ?string $ownerId = null,
+        ?string $from = null,
+        ?string $to = null,
+        public ?string $search = null,
+        int $page = 1,
+        int $limit = 50,
     ) {
+        parent::__construct($page, $limit);
+
+        $this->from = self::parseDate($from);
+        $this->to   = self::parseDate($to);
+    }
+
+    /** Invalid or empty date strings are ignored (filter not applied). */
+    private static function parseDate(?string $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception) {
+            return null;
+        }
     }
 }

--- a/back/src/Notification/Application/Schedule/PurgeActivityLogsTask.php
+++ b/back/src/Notification/Application/Schedule/PurgeActivityLogsTask.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Schedule;
+
+use App\Notification\Domain\Service\ActivityLogPurger;
+use Symfony\Component\Scheduler\Attribute\AsCronTask;
+
+/**
+ * Daily purge of activity logs older than the default retention window.
+ * Runs at 04:30 UTC, before the 06:00 crawl dispatch, on the default schedule
+ * provided by App\Schedule.
+ */
+#[AsCronTask('30 4 * * *')]
+final readonly class PurgeActivityLogsTask
+{
+    public function __construct(private ActivityLogPurger $purger)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        $this->purger->purgeOlderThanDays(ActivityLogPurger::DEFAULT_RETENTION_DAYS);
+    }
+}

--- a/back/src/Notification/Domain/ActivityLog.php
+++ b/back/src/Notification/Domain/ActivityLog.php
@@ -77,6 +77,11 @@ class ActivityLog
             'id'               => $this->id,
             'eventType'        => $this->eventType->value,
             'sourceName'       => $this->sourceName,
+            'owner'            => $this->owner === null ? null : [
+                'id'          => $this->owner->id,
+                'email'       => $this->owner->email,
+                'displayName' => $this->owner->displayName,
+            ],
             'collectionEntryId' => $this->collectionEntry?->id,
             'mangaTitle'       => $this->collectionEntry?->manga->title,
             'status'           => $this->status,

--- a/back/src/Notification/Domain/ActivityLogOwnerResolverInterface.php
+++ b/back/src/Notification/Domain/ActivityLogOwnerResolverInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain;
+
+use App\Auth\Domain\User;
+
+/**
+ * Resolves the User to attribute an ActivityLog to.
+ *
+ * Implemented in Auth Infrastructure (Symfony Security token). In worker /
+ * scheduler contexts there is no security token, so currentOwner() returns null.
+ */
+interface ActivityLogOwnerResolverInterface
+{
+    public function currentOwner(): ?User;
+
+    public function findById(string $userId): ?User;
+}

--- a/back/src/Notification/Domain/ActivityLogRepositoryInterface.php
+++ b/back/src/Notification/Domain/ActivityLogRepositoryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Notification\Domain;
 
+use DateTimeImmutable;
+
 interface ActivityLogRepositoryInterface
 {
     public function save(ActivityLog $log): void;
@@ -11,10 +13,21 @@ interface ActivityLogRepositoryInterface
     public function findById(string $id): ?ActivityLog;
 
     /**
-     * @param array{eventType?: string, status?: string, collectionEntryId?: string} $filters
-     * @return array{items: ActivityLog[], total: int}
+     * @param array{
+     *     eventType?: string,
+     *     status?: string,
+     *     collectionEntryId?: string,
+     *     ownerId?: string,
+     *     from?: DateTimeImmutable,
+     *     to?: DateTimeImmutable,
+     *     search?: string,
+     * } $filters
+     * @return array{items: list<ActivityLog>, total: int}
      */
     public function findPaginated(int $page, int $limit, array $filters = []): array;
 
     public function countRecentErrors(int $windowMinutes = 10): int;
+
+    /** @return int Number of deleted rows */
+    public function deleteOlderThan(DateTimeImmutable $before): int;
 }

--- a/back/src/Notification/Domain/Service/ActivityLogEventHandler.php
+++ b/back/src/Notification/Domain/Service/ActivityLogEventHandler.php
@@ -6,6 +6,7 @@ namespace App\Notification\Domain\Service;
 
 use App\Collection\Domain\CollectionRepositoryInterface;
 use App\Notification\Domain\ActivityLog;
+use App\Notification\Domain\ActivityLogOwnerResolverInterface;
 use App\Notification\Domain\ActivityLogRepositoryInterface;
 use App\Notification\Domain\EventTypeEnum;
 use ReflectionObject;
@@ -19,12 +20,21 @@ use Throwable;
  * - Single Responsibility: handles ActivityLog lifecycle only
  * - Open/Closed: new event types automatically supported via reflection
  * - Dependency Inversion: depends on interfaces (ActivityLogRepositoryInterface, CollectionRepositoryInterface)
+ *
+ * Metadata extracted from events is sanitized: properties whose name matches
+ * the sensitive denylist (token, password, secret, jwt, authorization, apikey)
+ * are never copied, only scalars / arrays of scalars are kept, and strings are
+ * truncated so a single event can never flood the journal.
  */
 final readonly class ActivityLogEventHandler
 {
+    private const SENSITIVE_NAME_PATTERN = '/token|password|secret|jwt|authorization|apikey/i';
+    private const MAX_STRING_LENGTH      = 500;
+
     public function __construct(
         private ActivityLogRepositoryInterface $activityLogRepository,
         private CollectionRepositoryInterface $collectionRepository,
+        private ActivityLogOwnerResolverInterface $ownerResolver,
     ) {
     }
 
@@ -52,6 +62,7 @@ final readonly class ActivityLogEventHandler
             id: $correlationId,
             eventType: $eventType,
             sourceName: (string) $sourceName,
+            owner: $this->ownerResolver->currentOwner(),
             collectionEntry: $collectionEntry,
         );
 
@@ -61,7 +72,7 @@ final readonly class ActivityLogEventHandler
     /**
      * Handle a Succeeded event: find ActivityLog by correlationId and mark success.
      *
-     * @param object $event Must have: correlationId. Optional: newCount, addedCount, itemsScanned
+     * @param object $event Must have: correlationId. Optional: newCount, addedCount, itemsScanned, userId
      */
     public function handleSucceededEvent(object $event, ?int $forcedCount = null): void
     {
@@ -78,6 +89,8 @@ final readonly class ActivityLogEventHandler
         // Extract count from event properties or use forced value
         $count = $forcedCount ?? $this->extractCountFromEvent($event);
         $metadata = $this->extractMetadata($event);
+
+        $this->attributeOwnerFromEvent($log, $event);
 
         $log->markSuccess($count, $metadata);
         $this->activityLogRepository->save($log);
@@ -103,7 +116,10 @@ final readonly class ActivityLogEventHandler
         $error = $this->extractProperty($event, 'error') ?? 'Unknown error';
         $exceptionClass = $this->extractProperty($event, 'exceptionClass') ?? Throwable::class;
 
-        $metadata = ['exception_class' => $exceptionClass];
+        $metadata = array_merge(
+            $this->extractMetadata($event),
+            ['exception_class' => $exceptionClass],
+        );
         $log->markError((string) $error, $metadata);
 
         $this->activityLogRepository->save($log);
@@ -115,13 +131,28 @@ final readonly class ActivityLogEventHandler
         $namespace = $event::class;
 
         return match (true) {
+            str_contains($namespace, 'Wishlist') => EventTypeEnum::WishlistAction,
             str_contains($namespace, 'Auth\\Shared\\') => EventTypeEnum::AuthAction,
             str_contains($namespace, 'Collection\\Shared\\') => EventTypeEnum::CollectionAction,
             str_contains($namespace, 'Manga\\Shared\\') => EventTypeEnum::MangaAction,
-            str_contains($namespace, 'Wishlist\\Shared\\') => EventTypeEnum::WishlistAction,
             str_contains($namespace, 'Notification\\Shared\\') => EventTypeEnum::UserAction,
             default => EventTypeEnum::UserAction,
         };
+    }
+
+    /** Attribute the log to the user identified by the event's userId, if not already owned. */
+    private function attributeOwnerFromEvent(ActivityLog $log, object $event): void
+    {
+        if ($log->owner !== null) {
+            return;
+        }
+
+        $userId = $this->extractProperty($event, 'userId');
+        if (!is_string($userId) || $userId === '') {
+            return;
+        }
+
+        $log->owner = $this->ownerResolver->findById($userId);
     }
 
     /** Extract a public property value via reflection */
@@ -140,8 +171,8 @@ final readonly class ActivityLogEventHandler
     /** Extract count value from common property names */
     private function extractCountFromEvent(object $event): int
     {
-        foreach (['newCount', 'addedCount', 'itemsScanned', 'count', 'articleCount'] as $prop) {
-            $value = $this->extractProperty($event, $prop);
+        foreach (['newCount', 'addedCount', 'itemsScanned', 'count', 'articleCount'] as $propertyName) {
+            $value = $this->extractProperty($event, $propertyName);
             if ($value !== null && is_int($value)) {
                 return $value;
             }
@@ -149,7 +180,7 @@ final readonly class ActivityLogEventHandler
         return 0;
     }
 
-    /** Extract non-reserved properties as metadata.
+    /** Extract non-reserved, non-sensitive properties as sanitized metadata.
      * @return array<string, mixed>
      */
     private function extractMetadata(object $event): array
@@ -157,19 +188,24 @@ final readonly class ActivityLogEventHandler
         $reserved = [
             'correlationId', 'newCount', 'addedCount', 'itemsScanned',
             'sourceName', 'collectionEntryId', 'eventType', 'count', 'articleCount',
+            'error', 'exceptionClass', 'userId',
         ];
         $metadata = [];
 
         try {
             $reflection = new ReflectionObject($event);
-            foreach ($reflection->getProperties() as $prop) {
-                $name = $prop->getName();
-                if (!in_array($name, $reserved, true)) {
-                    $prop->setAccessible(true);
-                    $value = $prop->getValue($event);
-                    if ($value !== null) {
-                        $metadata[$name] = $value;
-                    }
+            foreach ($reflection->getProperties() as $property) {
+                $propertyName = $property->getName();
+                if (in_array($propertyName, $reserved, true)) {
+                    continue;
+                }
+                if (preg_match(self::SENSITIVE_NAME_PATTERN, $propertyName) === 1) {
+                    continue;
+                }
+                $property->setAccessible(true);
+                $sanitizedValue = $this->sanitizeValue($property->getValue($event));
+                if ($sanitizedValue !== null) {
+                    $metadata[$propertyName] = $sanitizedValue;
                 }
             }
         } catch (Throwable) {
@@ -177,5 +213,36 @@ final readonly class ActivityLogEventHandler
         }
 
         return $metadata;
+    }
+
+    /**
+     * Keep only scalars and arrays of scalars; truncate long strings; drop
+     * objects, resources and sensitive array keys.
+     */
+    private function sanitizeValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return mb_substr($value, 0, self::MAX_STRING_LENGTH);
+        }
+
+        if (is_int($value) || is_float($value) || is_bool($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            $sanitizedArray = [];
+            foreach ($value as $arrayKey => $arrayValue) {
+                if (is_string($arrayKey) && preg_match(self::SENSITIVE_NAME_PATTERN, $arrayKey) === 1) {
+                    continue;
+                }
+                $sanitizedItem = $this->sanitizeValue($arrayValue);
+                if ($sanitizedItem !== null) {
+                    $sanitizedArray[$arrayKey] = $sanitizedItem;
+                }
+            }
+            return $sanitizedArray;
+        }
+
+        return null;
     }
 }

--- a/back/src/Notification/Domain/Service/ActivityLogPurger.php
+++ b/back/src/Notification/Domain/Service/ActivityLogPurger.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain\Service;
+
+use App\Notification\Domain\ActivityLogRepositoryInterface;
+use DateTimeImmutable;
+use InvalidArgumentException;
+
+/**
+ * Deletes activity logs older than the retention window.
+ * Called by the daily scheduled task and the app:activity-log:purge console command.
+ */
+final readonly class ActivityLogPurger
+{
+    public const DEFAULT_RETENTION_DAYS = 90;
+
+    public function __construct(private ActivityLogRepositoryInterface $activityLogRepository)
+    {
+    }
+
+    /** @return int Number of deleted rows */
+    public function purgeOlderThanDays(int $days = self::DEFAULT_RETENTION_DAYS): int
+    {
+        if ($days < 1) {
+            throw new InvalidArgumentException('Retention must be at least 1 day.');
+        }
+
+        $cutoff = new DateTimeImmutable(sprintf('-%d days', $days));
+
+        return $this->activityLogRepository->deleteOlderThan($cutoff);
+    }
+}

--- a/back/src/Notification/Infrastructure/Console/PurgeActivityLogsCommand.php
+++ b/back/src/Notification/Infrastructure/Console/PurgeActivityLogsCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\Console;
+
+use App\Notification\Domain\Service\ActivityLogPurger;
+use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:activity-log:purge',
+    description: 'Delete activity logs older than the retention window (default 90 days).',
+)]
+final class PurgeActivityLogsCommand extends Command
+{
+    public function __construct(private readonly ActivityLogPurger $purger)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'days',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Retention window in days',
+            (string) ActivityLogPurger::DEFAULT_RETENTION_DAYS,
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io   = new SymfonyStyle($input, $output);
+        $days = (int) $input->getOption('days');
+
+        try {
+            $deletedCount = $this->purger->purgeOlderThanDays($days);
+        } catch (InvalidArgumentException $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::INVALID;
+        }
+
+        $io->success(sprintf('Deleted %d activity log(s) older than %d day(s).', $deletedCount, $days));
+
+        return Command::SUCCESS;
+    }
+}

--- a/back/src/Notification/Infrastructure/Doctrine/DoctrineActivityLogRepository.php
+++ b/back/src/Notification/Infrastructure/Doctrine/DoctrineActivityLogRepository.php
@@ -54,37 +54,73 @@ final readonly class DoctrineActivityLogRepository implements ActivityLogReposit
 
     public function findPaginated(int $page, int $limit, array $filters = []): array
     {
-        $qb = $this->em()->createQueryBuilder()
-            ->select('l')
-            ->from(ActivityLog::class, 'l')
-            ->leftJoin('l.collectionEntry', 'ce')
-            ->orderBy('l.startedAt', 'DESC');
+        $queryBuilder = $this->em()->createQueryBuilder()
+            ->select('log')
+            ->from(ActivityLog::class, 'log')
+            ->leftJoin('log.collectionEntry', 'entry')
+            ->orderBy('log.startedAt', 'DESC');
 
         if (isset($filters['eventType'])) {
-            $qb->andWhere('l.eventType = :et')
-               ->setParameter('et', $filters['eventType']);
+            $queryBuilder->andWhere('log.eventType = :eventType')
+               ->setParameter('eventType', $filters['eventType']);
         }
 
         if (isset($filters['status'])) {
-            $qb->andWhere('l.status = :status')
+            $queryBuilder->andWhere('log.status = :status')
                ->setParameter('status', $filters['status']);
         }
 
         if (isset($filters['collectionEntryId'])) {
-            $qb->andWhere('ce.id = :ceId')
-               ->setParameter('ceId', $filters['collectionEntryId']);
+            $queryBuilder->andWhere('entry.id = :collectionEntryId')
+               ->setParameter('collectionEntryId', $filters['collectionEntryId']);
         }
 
-        $total = (clone $qb)->select('COUNT(l.id)')->resetDQLPart('orderBy')
+        if (isset($filters['ownerId'])) {
+            $queryBuilder->andWhere('log.owner = :ownerId')
+               ->setParameter('ownerId', $filters['ownerId']);
+        }
+
+        if (isset($filters['from'])) {
+            $queryBuilder->andWhere('log.startedAt >= :fromDate')
+               ->setParameter('fromDate', $filters['from']);
+        }
+
+        if (isset($filters['to'])) {
+            $queryBuilder->andWhere('log.startedAt <= :toDate')
+               ->setParameter('toDate', $filters['to']);
+        }
+
+        if (isset($filters['search'])) {
+            $queryBuilder->andWhere(
+                'LOWER(log.sourceName) LIKE :search'
+                . ' OR LOWER(log.errorMessage) LIKE :search'
+                . " OR LOWER(JSON_GET_TEXT(log.metadata, 'path')) LIKE :search",
+            )->setParameter('search', '%' . mb_strtolower($filters['search']) . '%');
+        }
+
+        $total = (clone $queryBuilder)->select('COUNT(log.id)')->resetDQLPart('orderBy')
             ->getQuery()->getSingleScalarResult();
 
-        $items = $qb
+        $items = $queryBuilder
+            ->addSelect('entry')
+            ->leftJoin('log.owner', 'owner')
+            ->addSelect('owner')
             ->setFirstResult(($page - 1) * $limit)
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
 
         return ['items' => $items, 'total' => (int) $total];
+    }
+
+    public function deleteOlderThan(DateTimeImmutable $before): int
+    {
+        return (int) $this->em()->createQueryBuilder()
+            ->delete(ActivityLog::class, 'log')
+            ->where('log.startedAt < :before')
+            ->setParameter('before', $before)
+            ->getQuery()
+            ->execute();
     }
 
     public function countRecentErrors(int $windowMinutes = 10): int
@@ -95,13 +131,15 @@ final readonly class DoctrineActivityLogRepository implements ActivityLogReposit
             SELECT COUNT(*)
             FROM activity_logs
             WHERE status = :status
+              AND event_type = :eventType
               AND started_at >= :since
               AND (metadata->>'external_api_failure' IS DISTINCT FROM 'true')
         SQL;
 
         return (int) $this->em()->getConnection()->executeQuery($sql, [
-            'status' => 'error',
-            'since'  => $since->format('Y-m-d H:i:s.uP'),
+            'status'    => 'error',
+            'eventType' => 'worker_failure',
+            'since'     => $since->format('Y-m-d H:i:s.uP'),
         ])->fetchOne();
     }
 }

--- a/back/src/Notification/Infrastructure/Http/ActivityLogKernelSubscriber.php
+++ b/back/src/Notification/Infrastructure/Http/ActivityLogKernelSubscriber.php
@@ -13,7 +13,19 @@ use Symfony\Component\HttpKernel\KernelEvents;
 #[AsEventListener(event: KernelEvents::RESPONSE)]
 final readonly class ActivityLogKernelSubscriber
 {
+    /**
+     * /api/auth is excluded for successful responses only: successful logins,
+     * registrations and gate unlocks are logged as semantic AuthAction events
+     * by the Auth handlers (single clean source). Failed auth attempts cannot
+     * be logged there (the command transaction rolls back), so they flow
+     * through the generic HTTP >= 400 pipeline below.
+     */
     private const EXCLUDED_PREFIXES = ['/api/auth'];
+
+    /** Path prefixes whose following segments may carry secrets (share/scan tokens). */
+    private const MASKED_PREFIXES = ['/api/share/', '/api/scan/'];
+
+    private const MAX_USER_AGENT_LENGTH = 255;
 
     public function __construct(private EventBusInterface $eventBus)
     {
@@ -25,15 +37,16 @@ final readonly class ActivityLogKernelSubscriber
             return;
         }
 
-        $request = $event->getRequest();
-        $path    = $request->getPathInfo();
+        $request    = $event->getRequest();
+        $path       = $request->getPathInfo();
+        $statusCode = $event->getResponse()->getStatusCode();
 
         if (!str_starts_with($path, '/api/')) {
             return;
         }
 
         foreach (self::EXCLUDED_PREFIXES as $prefix) {
-            if (str_starts_with($path, $prefix)) {
+            if (str_starts_with($path, $prefix) && $statusCode < 400) {
                 return;
             }
         }
@@ -41,12 +54,41 @@ final readonly class ActivityLogKernelSubscriber
         $startTime  = $request->server->get('REQUEST_TIME_FLOAT') ?? microtime(true);
         $durationMs = (int) ((microtime(true) - (float) $startTime) * 1000);
 
+        $userAgent = $request->headers->get('User-Agent');
+
         $this->eventBus->publish(new UserActionEvent(
             method: $request->getMethod(),
-            path: $path,
-            statusCode: $event->getResponse()->getStatusCode(),
+            path: $this->maskSensitivePath($path),
+            statusCode: $statusCode,
             routeName: (string) ($request->attributes->get('_route') ?? ''),
             durationMs: $durationMs,
+            clientIp: $request->getClientIp(),
+            userAgent: $userAgent !== null ? mb_substr($userAgent, 0, self::MAX_USER_AGENT_LENGTH) : null,
         ));
+    }
+
+    /**
+     * Masks token-looking segments in share/scan paths so secrets never land
+     * in the journal metadata (/api/share/{token} → /api/share/***).
+     */
+    private function maskSensitivePath(string $path): string
+    {
+        foreach (self::MASKED_PREFIXES as $prefix) {
+            if (!str_starts_with($path, $prefix)) {
+                continue;
+            }
+
+            $segments = explode('/', substr($path, strlen($prefix)));
+            $maskedSegments = array_map(
+                static fn (string $segment): string => preg_match('/^[A-Za-z0-9._~-]{16,}$/', $segment) === 1
+                    ? '***'
+                    : $segment,
+                $segments,
+            );
+
+            return $prefix . implode('/', $maskedSegments);
+        }
+
+        return $path;
     }
 }

--- a/back/src/Notification/Infrastructure/Http/ActivityLogUserActionListener.php
+++ b/back/src/Notification/Infrastructure/Http/ActivityLogUserActionListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notification\Infrastructure\Http;
 
 use App\Notification\Domain\ActivityLog;
+use App\Notification\Domain\ActivityLogOwnerResolverInterface;
 use App\Notification\Domain\ActivityLogRepositoryInterface;
 use App\Notification\Domain\EventTypeEnum;
 use App\Shared\Event\UserActionEvent;
@@ -14,25 +15,38 @@ use Symfony\Component\Uid\Uuid;
 #[AsEventListener]
 final readonly class ActivityLogUserActionListener
 {
-    public function __construct(private ActivityLogRepositoryInterface $activityLogRepository)
-    {
+    public function __construct(
+        private ActivityLogRepositoryInterface $activityLogRepository,
+        private ActivityLogOwnerResolverInterface $ownerResolver,
+    ) {
     }
 
     public function __invoke(UserActionEvent $event): void
     {
+        $isHttpError = $event->statusCode >= 400;
+
         $log = new ActivityLog(
             id: Uuid::v4()->toRfc4122(),
-            eventType: EventTypeEnum::UserAction,
+            eventType: $isHttpError ? EventTypeEnum::HttpError : EventTypeEnum::UserAction,
             sourceName: 'http',
+            owner: $this->ownerResolver->currentOwner(),
             metadata: [
                 'method'      => $event->method,
                 'path'        => $event->path,
                 'status_code' => $event->statusCode,
                 'route'       => $event->routeName,
                 'duration_ms' => $event->durationMs,
+                'ip'          => $event->clientIp,
+                'user_agent'  => $event->userAgent,
             ],
         );
-        $log->markSuccess();
+
+        if ($isHttpError) {
+            $log->markError(sprintf('HTTP %d %s %s', $event->statusCode, $event->method, $event->path));
+        } else {
+            $log->markSuccess();
+        }
+
         $this->activityLogRepository->save($log);
     }
 }

--- a/back/src/Notification/Infrastructure/Http/ArticleController.php
+++ b/back/src/Notification/Infrastructure/Http/ArticleController.php
@@ -11,6 +11,7 @@ use App\Shared\Application\Bus\QueryBusInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/api/articles')]
 final readonly class ArticleController
@@ -42,16 +43,24 @@ final readonly class ArticleController
     }
 
     #[Route('/activity-logs', methods: ['GET'])]
+    #[IsGranted('ROLE_ADMIN_UNLOCKED')]
     public function activityLogs(Request $request): JsonResponse
     {
-        $page              = max(1, (int) $request->query->get('page', 1));
-        $limit             = min(100, max(1, (int) $request->query->get('limit', 50)));
-        $eventType         = $request->query->get('eventType') ?: null;
-        $status            = $request->query->get('status') ?: null;
-        $collectionEntryId = $request->query->get('collectionEntryId') ?: null;
+        $page  = max(1, (int) $request->query->get('page', 1));
+        $limit = min(100, max(1, (int) $request->query->get('limit', 50)));
 
         return new JsonResponse(
-            $this->queryBus->ask(new GetActivityLogsQuery($page, $limit, $eventType, $status, $collectionEntryId)),
+            $this->queryBus->ask(new GetActivityLogsQuery(
+                eventType: $request->query->get('eventType') ?: null,
+                status: $request->query->get('status') ?: null,
+                collectionEntryId: $request->query->get('collectionEntryId') ?: null,
+                ownerId: $request->query->get('ownerId') ?: null,
+                from: $request->query->get('from') ?: null,
+                to: $request->query->get('to') ?: null,
+                search: $request->query->get('search') ?: null,
+                page: $page,
+                limit: $limit,
+            )),
         );
     }
 }

--- a/back/src/Notification/Infrastructure/Messenger/WorkerFailureSubscriber.php
+++ b/back/src/Notification/Infrastructure/Messenger/WorkerFailureSubscriber.php
@@ -60,8 +60,10 @@ final readonly class WorkerFailureSubscriber
         $recentErrors = $this->activityLogRepository->countRecentErrors(self::WINDOW_MINUTES);
 
         if ($recentErrors >= self::ERROR_THRESHOLD) {
+            $alertTitle = sprintf('%d erreurs worker en %d min', $recentErrors, self::WINDOW_MINUTES);
+
             $this->discord->sendAlert(
-                title: sprintf('%d erreurs worker en %d min', $recentErrors, self::WINDOW_MINUTES),
+                title: $alertTitle,
                 description: sprintf(
                     "**Message:** `%s`\n**Erreur:** %s",
                     $messageName,
@@ -69,6 +71,19 @@ final readonly class WorkerFailureSubscriber
                 ),
                 critical: true,
             );
+
+            $discordLog = new ActivityLog(
+                id: Uuid::v4()->toRfc4122(),
+                eventType: EventTypeEnum::DiscordSent,
+                sourceName: 'discord',
+                metadata: [
+                    'title'         => $alertTitle,
+                    'message_class' => $messageName,
+                    'recent_errors' => $recentErrors,
+                ],
+            );
+            $discordLog->markSuccess();
+            $this->activityLogRepository->save($discordLog);
         }
     }
 

--- a/back/src/Shared/Event/UserActionEvent.php
+++ b/back/src/Shared/Event/UserActionEvent.php
@@ -12,6 +12,8 @@ final readonly class UserActionEvent
         public int $statusCode,
         public string $routeName,
         public int $durationMs,
+        public ?string $clientIp = null,
+        public ?string $userAgent = null,
     ) {
     }
 }

--- a/back/src/Shared/Infrastructure/Doctrine/Query/JsonGetTextFunction.php
+++ b/back/src/Shared/Infrastructure/Doctrine/Query/JsonGetTextFunction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Query;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
+use RuntimeException;
+
+/**
+ * JSON_GET_TEXT(document, key) → PostgreSQL "document ->> key".
+ *
+ * Extracts a top-level JSON field as text so DQL queries can filter on JSON
+ * columns (e.g. activity_logs.metadata ->> 'path').
+ */
+final class JsonGetTextFunction extends FunctionNode
+{
+    private ?Node $jsonDocument = null;
+    private ?Node $jsonKey = null;
+
+    public function parse(Parser $parser): void
+    {
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
+        $this->jsonDocument = $parser->StringPrimary();
+        $parser->match(TokenType::T_COMMA);
+        $this->jsonKey = $parser->StringPrimary();
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker): string
+    {
+        if ($this->jsonDocument === null || $this->jsonKey === null) {
+            throw new RuntimeException('JSON_GET_TEXT was not parsed before SQL generation.');
+        }
+
+        return sprintf(
+            '(%s ->> %s)',
+            $this->jsonDocument->dispatch($sqlWalker),
+            $this->jsonKey->dispatch($sqlWalker),
+        );
+    }
+}

--- a/back/tests/Fixtures/ChasseAuxLivres/prix-berserk.html
+++ b/back/tests/Fixtures/ChasseAuxLivres/prix-berserk.html
@@ -16,6 +16,18 @@
         <td><a href="/redirection/amazon/9782723425483">Voir l'offre</a></td>
       </tr>
       <tr class="offer-row">
+        <td><img src="/img/sellers/fnac.png" alt="Fnac.com"></td>
+        <td>Neuf</td>
+        <td class="price">7,90 €</td>
+        <td><a href="/redirection/fnac/9782723425483">Voir l'offre</a></td>
+      </tr>
+      <tr class="offer-row">
+        <td><img src="/img/sellers/ebay.png" alt="eBay France"></td>
+        <td>Occasion - Bon état</td>
+        <td class="price">5,40 €</td>
+        <td><a href="/redirection/ebay/9782723425483">Voir l'offre</a></td>
+      </tr>
+      <tr class="offer-row">
         <td><img src="/img/sellers/rakuten.png" alt="Rakuten"></td>
         <td>Neuf</td>
         <td class="price">6,50 €</td>

--- a/back/tests/Fixtures/ChasseAuxLivres/prix-blocks.html
+++ b/back/tests/Fixtures/ChasseAuxLivres/prix-blocks.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Berserk Tome 1 - Comparateur de prix</title></head>
+<body>
+<main>
+  <h1>Berserk Tome 1 — ISBN 9782723425483</h1>
+  <!-- Non-table layout: offer blocks, merchant carried by data attributes on descendants. -->
+  <ul class="results">
+    <li class="offer-item">
+      <span class="seller" data-merchant="Amazon"></span>
+      <span class="amount">7,20 €</span>
+      <a class="buy" href="/redirection/amazon/9782723425483">Acheter</a>
+    </li>
+    <li class="offer-item">
+      <span class="seller" data-seller="Fnac"></span>
+      <span class="amount">7,90 €</span>
+      <a class="buy" href="/redirection/fnac/9782723425483">Acheter</a>
+    </li>
+    <li class="offer-item">
+      <span class="seller" data-vendor="momox"></span>
+      <span class="amount">4,99 €</span>
+      <a class="buy" href="//momox.example/article/9782723425483">Acheter</a>
+    </li>
+  </ul>
+</main>
+</body>
+</html>

--- a/back/tests/Fixtures/ChasseAuxLivres/prix-fallback-texte.html
+++ b/back/tests/Fixtures/ChasseAuxLivres/prix-fallback-texte.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head><meta charset="utf-8"><title>Berserk Tome 1 - Comparateur de prix</title></head>
+<body>
+<main>
+  <h1>Berserk Tome 1 — ISBN 9782723425483</h1>
+  <!-- Unexpected layout: no table, no offer class, no data attribute, no per-offer link. -->
+  <section>
+    <p>Meilleure offre Amazon : neuf à partir de 7,20 € livraison incluse.</p>
+    <p>Chez Fnac le tome est proposé neuf au prix de 7,90 € (retrait magasin).</p>
+    <p>Sur eBay, une annonce en bon état est disponible pour 5,40 € hors livraison.</p>
+  </section>
+</main>
+</body>
+</html>

--- a/back/tests/Fixtures/ChasseAuxLivres/prix-jsonld.html
+++ b/back/tests/Fixtures/ChasseAuxLivres/prix-jsonld.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Berserk Tome 1 - Comparateur de prix</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Product",
+      "name": "Berserk Tome 1",
+      "gtin13": "9782723425483",
+      "offers": [
+        {
+          "@type": "Offer",
+          "price": "7,20",
+          "priceCurrency": "EUR",
+          "url": "/redirection/amazon/9782723425483",
+          "seller": { "@type": "Organization", "name": "Amazon" }
+        },
+        {
+          "@type": "Offer",
+          "price": 6.99,
+          "priceCurrency": "EUR",
+          "url": "https://www.fnac.com/livre/9782723425483",
+          "seller": { "@type": "Organization", "name": "Fnac" }
+        },
+        {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "EUR",
+          "seller": { "@type": "Organization", "name": "Broken" }
+        },
+        {
+          "@type": "Offer",
+          "price": "5,10",
+          "priceCurrency": "EUR",
+          "url": "//ebay.example/itm/42"
+        }
+      ]
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<main>
+  <h1>Berserk Tome 1 — ISBN 9782723425483</h1>
+  <div id="app">Chargement des offres…</div>
+</main>
+</body>
+</html>

--- a/back/tests/Functional/Manga/GetVolumePricesTest.php
+++ b/back/tests/Functional/Manga/GetVolumePricesTest.php
@@ -82,6 +82,21 @@ final class GetVolumePricesTest extends AbstractApiTestCase
 
         $this->assertFalse($data['hasIsbn']);
         $this->assertSame([], $data['offers']);
+        $this->assertRetailersAllNotFound($data);
+    }
+
+    /** @param array<string, mixed> $data */
+    private function assertRetailersAllNotFound(array $data): void
+    {
+        $this->assertArrayHasKey('retailers', $data);
+        $this->assertCount(3, $data['retailers']);
+        $this->assertSame(['amazon', 'fnac', 'ebay'], array_column($data['retailers'], 'retailer'));
+        $this->assertSame(['Amazon', 'Fnac', 'eBay'], array_column($data['retailers'], 'label'));
+
+        foreach ($data['retailers'] as $retailerBlock) {
+            $this->assertSame('not_found', $retailerBlock['status']);
+            $this->assertNull($retailerBlock['bestOffer']);
+        }
     }
 
     public function testVolumePricesReturnsOffersWhenVolumeHasIsbn(): void
@@ -104,6 +119,9 @@ final class GetVolumePricesTest extends AbstractApiTestCase
         $this->assertArrayHasKey('marketplace', $data);
         // NullPriceProvider returns empty offers — just check shape is correct
         $this->assertIsArray($data['offers']);
+
+        // With no offer at all, the three target shops honestly report not_found
+        $this->assertRetailersAllNotFound($data);
     }
 
     public function testVolumePricesRespectsMarketplaceQueryParam(): void

--- a/back/tests/Functional/Manga/MangaControllerTest.php
+++ b/back/tests/Functional/Manga/MangaControllerTest.php
@@ -185,6 +185,53 @@ final class MangaControllerTest extends AbstractApiTestCase
         $this->assertSame('9782811645632', $volume['isbn']);
     }
 
+    public function testUpdateVolumeWithIsbnAlone(): void
+    {
+        $mangaId = $this->importManga();
+
+        $volData = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga/' . $mangaId . '/volumes',
+            ['number' => 1],
+        ));
+        $volumeId = $volData['id'];
+
+        // The ISBN is the only field of the PATCH — the auto-save flow of the front
+        $response = $this->jsonRequest(
+            'PATCH',
+            '/api/manga/' . $mangaId . '/volumes/' . $volumeId,
+            ['isbn' => '978-2-8116-4563-2'],
+        );
+        $this->assertSame(204, $response->getStatusCode());
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
+        $volume = $detail['volumes'][0];
+        $this->assertSame('9782811645632', $volume['isbn']);
+    }
+
+    public function testUpdateVolumeConvertsIsbn10ToIsbn13(): void
+    {
+        $mangaId = $this->importManga();
+
+        $volData = $this->assertJsonStatus(201, $this->jsonRequest(
+            'POST',
+            '/api/manga/' . $mangaId . '/volumes',
+            ['number' => 1],
+        ));
+        $volumeId = $volData['id'];
+
+        // 2723425487 is a checksum-valid ISBN-10 — stored as its ISBN-13 form
+        $response = $this->jsonRequest(
+            'PATCH',
+            '/api/manga/' . $mangaId . '/volumes/' . $volumeId,
+            ['isbn' => '2723425487'],
+        );
+        $this->assertSame(204, $response->getStatusCode());
+
+        $detail = $this->assertJsonStatus(200, $this->jsonRequest('GET', '/api/manga/' . $mangaId));
+        $this->assertSame('9782723425483', $detail['volumes'][0]['isbn']);
+    }
+
     public function testUpdateVolumeRejectsInvalidIsbn(): void
     {
         $mangaId = $this->importManga();

--- a/back/tests/Functional/Notification/ActivityLogControllerTest.php
+++ b/back/tests/Functional/Notification/ActivityLogControllerTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Notification;
+
+use App\Notification\Domain\ActivityLog;
+use App\Notification\Domain\EventTypeEnum;
+use App\Tests\Functional\AbstractApiTestCase;
+use App\Tests\Functional\Fixtures\UserFixtureFactory;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+final class ActivityLogControllerTest extends AbstractApiTestCase
+{
+    // ── Authorization ────────────────────────────────────────────────────────
+
+    public function testActivityLogsRequiresAuth(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/articles/activity-logs', auth: false);
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function testActivityLogsForbiddenForPlainUser(): void
+    {
+        UserFixtureFactory::createActiveUser(static::getContainer(), email: 'plain@test.local');
+        $userToken = $this->tokenForUser('plain@test.local');
+
+        $response = $this->requestWithToken('GET', '/api/articles/activity-logs', $userToken);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testActivityLogsForbiddenForAdminWithoutGate(): void
+    {
+        // $this->token is ROLE_ADMIN but NOT ROLE_ADMIN_UNLOCKED
+        $response = $this->jsonRequest('GET', '/api/articles/activity-logs');
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testActivityLogsReturnsPagedResultForAdminUnlocked(): void
+    {
+        $data = $this->fetchActivityLogs();
+
+        $this->assertArrayHasKey('items', $data);
+        $this->assertArrayHasKey('total', $data);
+        $this->assertArrayHasKey('page', $data);
+        $this->assertArrayHasKey('limit', $data);
+        $this->assertIsArray($data['items']);
+    }
+
+    public function testActivityLogsWithCustomPagination(): void
+    {
+        $data = $this->fetchActivityLogs('page=1&limit=10');
+
+        $this->assertSame(1, $data['page']);
+        $this->assertSame(10, $data['limit']);
+    }
+
+    // ── Owner exposure & owner filter ────────────────────────────────────────
+
+    public function testActivityLogItemsExposeOwner(): void
+    {
+        // The setUp admin performs an API call → owner must be attributed.
+        $this->jsonRequest('GET', '/api/collection');
+
+        $items = $this->itemsFor('eventType=user_action&search=/api/collection');
+
+        $this->assertNotEmpty($items);
+        $ownerEmails = array_map(static fn (array $item) => $item['owner']['email'] ?? null, $items);
+        $this->assertContains('admin@test.local', $ownerEmails);
+    }
+
+    public function testActivityLogsFilterByOwnerId(): void
+    {
+        $reader = UserFixtureFactory::createActiveUser(static::getContainer(), email: 'owner-filter@test.local');
+        $readerToken = $this->tokenForUser('owner-filter@test.local');
+
+        // Each account performs one API call → one user_action log per owner.
+        $this->jsonRequest('GET', '/api/collection');
+        $this->requestWithToken('GET', '/api/collection', $readerToken);
+
+        $items = $this->itemsFor('eventType=user_action&ownerId=' . $reader->id);
+
+        $this->assertNotEmpty($items);
+        foreach ($items as $item) {
+            $this->assertSame($reader->id, $item['owner']['id']);
+        }
+    }
+
+    // ── from / to / search filters ───────────────────────────────────────────
+
+    public function testActivityLogsFilterByFromAndTo(): void
+    {
+        $this->persistLog(sourceName: 'old-window-source', startedAt: new DateTimeImmutable('-10 days'));
+        $this->persistLog(sourceName: 'recent-window-source', startedAt: new DateTimeImmutable('-1 hour'));
+
+        $fromYesterday = urlencode((new DateTimeImmutable('-1 day'))->format(DateTimeInterface::ATOM));
+        $recentOnly    = $this->itemsFor('search=window-source&from=' . $fromYesterday);
+        $this->assertSame(['recent-window-source'], array_column($recentOnly, 'sourceName'));
+
+        $toTwoDaysAgo = urlencode((new DateTimeImmutable('-2 days'))->format(DateTimeInterface::ATOM));
+        $oldOnly      = $this->itemsFor('search=window-source&to=' . $toTwoDaysAgo);
+        $this->assertSame(['old-window-source'], array_column($oldOnly, 'sourceName'));
+    }
+
+    public function testActivityLogsSearchMatchesSourceNameErrorMessageAndPath(): void
+    {
+        $this->persistLog(sourceName: 'zzz-unique-source');
+        $this->persistLog(sourceName: 'other', errorMessage: 'yyy-unique-error happened');
+        $this->persistLog(sourceName: 'http', metadata: ['path' => '/api/xxx-unique-path']);
+
+        $this->assertSame(
+            ['zzz-unique-source'],
+            array_column($this->itemsFor('search=ZZZ-UNIQUE'), 'sourceName'),
+        );
+
+        $errorItems = $this->itemsFor('search=yyy-unique');
+        $this->assertCount(1, $errorItems);
+        $this->assertSame('yyy-unique-error happened', $errorItems[0]['errorMessage']);
+
+        $pathItems = $this->itemsFor('search=xxx-unique');
+        $this->assertCount(1, $pathItems);
+        $this->assertSame('/api/xxx-unique-path', $pathItems[0]['metadata']['path']);
+    }
+
+    // ── Auth coverage ────────────────────────────────────────────────────────
+
+    public function testSuccessfulLoginCreatesAuthActionLogWithoutSensitiveData(): void
+    {
+        // setUp already logged in as admin@test.local.
+        $items = $this->itemsFor('eventType=auth_action&search=login');
+
+        $loginItems = array_values(array_filter(
+            $items,
+            static fn (array $item) => $item['sourceName'] === 'login',
+        ));
+
+        $this->assertNotEmpty($loginItems);
+        $loginLog = $loginItems[0];
+        $this->assertSame('success', $loginLog['status']);
+        $this->assertSame('admin@test.local', $loginLog['metadata']['email'] ?? null);
+        $this->assertSame('admin@test.local', $loginLog['owner']['email'] ?? null);
+
+        $metadataJson = strtolower((string) json_encode($loginLog['metadata']));
+        $this->assertStringNotContainsString('password', $metadataJson);
+        $this->assertStringNotContainsString('token', $metadataJson);
+    }
+
+    public function testFailedLoginCreatesHttpErrorLog(): void
+    {
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/auth/login',
+            ['email' => 'admin@test.local', 'password' => 'wrong-password'],
+            auth: false,
+        );
+        $this->assertSame(401, $response->getStatusCode());
+
+        $items = $this->itemsFor('eventType=http_error&search=/api/auth/login');
+
+        $this->assertNotEmpty($items);
+        $failedLog = $items[0];
+        $this->assertSame('error', $failedLog['status']);
+        $this->assertSame(401, $failedLog['metadata']['status_code']);
+        $this->assertSame('/api/auth/login', $failedLog['metadata']['path']);
+        $this->assertStringContainsString('HTTP 401', (string) $failedLog['errorMessage']);
+    }
+
+    public function testRegistrationCreatesAuthActionLogWithoutVerificationToken(): void
+    {
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/auth/register',
+            ['email' => 'journal-reg@test.local', 'password' => 'Password1!', 'displayName' => 'Journal Reg'],
+            auth: false,
+        );
+        $this->assertSame(201, $response->getStatusCode());
+
+        $items = $this->itemsFor('eventType=auth_action&search=register');
+
+        $registerItems = array_values(array_filter(
+            $items,
+            static fn (array $item) => $item['sourceName'] === 'register',
+        ));
+
+        $this->assertNotEmpty($registerItems);
+        $registerLog = $registerItems[0];
+        $this->assertSame('success', $registerLog['status']);
+        $this->assertSame('journal-reg@test.local', $registerLog['metadata']['email'] ?? null);
+        $this->assertSame('journal-reg@test.local', $registerLog['owner']['email'] ?? null);
+
+        $metadataJson = strtolower((string) json_encode($registerLog['metadata']));
+        $this->assertStringNotContainsString('token', $metadataJson);
+        $this->assertStringNotContainsString('password', $metadataJson);
+    }
+
+    public function testGateTokenNeverAppearsInActivityLogs(): void
+    {
+        $unlockedToken = $this->getAdminUnlockedToken();
+
+        $response = $this->requestWithToken(
+            'GET',
+            '/api/articles/activity-logs?eventType=auth_action',
+            $unlockedToken,
+        );
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = (string) $response->getContent();
+        $this->assertStringNotContainsString($unlockedToken, $body);
+
+        /** @var array{items: list<array<string, mixed>>} $data */
+        $data      = (array) json_decode($body, true);
+        $gateItems = array_values(array_filter(
+            $data['items'],
+            static fn (array $item) => $item['sourceName'] === 'gate',
+        ));
+
+        $this->assertNotEmpty($gateItems);
+        $this->assertSame('success', $gateItems[0]['status']);
+        $metadataJson = strtolower((string) json_encode($gateItems[0]['metadata']));
+        $this->assertStringNotContainsString('token', $metadataJson);
+    }
+
+    // ── HTTP error pipeline & path masking ───────────────────────────────────
+
+    public function testNotFoundRequestCreatesHttpErrorLog(): void
+    {
+        $response = $this->jsonRequest('GET', '/api/does-not-exist');
+        $this->assertSame(404, $response->getStatusCode());
+
+        $items = $this->itemsFor('eventType=http_error&search=/api/does-not-exist');
+
+        $this->assertNotEmpty($items);
+        $notFoundLog = $items[0];
+        $this->assertSame('error', $notFoundLog['status']);
+        $this->assertSame('HTTP 404 GET /api/does-not-exist', $notFoundLog['errorMessage']);
+        $this->assertSame(404, $notFoundLog['metadata']['status_code']);
+        $this->assertArrayHasKey('ip', $notFoundLog['metadata']);
+        $this->assertArrayHasKey('user_agent', $notFoundLog['metadata']);
+    }
+
+    public function testSharePathTokenIsMaskedInActivityLog(): void
+    {
+        $shareToken = str_repeat('a1b2', 8); // 32 hex chars, matches the share route
+        $response   = $this->jsonRequest('GET', '/api/share/' . $shareToken, auth: false);
+        $this->assertSame(404, $response->getStatusCode());
+
+        $items = $this->itemsFor('eventType=http_error&search=/api/share/');
+
+        $this->assertNotEmpty($items);
+        $maskedLog = $items[0];
+        $this->assertSame('/api/share/***', $maskedLog['metadata']['path']);
+        $this->assertStringNotContainsString($shareToken, (string) json_encode($maskedLog));
+    }
+
+    public function testScanPathTokenIsMaskedInActivityLog(): void
+    {
+        $scanToken = 'scan-secret-token-abcdef123456';
+        $response  = $this->jsonRequest('GET', '/api/scan/' . $scanToken);
+        $this->assertSame(404, $response->getStatusCode());
+
+        $items = $this->itemsFor('eventType=http_error&search=/api/scan/');
+
+        $this->assertNotEmpty($items);
+        $maskedLog = $items[0];
+        $this->assertSame('/api/scan/***', $maskedLog['metadata']['path']);
+        $this->assertStringNotContainsString($scanToken, (string) json_encode($maskedLog));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private function getAdminUnlockedToken(): string
+    {
+        $gateResponse = $this->jsonRequest('POST', '/api/auth/gate', ['password' => 'ziggy123']);
+        /** @var array{token?: string} $data */
+        $data = json_decode((string) $gateResponse->getContent(), true);
+
+        return $data['token'] ?? '';
+    }
+
+    private function requestWithToken(string $method, string $url, string $token, string $body = ''): Response
+    {
+        $this->client->request($method, $url, [], [], [
+            'CONTENT_TYPE'       => 'application/json',
+            'HTTP_ACCEPT'        => 'application/json',
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $token,
+        ], $body);
+
+        return $this->client->getResponse();
+    }
+
+    /** Fetches the journal as admin-unlocked and returns the decoded payload. */
+    private function fetchActivityLogs(string $queryString = ''): array
+    {
+        $url = '/api/articles/activity-logs' . ($queryString !== '' ? '?' . $queryString : '');
+
+        $response = $this->requestWithToken('GET', $url, $this->getAdminUnlockedToken());
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        return (array) json_decode((string) $response->getContent(), true);
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function itemsFor(string $queryString): array
+    {
+        /** @var list<array<string, mixed>> $items */
+        $items = $this->fetchActivityLogs($queryString)['items'] ?? [];
+
+        return $items;
+    }
+
+    private function persistLog(
+        string $sourceName,
+        ?DateTimeImmutable $startedAt = null,
+        ?string $errorMessage = null,
+        ?array $metadata = null,
+    ): void {
+        $container     = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        $log = new ActivityLog(
+            id: Uuid::v4()->toRfc4122(),
+            eventType: EventTypeEnum::UserAction,
+            sourceName: $sourceName,
+            metadata: $metadata,
+        );
+        if ($errorMessage !== null) {
+            $log->markError($errorMessage);
+        } else {
+            $log->markSuccess();
+        }
+        if ($startedAt !== null) {
+            $log->startedAt = $startedAt;
+        }
+
+        $entityManager->persist($log);
+        $entityManager->flush();
+    }
+}

--- a/back/tests/Functional/Notification/ArticleControllerTest.php
+++ b/back/tests/Functional/Notification/ArticleControllerTest.php
@@ -161,42 +161,8 @@ final class ArticleControllerTest extends AbstractApiTestCase
         $this->assertSame([], $otherData);
     }
 
-    // ── GET /api/articles/activity-logs ──────────────────────────────────────
-
-    public function testActivityLogsRequiresAuth(): void
-    {
-        $response = $this->jsonRequest('GET', '/api/articles/activity-logs', auth: false);
-        $this->assertSame(401, $response->getStatusCode());
-    }
-
-    public function testActivityLogsReturnsPagedResult(): void
-    {
-        $response = $this->jsonRequest('GET', '/api/articles/activity-logs');
-        $data     = $this->assertJsonStatus(200, $response);
-
-        $this->assertArrayHasKey('items', $data);
-        $this->assertArrayHasKey('total', $data);
-        $this->assertArrayHasKey('page', $data);
-        $this->assertArrayHasKey('limit', $data);
-        $this->assertArrayHasKey('totalPages', $data);
-    }
-
-    public function testActivityLogsWithFilters(): void
-    {
-        $response = $this->jsonRequest('GET', '/api/articles/activity-logs?eventType=auth_action&status=success');
-        $data     = $this->assertJsonStatus(200, $response);
-
-        $this->assertIsArray($data['items']);
-    }
-
-    public function testActivityLogsWithCustomPagination(): void
-    {
-        $response = $this->jsonRequest('GET', '/api/articles/activity-logs?page=1&limit=10');
-        $data     = $this->assertJsonStatus(200, $response);
-
-        $this->assertSame(1, $data['page']);
-        $this->assertSame(10, $data['limit']);
-    }
+    // Activity-log endpoint coverage lives in ActivityLogControllerTest
+    // (the endpoint is now restricted to ROLE_ADMIN_UNLOCKED).
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/back/tests/Unit/Manga/Application/GetVolumePrices/GetVolumePricesHandlerTest.php
+++ b/back/tests/Unit/Manga/Application/GetVolumePrices/GetVolumePricesHandlerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Application\GetVolumePrices;
+
+use App\Manga\Application\GetVolumePrices\GetVolumePricesHandler;
+use App\Manga\Application\GetVolumePrices\GetVolumePricesQuery;
+use App\Manga\Domain\Isbn;
+use App\Manga\Domain\Manga;
+use App\Manga\Domain\MangaRepositoryInterface;
+use App\Manga\Domain\PriceKindEnum;
+use App\Manga\Domain\PriceOfferCacheInterface;
+use App\Manga\Domain\PriceOfferDto;
+use App\Manga\Domain\Service\PriceOfferSorter;
+use App\Manga\Domain\Service\RetailerOfferResolver;
+use App\Manga\Domain\Volume;
+use App\Manga\Domain\VolumePriceProviderInterface;
+use App\Shared\Domain\Exception\NotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class GetVolumePricesHandlerTest extends TestCase
+{
+    private const string MANGA_ID  = 'manga-1';
+    private const string VOLUME_ID = 'volume-1';
+    private const string ISBN      = '9782723425483';
+
+    private MangaRepositoryInterface&MockObject $repository;
+    private VolumePriceProviderInterface&MockObject $priceProvider;
+    private PriceOfferCacheInterface&MockObject $cache;
+    private GetVolumePricesHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->repository    = $this->createMock(MangaRepositoryInterface::class);
+        $this->priceProvider = $this->createMock(VolumePriceProviderInterface::class);
+        $this->cache         = $this->createMock(PriceOfferCacheInterface::class);
+
+        $this->handler = new GetVolumePricesHandler(
+            $this->repository,
+            $this->priceProvider,
+            $this->cache,
+            new PriceOfferSorter(),
+            new RetailerOfferResolver(),
+        );
+    }
+
+    private function makeManga(?Isbn $isbn): Manga
+    {
+        $manga  = new Manga(id: self::MANGA_ID, title: 'Berserk', edition: null, language: 'fr');
+        $volume = new Volume(id: self::VOLUME_ID, manga: $manga, number: 1, isbn: $isbn);
+        $manga->addVolume($volume);
+
+        return $manga;
+    }
+
+    private function makeOffer(string $merchant, float $amount): PriceOfferDto
+    {
+        return new PriceOfferDto(
+            kind:         PriceKindEnum::MerchantLive,
+            merchant:     $merchant,
+            merchantLogo: 'test',
+            amount:       $amount,
+            currency:     'EUR',
+            url:          null,
+            imageUrl:     null,
+            source:       'test',
+        );
+    }
+
+    public function testThrowsNotFoundForUnknownManga(): void
+    {
+        $this->repository->method('findById')->willReturn(null);
+
+        $this->expectException(NotFoundException::class);
+
+        ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID));
+    }
+
+    public function testThrowsNotFoundForUnknownVolume(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(null));
+
+        $this->expectException(NotFoundException::class);
+
+        ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, 'other-volume'));
+    }
+
+    public function testVolumeWithoutIsbnReturnsThreeNotFoundRetailers(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(null));
+
+        $result = ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID));
+
+        $this->assertFalse($result['hasIsbn']);
+        $this->assertSame([], $result['offers']);
+        $this->assertNull($result['marketplace']);
+
+        $this->assertCount(3, $result['retailers']);
+        $this->assertSame(['amazon', 'fnac', 'ebay'], array_column($result['retailers'], 'retailer'));
+        foreach ($result['retailers'] as $retailerBlock) {
+            $this->assertSame('not_found', $retailerBlock['status']);
+            $this->assertNull($retailerBlock['bestOffer']);
+        }
+    }
+
+    public function testFreshOffersFeedTheRetailerBlocks(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(Isbn::fromString(self::ISBN)));
+        $this->cache->method('get')->willReturn(null);
+        $this->priceProvider->method('findOffers')->willReturn([
+            $this->makeOffer('Amazon.fr', 7.20),
+            $this->makeOffer('eBay', 5.40),
+            $this->makeOffer('Rakuten', 6.50),
+        ]);
+
+        $result = ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID));
+
+        $this->assertTrue($result['hasIsbn']);
+        $this->assertSame('EBAY_FR', $result['marketplace']);
+        $this->assertCount(3, $result['offers']);
+
+        [$amazonBlock, $fnacBlock, $ebayBlock] = $result['retailers'];
+        $this->assertSame('found', $amazonBlock['status']);
+        $this->assertSame('Amazon.fr', $amazonBlock['bestOffer']['merchant']);
+        $this->assertSame('not_found', $fnacBlock['status']);
+        $this->assertNull($fnacBlock['bestOffer']);
+        $this->assertSame('found', $ebayBlock['status']);
+        $this->assertSame(5.40, $ebayBlock['bestOffer']['amount']);
+    }
+
+    public function testFreshOffersAreCached(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(Isbn::fromString(self::ISBN)));
+        $this->cache->method('get')->willReturn(null);
+        $this->priceProvider->method('findOffers')->willReturn([$this->makeOffer('Amazon', 7.20)]);
+
+        $this->cache->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(static fn (array $offers) => count($offers) === 1
+                    && $offers[0]['merchant'] === 'Amazon'),
+            );
+
+        ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID));
+    }
+
+    public function testCachedOffersAlsoFeedTheRetailerBlocksWithoutProviderCall(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(Isbn::fromString(self::ISBN)));
+        $this->cache->method('get')->willReturn([$this->makeOffer('Fnac', 7.90)->toArray()]);
+        $this->priceProvider->expects($this->never())->method('findOffers');
+
+        $result = ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID));
+
+        [$amazonBlock, $fnacBlock, $ebayBlock] = $result['retailers'];
+        $this->assertSame('not_found', $amazonBlock['status']);
+        $this->assertSame('found', $fnacBlock['status']);
+        $this->assertSame(7.90, $fnacBlock['bestOffer']['amount']);
+        $this->assertSame('not_found', $ebayBlock['status']);
+    }
+
+    public function testMarketplaceQueryParamIsRespected(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeManga(Isbn::fromString(self::ISBN)));
+        $this->cache->method('get')->willReturn(null);
+        $this->priceProvider->method('findOffers')->willReturn([]);
+
+        $result = ($this->handler)(new GetVolumePricesQuery(self::MANGA_ID, self::VOLUME_ID, 'EBAY_US'));
+
+        $this->assertSame('EBAY_US', $result['marketplace']);
+    }
+}

--- a/back/tests/Unit/Manga/Application/UpdateVolume/UpdateVolumeHandlerTest.php
+++ b/back/tests/Unit/Manga/Application/UpdateVolume/UpdateVolumeHandlerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Application\UpdateVolume;
+
+use App\Manga\Application\UpdateVolume\UpdateVolumeCommand;
+use App\Manga\Application\UpdateVolume\UpdateVolumeHandler;
+use App\Manga\Domain\Exception\InvalidIsbnException;
+use App\Manga\Domain\Isbn;
+use App\Manga\Domain\Manga;
+use App\Manga\Domain\MangaRepositoryInterface;
+use App\Manga\Domain\Volume;
+use App\Manga\Shared\Event\UpdateVolumeSucceededEvent;
+use App\Shared\Application\Bus\EventBusInterface;
+use App\Shared\Domain\Exception\NotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateVolumeHandlerTest extends TestCase
+{
+    private const string MANGA_ID  = 'manga-1';
+    private const string VOLUME_ID = 'volume-1';
+
+    private MangaRepositoryInterface&MockObject $repository;
+    private EventBusInterface&MockObject $eventBus;
+    private UpdateVolumeHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(MangaRepositoryInterface::class);
+        $this->eventBus   = $this->createMock(EventBusInterface::class);
+        $this->handler    = new UpdateVolumeHandler($this->repository, $this->eventBus);
+    }
+
+    private function makeMangaWithVolume(): Manga
+    {
+        $manga  = new Manga(id: self::MANGA_ID, title: 'Berserk', edition: null, language: 'fr');
+        $volume = new Volume(id: self::VOLUME_ID, manga: $manga, number: 1);
+        $manga->addVolume($volume);
+
+        return $manga;
+    }
+
+    private function firstVolume(Manga $manga): Volume
+    {
+        $volume = $manga->volumes->first();
+        $this->assertInstanceOf(Volume::class, $volume);
+
+        return $volume;
+    }
+
+    public function testThrowsNotFoundForUnknownManga(): void
+    {
+        $this->repository->method('findById')->willReturn(null);
+        $this->repository->expects($this->never())->method('save');
+
+        $this->expectException(NotFoundException::class);
+
+        ($this->handler)(new UpdateVolumeCommand(mangaId: self::MANGA_ID, volumeId: self::VOLUME_ID));
+    }
+
+    public function testThrowsNotFoundForUnknownVolume(): void
+    {
+        $this->repository->method('findById')->willReturn($this->makeMangaWithVolume());
+        $this->repository->expects($this->never())->method('save');
+
+        $this->expectException(NotFoundException::class);
+
+        ($this->handler)(new UpdateVolumeCommand(mangaId: self::MANGA_ID, volumeId: 'other-volume'));
+    }
+
+    public function testPersistsIsbnAloneNormalizedToIsbn13(): void
+    {
+        $manga = $this->makeMangaWithVolume();
+        $this->repository->method('findById')->willReturn($manga);
+        $this->repository->expects($this->once())->method('save')->with($manga);
+
+        ($this->handler)(new UpdateVolumeCommand(
+            mangaId:  self::MANGA_ID,
+            volumeId: self::VOLUME_ID,
+            isbn:     '978-2-7234-2548-3',
+        ));
+
+        $volume = $this->firstVolume($manga);
+        $this->assertInstanceOf(Isbn::class, $volume->isbn);
+        $this->assertSame('9782723425483', $volume->isbn->value);
+    }
+
+    public function testConvertsScannedIsbn10ToIsbn13(): void
+    {
+        $manga = $this->makeMangaWithVolume();
+        $this->repository->method('findById')->willReturn($manga);
+
+        // 2723425487 is a checksum-valid ISBN-10 (converts to 9782723425483)
+        ($this->handler)(new UpdateVolumeCommand(
+            mangaId:  self::MANGA_ID,
+            volumeId: self::VOLUME_ID,
+            isbn:     '2723425487',
+        ));
+
+        $volume = $this->firstVolume($manga);
+        $this->assertSame('9782723425483', $volume->isbn?->value);
+    }
+
+    public function testInvalidIsbnThrowsAndSavesNothing(): void
+    {
+        $manga = $this->makeMangaWithVolume();
+        $this->repository->method('findById')->willReturn($manga);
+        $this->repository->expects($this->never())->method('save');
+        $this->eventBus->expects($this->never())->method('publish');
+
+        $this->expectException(InvalidIsbnException::class);
+
+        ($this->handler)(new UpdateVolumeCommand(
+            mangaId:  self::MANGA_ID,
+            volumeId: self::VOLUME_ID,
+            isbn:     'not-an-isbn',
+        ));
+    }
+
+    public function testUpdatesOnlyTheProvidedFields(): void
+    {
+        $manga = $this->makeMangaWithVolume();
+        $this->repository->method('findById')->willReturn($manga);
+
+        ($this->handler)(new UpdateVolumeCommand(
+            mangaId:     self::MANGA_ID,
+            volumeId:    self::VOLUME_ID,
+            coverUrl:    'https://covers.example/berserk-1.jpg',
+            releaseDate: '2026-04-01',
+            price:       7.99,
+            spineUrl:    'https://covers.example/berserk-1-spine.jpg',
+        ));
+
+        $volume = $this->firstVolume($manga);
+        $this->assertSame('https://covers.example/berserk-1.jpg', $volume->coverUrl);
+        $this->assertSame('2026-04-01', $volume->releaseDate?->format('Y-m-d'));
+        $this->assertSame(7.99, $volume->price);
+        $this->assertSame('https://covers.example/berserk-1-spine.jpg', $volume->spineUrl);
+        $this->assertNull($volume->isbn);
+    }
+
+    public function testPublishesSucceededEventAfterSave(): void
+    {
+        $manga = $this->makeMangaWithVolume();
+        $this->repository->method('findById')->willReturn($manga);
+
+        $this->eventBus->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(
+                static fn (UpdateVolumeSucceededEvent $event) => $event->mangaId === self::MANGA_ID
+                    && $event->volumeId === self::VOLUME_ID,
+            ));
+
+        ($this->handler)(new UpdateVolumeCommand(
+            mangaId:  self::MANGA_ID,
+            volumeId: self::VOLUME_ID,
+            price:    5.0,
+        ));
+    }
+}

--- a/back/tests/Unit/Manga/Domain/EditionFormatEnumTest.php
+++ b/back/tests/Unit/Manga/Domain/EditionFormatEnumTest.php
@@ -80,6 +80,28 @@ final class EditionFormatEnumTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideArtbookLabels')]
+    public function testFromRawLabelReturnsArtbook(string $label): void
+    {
+        $this->assertSame(EditionFormatEnum::Artbook, EditionFormatEnum::fromRawLabel($label));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function provideArtbookLabels(): array
+    {
+        return [
+            'Artbook'       => ['Artbook'],
+            'art book'      => ['art book'],
+            'Artworks'      => ['Artworks'],
+            'Art of'        => ['The Art of Berserk'],
+            'Illustrations' => ['Berserk illustrations'],
+            'kanji artbook' => ['ベルセルク画集'],
+            'Guidebook'     => ['Guidebook'],
+            'Fanbook'       => ['Official fanbook'],
+            'Databook'      => ['Databook'],
+        ];
+    }
+
     public function testFromRawLabelReturnsUnknownForNull(): void
     {
         $this->assertSame(EditionFormatEnum::Unknown, EditionFormatEnum::fromRawLabel(null));

--- a/back/tests/Unit/Manga/Domain/IsbnTest.php
+++ b/back/tests/Unit/Manga/Domain/IsbnTest.php
@@ -71,6 +71,44 @@ final class IsbnTest extends TestCase
         $this->assertSame('978', $isbn->prefix());
     }
 
+    // --- EAN add-on codes (barcode scanners append them after the 13 digits) ---
+
+    public function testFromStringDropsEan5AddOn(): void
+    {
+        $isbn = Isbn::fromString(self::VALID_ISBN13 . '12345');
+
+        $this->assertSame(self::VALID_ISBN13, $isbn->value);
+    }
+
+    public function testFromStringDropsEan2AddOn(): void
+    {
+        $isbn = Isbn::fromString(self::VALID_ISBN13 . '99');
+
+        $this->assertSame(self::VALID_ISBN13, $isbn->value);
+    }
+
+    public function testFromStringDropsAddOnAfterStrippingSeparators(): void
+    {
+        $isbn = Isbn::fromString('978-2-1234-5678-0 12345');
+
+        $this->assertSame(self::VALID_ISBN13, $isbn->value);
+    }
+
+    public function testFromStringStillValidatesChecksumWhenAddOnIsDropped(): void
+    {
+        $this->expectException(InvalidIsbnException::class);
+        // 9782123456789 has a wrong check digit — the EAN-5 add-on must not mask it
+        Isbn::fromString('978212345678912345');
+    }
+
+    public function testTryFromDropsEan5AddOn(): void
+    {
+        $isbn = Isbn::tryFrom(self::VALID_ISBN13 . '12345');
+
+        $this->assertInstanceOf(Isbn::class, $isbn);
+        $this->assertSame(self::VALID_ISBN13, $isbn->value);
+    }
+
     // --- Invalid ISBN-13 ---
 
     public function testFromStringRejectsInvalidPrefix(): void

--- a/back/tests/Unit/Manga/Domain/RetailerEnumTest.php
+++ b/back/tests/Unit/Manga/Domain/RetailerEnumTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain;
+
+use App\Manga\Domain\RetailerEnum;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RetailerEnumTest extends TestCase
+{
+    public function testTargetsListsTheThreeShopsInOrder(): void
+    {
+        $this->assertSame(
+            [RetailerEnum::Amazon, RetailerEnum::Fnac, RetailerEnum::Ebay],
+            RetailerEnum::targets(),
+        );
+    }
+
+    /** @return iterable<string, array{string, RetailerEnum}> */
+    public static function merchantMappingProvider(): iterable
+    {
+        yield 'exact lowercase'          => ['amazon', RetailerEnum::Amazon];
+        yield 'capitalized'              => ['Amazon', RetailerEnum::Amazon];
+        yield 'domain suffix'            => ['Amazon.fr', RetailerEnum::Amazon];
+        yield 'marketplace suffix'       => ['Amazon Marketplace', RetailerEnum::Amazon];
+        yield 'uppercase with accent'    => ['AMAZÔN', RetailerEnum::Amazon];
+        yield 'fnac exact'               => ['Fnac', RetailerEnum::Fnac];
+        yield 'fnac dot com'             => ['Fnac.com', RetailerEnum::Fnac];
+        yield 'fnac with article'        => ['La Fnac', RetailerEnum::Fnac];
+        yield 'ebay camel case'          => ['eBay', RetailerEnum::Ebay];
+        yield 'ebay with country'        => ['eBay France', RetailerEnum::Ebay];
+        yield 'ebay uppercase'           => ['EBAY', RetailerEnum::Ebay];
+        yield 'surrounding whitespace'   => ['  amazon  ', RetailerEnum::Amazon];
+    }
+
+    #[DataProvider('merchantMappingProvider')]
+    public function testFromMerchantMapsKnownNames(string $merchant, RetailerEnum $expected): void
+    {
+        $this->assertSame($expected, RetailerEnum::fromMerchant($merchant));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function unknownMerchantProvider(): iterable
+    {
+        yield 'other merchant'      => ['Rakuten'];
+        yield 'second-hand shop'    => ['momox'];
+        yield 'publisher reference' => ['Google Play'];
+        yield 'contains not prefix' => ['Librairie Amazonie'];
+        yield 'empty'               => [''];
+        yield 'whitespace only'     => ['   '];
+    }
+
+    #[DataProvider('unknownMerchantProvider')]
+    public function testFromMerchantReturnsNullForUnknownNames(string $merchant): void
+    {
+        $this->assertNull(RetailerEnum::fromMerchant($merchant));
+    }
+
+    public function testLabels(): void
+    {
+        $this->assertSame('Amazon', RetailerEnum::Amazon->label());
+        $this->assertSame('Fnac', RetailerEnum::Fnac->label());
+        $this->assertSame('eBay', RetailerEnum::Ebay->label());
+    }
+}

--- a/back/tests/Unit/Manga/Domain/Service/EditionGrouperTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/EditionGrouperTest.php
@@ -168,4 +168,54 @@ final class EditionGrouperTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertSame('Glénat — Perfect Edition', $result[0]->editionLabel);
     }
+
+    public function testDistinctImprintsSharingDisplayNameStaySeparate(): void
+    {
+        // Tonkam's run and a Delcourt run both display as "Delcourt/Tonkam", but they
+        // are distinct editorial lines — the display merge must not group them.
+        $tonkam   = $this->makeDto('Tonkam', 'fr', EditionFormatEnum::Broche, isbnSample: '9782845803350');
+        $delcourt = $this->makeDto('Delcourt', 'fr', EditionFormatEnum::Broche, isbnSample: '9782756071121');
+
+        $result = $this->grouper->group([$tonkam, $delcourt]);
+
+        $this->assertCount(2, $result);
+        foreach ($result as $edition) {
+            $this->assertSame('Delcourt/Tonkam', $edition->publisher);
+        }
+    }
+
+    public function testConflictingIsbnRegistrationGroupsAreNotMerged(): void
+    {
+        // Same normalised publisher + language, but a 978-2 (French) ISBN and a 978-4
+        // (Japanese) ISBN cannot belong to the same edition line.
+        $french   = $this->makeDto('Glénat', 'fr', EditionFormatEnum::Broche, isbnSample: '9782344001233');
+        $japanese = $this->makeDto('Glénat', 'fr', EditionFormatEnum::Broche, isbnSample: '9784063842760');
+
+        $result = $this->grouper->group([$french, $japanese]);
+
+        $this->assertCount(2, $result);
+    }
+
+    public function testEnglishIsbnGroupsZeroAndOneAreMergedTogether(): void
+    {
+        // 978-0 and 978-1 are both the English-speaking registration area — a US line
+        // printing under both must stay one entry.
+        $groupZero = $this->makeDto('Dark Horse', 'en', EditionFormatEnum::Broche, isbnSample: '9780123456786');
+        $groupOne  = $this->makeDto('Dark Horse', 'en', EditionFormatEnum::Broche, isbnSample: '9781593070205');
+
+        $result = $this->grouper->group([$groupZero, $groupOne]);
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testDtosWithoutIsbnNeverForceASplit(): void
+    {
+        $withIsbn    = $this->makeDto('Glénat', 'fr', EditionFormatEnum::Broche, isbnSample: '9782344001233');
+        $withoutIsbn = $this->makeDto('Glénat', 'fr', EditionFormatEnum::Broche, isbnSample: null);
+
+        $result = $this->grouper->group([$withIsbn, $withoutIsbn]);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('9782344001233', $result[0]->isbnSample);
+    }
 }

--- a/back/tests/Unit/Manga/Domain/Service/EditionLineExtractorTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/EditionLineExtractorTest.php
@@ -67,7 +67,44 @@ final class EditionLineExtractorTest extends TestCase
         $this->assertSame('Édition pastel', $this->extractor->extract('Dragon Ball : édition pastel. 1'));
         $this->assertSame('Édition spéciale', $this->extractor->extract('Dragon Ball : édition spéciale'));
         $this->assertSame('Édition limitée', $this->extractor->extract('Naruto édition limitée, tome 3'));
-        $this->assertSame('Anniversary Edition', $this->extractor->extract('One Piece anniversary edition'));
+    }
+
+    public function testDetectsArtbooksAndCompanionBooks(): void
+    {
+        $this->assertSame('Artbook', $this->extractor->extract('Dragon Ball artbook'));
+        $this->assertSame('Artbook', $this->extractor->extract('Berserk illustrations'));
+        $this->assertSame('Artbook', $this->extractor->extract('The Artwork of Berserk'));
+        $this->assertSame('Artbook', $this->extractor->extract('The Art of Fullmetal Alchemist'));
+        $this->assertSame('Artbook', $this->extractor->extract('ベルセルク画集'));
+        $this->assertSame('Guidebook', $this->extractor->extract('Attack on Titan Guidebook'));
+        $this->assertSame('Guidebook', $this->extractor->extract('進撃の巨人 公式ガイドブック'));
+        $this->assertSame('Fanbook', $this->extractor->extract('One Piece official fan book'));
+        $this->assertSame('Databook', $this->extractor->extract('Naruto databook'));
+    }
+
+    public function testDetectsAnniversaryEditions(): void
+    {
+        $this->assertSame('Anniversaire', $this->extractor->extract('One Piece anniversary edition'));
+        $this->assertSame('Anniversaire', $this->extractor->extract('One Piece 20th anniversary'));
+        $this->assertSame('Anniversaire', $this->extractor->extract('Naruto : édition 20 ans'));
+        $this->assertSame('Anniversaire', $this->extractor->extract('Berserk édition anniversaire'));
+    }
+
+    public function testDetectsBlackEdition(): void
+    {
+        $this->assertSame('Black Edition', $this->extractor->extract('Naruto Black Edition, Vol. 1'));
+    }
+
+    public function testDetectsPiloteEdition(): void
+    {
+        $this->assertSame('Édition pilote', $this->extractor->extract('Berserk : édition pilote. 1'));
+    }
+
+    public function testDetectsTransliteratedJapaneseEditionMarkers(): void
+    {
+        $this->assertSame('Deluxe', $this->extractor->extract('Dragon Ball aizoban 2'));
+        $this->assertSame('Nouvelle édition', $this->extractor->extract('Yu Yu Hakusho shinsoban'));
+        $this->assertSame('Bunko', $this->extractor->extract('Slam Dunk bunko, Vol. 5'));
     }
 
     public function testGenericFallbackIgnoresLanguageAndBindingStatements(): void

--- a/back/tests/Unit/Manga/Domain/Service/EditionRelevanceFilterTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/EditionRelevanceFilterTest.php
@@ -19,69 +19,108 @@ final class EditionRelevanceFilterTest extends TestCase
 
     public function testKeepsLegitimateMangaEdition(): void
     {
-        $this->assertTrue($this->filter->isRelevant('Berserk, Vol. 1', 'Glénat (Grenoble)', 'text'));
-        $this->assertTrue($this->filter->isRelevant('Berserk : édition deluxe', 'Dark Horse Comics', 'text'));
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'Berserk, Vol. 1', 'Glénat (Grenoble)', 'text'));
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'Berserk : édition deluxe', 'Dark Horse Comics', 'text'));
+    }
+
+    public function testKeepsArtbooksAndCompanionBooks(): void
+    {
+        // Artbooks are collectible editions now — never rejected on their title.
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'Berserk illustrations file', 'Glénat'));
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'The Artwork of Berserk', null));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball artbook', 'Glénat'));
+        $this->assertTrue($this->filter->isRelevant('進撃の巨人', '進撃の巨人 公式ガイドブック', '講談社'));
+        $this->assertTrue($this->filter->isRelevant('One Piece', 'One Piece official fan book', 'Shueisha'));
+    }
+
+    public function testKeepsEditionWithUnknownPublisherWhenTitleMatches(): void
+    {
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, tome 1', 'Tartempion Éditions'));
+    }
+
+    public function testKeepsEditionWithEmptyPublisherWhenTitleMatches(): void
+    {
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball : coffret tomes 1 à 5', null));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, tome 1', '   '));
+    }
+
+    public function testRejectsUnrelatedTitleFromUnknownPublisher(): void
+    {
+        // No title match, no recognised manga house → off-topic record.
+        $this->assertFalse($this->filter->isRelevant('Berserk', 'La cuisine japonaise pour tous', 'Tartempion Éditions'));
+        $this->assertFalse($this->filter->isRelevant('Berserk', 'Naruto, tome 1', null));
+    }
+
+    public function testKeepsTranslatedTitleFromKnownMangaPublisher(): void
+    {
+        // A Japanese edition surfacing under the western work title: the record title
+        // does not literally match, but the publisher is a recognised manga house.
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'ベルセルク 1', '白泉社'));
+        $this->assertTrue($this->filter->isRelevant('Attack on Titan', '進撃の巨人 1', 'Kodansha'));
+    }
+
+    public function testTitleMatchIsAccentAndCaseInsensitive(): void
+    {
+        $this->assertTrue($this->filter->isRelevant("L'Attaque des Titans", "L'attaque des titans : édition colossale", null));
+        $this->assertTrue($this->filter->isRelevant('Berserk', 'BERSERK — Coffret intégrale', null));
+    }
+
+    public function testTitleMatchRequiresEverySignificantWord(): void
+    {
+        // "Titans" alone is not the searched work.
+        $this->assertFalse($this->filter->isRelevant("L'Attaque des Titans", 'La guerre des titans', null));
     }
 
     public function testRejectsVideoByType(): void
     {
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Kana', 'image animée'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Kana', 'vidéo'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Dragon Ball Z', 'Kana', 'image animée'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Dragon Ball Z', 'Kana', 'vidéo'));
     }
 
     public function testRejectsDeniedPublishers(): void
     {
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'AB vidéo (La Plaine Saint-Denis)'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Hachette collections (Vanves)'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Éd. Atlas (Évreux)'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Third Editions'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball', 'AB vidéo (La Plaine Saint-Denis)'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball', 'Hachette collections (Vanves)'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball', 'Éd. Atlas (Évreux)'));
+        $this->assertFalse($this->filter->isRelevant('Berserk', "Berserk : le guide de l'âge d'or", 'Third Editions'));
     }
 
-    public function testRejectsDerivativePrintByTitle(): void
+    public function testRejectsNoiseByTitle(): void
     {
-        $this->assertFalse($this->filter->isRelevant("Berserk : le guide de l'âge d'or", 'Glénat'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball : the world of Akira Toriyama', 'Glénat'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball artbook', 'Glénat'));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball : the novel', 'Glénat'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball : coloriages', 'Glénat'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Agenda Dragon Ball 2026', null));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Calendrier Dragon Ball', null));
+        $this->assertFalse($this->filter->isRelevant('Naruto', 'Naruto : guide de lecture non officiel', null));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball : the novel', 'Glénat'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball', 'Dragon Ball : figurine Son Goku', null));
+        $this->assertFalse($this->filter->isRelevant('Berserk', 'Berserk : stickers officiels', null));
     }
 
     public function testDoesNotFalseRejectRomance(): void
     {
         // "roman" must not match inside "romance".
-        $this->assertTrue($this->filter->isRelevant('Romance shojo, tome 1', 'Kana'));
+        $this->assertTrue($this->filter->isRelevant('Romance shojo', 'Romance shojo, tome 1', 'Kana'));
     }
 
     public function testKeepsKnownMangaPublishersAcrossMarkets(): void
     {
-        $this->assertTrue($this->filter->isRelevant('Dragon Ball, Vol. 1', 'Carlsen Manga'));
-        $this->assertTrue($this->filter->isRelevant('Dragon Ball, Vol. 1', 'VIZ Media LLC'));
-        $this->assertTrue($this->filter->isRelevant('ドラゴンボール 1', 'Shueisha'));
-        $this->assertTrue($this->filter->isRelevant('Dragon Ball, Vol. 1', 'Star Comics'));
-        $this->assertTrue($this->filter->isRelevant('Dragon Ball, Vol. 1', 'Planeta Cómic'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, Vol. 1', 'Carlsen Manga'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, Vol. 1', 'VIZ Media LLC'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'ドラゴンボール 1', 'Shueisha'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, Vol. 1', 'Star Comics'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, Vol. 1', 'Planeta Cómic'));
     }
 
     public function testKeepsJapaneseEditionWithKanjiPublisher(): void
     {
         // Berserk's Japanese publisher (白泉社 / Hakusensha) arrives in kanji.
-        $this->assertTrue($this->filter->isRelevant('ベルセルク 1', '白泉社'));
-        $this->assertTrue($this->filter->isRelevant('ドラゴンボール 1', '株式会社集英社'));
-    }
-
-    public function testRejectsUnknownPublisher(): void
-    {
-        // Not a recognised manga house → dropped, however clean the record looks.
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball, tome 1', 'Tartempion Éditions'));
-    }
-
-    public function testRejectsEmptyPublisher(): void
-    {
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball, tome 1', null));
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball, tome 1', '   '));
+        $this->assertTrue($this->filter->isRelevant('ベルセルク', 'ベルセルク 1', '白泉社'));
+        $this->assertTrue($this->filter->isRelevant('ドラゴンボール', 'ドラゴンボール 1', '株式会社集英社'));
     }
 
     public function testRejectsVideoArmButKeepsMangaArm(): void
     {
-        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Kazé Video'));
-        $this->assertTrue($this->filter->isRelevant('Dragon Ball, tome 1', 'Kazé Manga'));
+        $this->assertFalse($this->filter->isRelevant('Dragon Ball Z', 'Dragon Ball Z', 'Kazé Video'));
+        $this->assertTrue($this->filter->isRelevant('Dragon Ball', 'Dragon Ball, tome 1', 'Kazé Manga'));
     }
 }

--- a/back/tests/Unit/Manga/Domain/Service/PublisherNormalizerTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/PublisherNormalizerTest.php
@@ -73,4 +73,37 @@ final class PublisherNormalizerTest extends TestCase
         $this->assertNull($this->normalizer->displayName('   '));
         $this->assertSame('', $this->normalizer->canonicalKey(null));
     }
+
+    public function testImprintKeyKeepsDelcourtAndTonkamApart(): void
+    {
+        // Display merges (one house today) but the imprints group separately.
+        $this->assertSame('Delcourt/Tonkam', $this->normalizer->displayName('Tonkam'));
+        $this->assertSame('Delcourt/Tonkam', $this->normalizer->displayName('Delcourt'));
+        $this->assertNotSame(
+            $this->normalizer->imprintKey('Tonkam'),
+            $this->normalizer->imprintKey('Delcourt'),
+        );
+    }
+
+    public function testImprintKeyStillCollapsesSpellingVariantsOfOneHouse(): void
+    {
+        $this->assertSame(
+            $this->normalizer->imprintKey('Glénat (Grenoble)'),
+            $this->normalizer->imprintKey('Glénat'),
+        );
+        $this->assertSame(
+            $this->normalizer->imprintKey('VIZ Media LLC'),
+            $this->normalizer->imprintKey('Viz Communications'),
+        );
+        $this->assertSame(
+            $this->normalizer->imprintKey('Éd. Tonkam (Paris)'),
+            $this->normalizer->imprintKey('Tonkam'),
+        );
+    }
+
+    public function testImprintKeyIsEmptyForBlankPublisher(): void
+    {
+        $this->assertSame('', $this->normalizer->imprintKey(null));
+        $this->assertSame('', $this->normalizer->imprintKey('   '));
+    }
 }

--- a/back/tests/Unit/Manga/Domain/Service/RetailerOfferResolverTest.php
+++ b/back/tests/Unit/Manga/Domain/Service/RetailerOfferResolverTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Domain\Service;
+
+use App\Manga\Domain\Service\RetailerOfferResolver;
+use PHPUnit\Framework\TestCase;
+
+final class RetailerOfferResolverTest extends TestCase
+{
+    private RetailerOfferResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new RetailerOfferResolver();
+    }
+
+    /** @return array<string, mixed> */
+    private function offer(string $merchant, float $amount, string $kind = 'merchant_live'): array
+    {
+        return [
+            'kind'         => $kind,
+            'merchant'     => $merchant,
+            'merchantLogo' => 'test',
+            'amount'       => $amount,
+            'currency'     => 'EUR',
+            'url'          => 'https://shop.example/offer',
+            'imageUrl'     => null,
+            'source'       => 'test',
+        ];
+    }
+
+    public function testEmptyOffersYieldThreeNotFoundBlocks(): void
+    {
+        $retailers = $this->resolver->resolve([]);
+
+        $this->assertCount(3, $retailers);
+        $this->assertSame(['amazon', 'fnac', 'ebay'], array_column($retailers, 'retailer'));
+        $this->assertSame(['Amazon', 'Fnac', 'eBay'], array_column($retailers, 'label'));
+
+        foreach ($retailers as $retailerBlock) {
+            $this->assertSame(RetailerOfferResolver::STATUS_NOT_FOUND, $retailerBlock['status']);
+            $this->assertNull($retailerBlock['bestOffer']);
+        }
+    }
+
+    public function testMapsEachTargetShopToItsOffer(): void
+    {
+        $amazonOffer = $this->offer('Amazon.fr', 7.20);
+        $fnacOffer   = $this->offer('Fnac.com', 7.90);
+        $ebayOffer   = $this->offer('eBay France', 5.40);
+
+        $retailers = $this->resolver->resolve([$amazonOffer, $fnacOffer, $ebayOffer]);
+
+        $this->assertSame(RetailerOfferResolver::STATUS_FOUND, $retailers[0]['status']);
+        $this->assertSame($amazonOffer, $retailers[0]['bestOffer']);
+        $this->assertSame(RetailerOfferResolver::STATUS_FOUND, $retailers[1]['status']);
+        $this->assertSame($fnacOffer, $retailers[1]['bestOffer']);
+        $this->assertSame(RetailerOfferResolver::STATUS_FOUND, $retailers[2]['status']);
+        $this->assertSame($ebayOffer, $retailers[2]['bestOffer']);
+    }
+
+    public function testKeepsTheCheapestOfferPerRetailer(): void
+    {
+        $expensiveAmazon = $this->offer('Amazon', 9.99);
+        $cheapAmazon     = $this->offer('Amazon Marketplace', 6.50);
+
+        $retailers = $this->resolver->resolve([$expensiveAmazon, $cheapAmazon]);
+
+        $this->assertSame($cheapAmazon, $retailers[0]['bestOffer']);
+    }
+
+    public function testUnmappedMerchantLeavesRetailerNotFound(): void
+    {
+        $retailers = $this->resolver->resolve([
+            $this->offer('Rakuten', 6.50),
+            $this->offer('momox', 4.99),
+        ]);
+
+        foreach ($retailers as $retailerBlock) {
+            $this->assertSame(RetailerOfferResolver::STATUS_NOT_FOUND, $retailerBlock['status']);
+            $this->assertNull($retailerBlock['bestOffer']);
+        }
+    }
+
+    public function testPublisherReferenceOffersNeverFeedRetailers(): void
+    {
+        $retailers = $this->resolver->resolve([
+            $this->offer('Amazon', 7.20, kind: 'publisher_reference'),
+        ]);
+
+        $this->assertSame(RetailerOfferResolver::STATUS_NOT_FOUND, $retailers[0]['status']);
+        $this->assertNull($retailers[0]['bestOffer']);
+    }
+
+    public function testMixedOffersOnlyFillTheMatchingShops(): void
+    {
+        $amazonOffer = $this->offer('Amazon', 7.20);
+
+        $retailers = $this->resolver->resolve([
+            $amazonOffer,
+            $this->offer('Rakuten', 6.50),
+            $this->offer('Google Play', 4.99, kind: 'publisher_reference'),
+        ]);
+
+        $this->assertSame(RetailerOfferResolver::STATUS_FOUND, $retailers[0]['status']);
+        $this->assertSame($amazonOffer, $retailers[0]['bestOffer']);
+        $this->assertSame(RetailerOfferResolver::STATUS_NOT_FOUND, $retailers[1]['status']);
+        $this->assertSame(RetailerOfferResolver::STATUS_NOT_FOUND, $retailers[2]['status']);
+    }
+}

--- a/back/tests/Unit/Manga/Infrastructure/BnfEditionProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/BnfEditionProviderTest.php
@@ -145,4 +145,90 @@ final class BnfEditionProviderTest extends TestCase
 
         $this->assertSame([], $editions);
     }
+
+    public function testFindEditionsStopsAfterSinglePageWhenAllRecordsFetched(): void
+    {
+        // numberOfRecords=6 in the fixture: everything fits in the first page.
+        $requestCount = 0;
+        $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+            $requestCount++;
+
+            return new MockResponse($this->fixtureXml(), ['http_code' => 200]);
+        });
+
+        $this->makeProvider($httpClient)->findEditions('Berserk', null, null);
+
+        $this->assertSame(1, $requestCount);
+    }
+
+    public function testFindEditionsPaginatesUntilNumberOfRecordsIsReached(): void
+    {
+        // Pretend the catalogue holds 150 records: page 1 (start 1) and page 2 (start
+        // 101) must be fetched, then the loop stops (201 > 150).
+        $largeCatalogueXml = str_replace(
+            '<srw:numberOfRecords>6</srw:numberOfRecords>',
+            '<srw:numberOfRecords>150</srw:numberOfRecords>',
+            $this->fixtureXml(),
+        );
+
+        $startRecords = [];
+        $httpClient   = new MockHttpClient(
+            function (string $method, string $url) use (&$startRecords, $largeCatalogueXml): MockResponse {
+                preg_match('/startRecord=(\d+)/', $url, $matches);
+                $startRecords[] = (int) ($matches[1] ?? 0);
+
+                return new MockResponse($largeCatalogueXml, ['http_code' => 200]);
+            },
+        );
+
+        $editions = $this->makeProvider($httpClient)->findEditions('Berserk', null, null);
+
+        $this->assertSame([1, 101], $startRecords);
+        // Both pages return the same 3 relevant records — deduplicated by ISBN.
+        $this->assertCount(3, $editions);
+    }
+
+    public function testFindEditionsCapsPaginationAtThreePages(): void
+    {
+        $hugeCatalogueXml = str_replace(
+            '<srw:numberOfRecords>6</srw:numberOfRecords>',
+            '<srw:numberOfRecords>1000</srw:numberOfRecords>',
+            $this->fixtureXml(),
+        );
+
+        $startRecords = [];
+        $httpClient   = new MockHttpClient(
+            function (string $method, string $url) use (&$startRecords, $hugeCatalogueXml): MockResponse {
+                preg_match('/startRecord=(\d+)/', $url, $matches);
+                $startRecords[] = (int) ($matches[1] ?? 0);
+
+                return new MockResponse($hugeCatalogueXml, ['http_code' => 200]);
+            },
+        );
+
+        $this->makeProvider($httpClient)->findEditions('Berserk', null, null);
+
+        $this->assertSame([1, 101, 201], $startRecords);
+    }
+
+    public function testFindEditionsWithAuthorAlsoSweepsWithoutAuthorAndDeduplicates(): void
+    {
+        // Artbooks are often catalogued under another creator: a second query without
+        // the author restriction must run, and shared records must not double up.
+        $queries    = [];
+        $httpClient = new MockHttpClient(function (string $method, string $url) use (&$queries): MockResponse {
+            preg_match('/query=([^&]+)/', $url, $matches);
+            $queries[] = urldecode($matches[1] ?? '');
+
+            return new MockResponse($this->fixtureXml(), ['http_code' => 200]);
+        });
+
+        $editions = $this->makeProvider($httpClient)->findEditions('Berserk', 'Kentaro Miura', null);
+
+        $this->assertCount(2, $queries);
+        $this->assertStringContainsString('bib.author all "Kentaro Miura"', $queries[0]);
+        $this->assertStringNotContainsString('bib.author', $queries[1]);
+        // Same fixture served twice → the 3 relevant records appear only once.
+        $this->assertCount(3, $editions);
+    }
 }

--- a/back/tests/Unit/Manga/Infrastructure/ChasseAuxLivresPriceProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/ChasseAuxLivresPriceProviderTest.php
@@ -9,6 +9,7 @@ use App\Manga\Domain\Marketplace;
 use App\Manga\Domain\PriceKindEnum;
 use App\Manga\Infrastructure\ExternalApi\ChasseAuxLivresPriceProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -21,18 +22,21 @@ final class ChasseAuxLivresPriceProviderTest extends TestCase
     private function makeProvider(
         MockHttpClient $httpClient,
         string $baseUrl = self::BASE_URL,
+        ?LoggerInterface $logger = null,
     ): ChasseAuxLivresPriceProvider {
-        return new ChasseAuxLivresPriceProvider($httpClient, $baseUrl, new NullLogger());
+        return new ChasseAuxLivresPriceProvider($httpClient, $baseUrl, $logger ?? new NullLogger());
     }
 
-    private function fixtureHtml(): string
+    private function fixtureHtml(string $name = 'prix-berserk'): string
     {
         return (string) file_get_contents(
-            dirname(__DIR__, 3) . '/Fixtures/ChasseAuxLivres/prix-berserk.html',
+            dirname(__DIR__, 3) . '/Fixtures/ChasseAuxLivres/' . $name . '.html',
         );
     }
 
-    public function testParsesMerchantOffersFromComparisonPage(): void
+    // ── Strategy: table rows (merchant from img alt) ─────────────────────────
+
+    public function testParsesMerchantOffersFromComparisonTable(): void
     {
         $provider = $this->makeProvider(new MockHttpClient([
             new MockResponse($this->fixtureHtml(), ['http_code' => 200]),
@@ -40,13 +44,13 @@ final class ChasseAuxLivresPriceProviderTest extends TestCase
 
         $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
 
-        $this->assertCount(3, $offers);
+        $this->assertCount(5, $offers);
 
         $merchants = array_map(static fn ($offer) => $offer->merchant, $offers);
-        $this->assertSame(['Amazon', 'Rakuten', 'momox'], $merchants);
+        $this->assertSame(['Amazon', 'Fnac.com', 'eBay France', 'Rakuten', 'momox'], $merchants);
 
         $amounts = array_map(static fn ($offer) => $offer->amount, $offers);
-        $this->assertSame([7.20, 6.50, 4.99], $amounts);
+        $this->assertSame([7.20, 7.90, 5.40, 6.50, 4.99], $amounts);
 
         foreach ($offers as $offer) {
             $this->assertSame(PriceKindEnum::MerchantLive, $offer->kind);
@@ -64,9 +68,105 @@ final class ChasseAuxLivresPriceProviderTest extends TestCase
         $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
 
         $this->assertSame(self::BASE_URL . '/redirection/amazon/' . self::ISBN, $offers[0]->url);
-        $this->assertSame('https://rakuten.example/offre/123', $offers[1]->url);
-        $this->assertSame('https://momox.example/article/' . self::ISBN, $offers[2]->url);
+        $this->assertSame('https://rakuten.example/offre/123', $offers[3]->url);
+        $this->assertSame('https://momox.example/article/' . self::ISBN, $offers[4]->url);
     }
+
+    // ── Strategy: JSON-LD (schema.org Product / Offer) ───────────────────────
+
+    public function testParsesOffersFromJsonLdWhenNoDomRowsExist(): void
+    {
+        $provider = $this->makeProvider(new MockHttpClient([
+            new MockResponse($this->fixtureHtml('prix-jsonld'), ['http_code' => 200]),
+        ]));
+
+        $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
+
+        // The zero-price offer and the seller-less offer are both skipped.
+        $this->assertCount(2, $offers);
+
+        $this->assertSame('Amazon', $offers[0]->merchant);
+        $this->assertSame(7.20, $offers[0]->amount);
+        $this->assertSame(self::BASE_URL . '/redirection/amazon/' . self::ISBN, $offers[0]->url);
+
+        $this->assertSame('Fnac', $offers[1]->merchant);
+        $this->assertSame(6.99, $offers[1]->amount);
+        $this->assertSame('https://www.fnac.com/livre/' . self::ISBN, $offers[1]->url);
+
+        foreach ($offers as $offer) {
+            $this->assertSame(PriceKindEnum::MerchantLive, $offer->kind);
+            $this->assertSame('EUR', $offer->currency);
+        }
+    }
+
+    // ── Strategy: offer-classed blocks + data-merchant/seller/vendor ─────────
+
+    public function testParsesOffersFromBlocksWithMerchantDataAttributes(): void
+    {
+        $provider = $this->makeProvider(new MockHttpClient([
+            new MockResponse($this->fixtureHtml('prix-blocks'), ['http_code' => 200]),
+        ]));
+
+        $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
+
+        $merchants = array_map(static fn ($offer) => $offer->merchant, $offers);
+        $this->assertSame(['Amazon', 'Fnac', 'momox'], $merchants);
+
+        $amounts = array_map(static fn ($offer) => $offer->amount, $offers);
+        $this->assertSame([7.20, 7.90, 4.99], $amounts);
+
+        $this->assertSame(self::BASE_URL . '/redirection/fnac/' . self::ISBN, $offers[1]->url);
+    }
+
+    // ── Strategy: tolerant text fallback (known merchant near "xx,xx €") ─────
+
+    public function testFallsBackToKnownMerchantsInPlainTextOnUnexpectedLayout(): void
+    {
+        $provider = $this->makeProvider(new MockHttpClient([
+            new MockResponse($this->fixtureHtml('prix-fallback-texte'), ['http_code' => 200]),
+        ]));
+
+        $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
+
+        $this->assertCount(3, $offers);
+
+        $merchants = array_map(static fn ($offer) => mb_strtolower($offer->merchant), $offers);
+        $this->assertSame(['amazon', 'fnac', 'ebay'], $merchants);
+
+        $amounts = array_map(static fn ($offer) => $offer->amount, $offers);
+        $this->assertSame([7.20, 7.90, 5.40], $amounts);
+
+        foreach ($offers as $offer) {
+            $this->assertNull($offer->url);
+            $this->assertSame(PriceKindEnum::MerchantLive, $offer->kind);
+        }
+    }
+
+    // ── Diagnostics ──────────────────────────────────────────────────────────
+
+    public function testLogsWarningWhenPageIsOkButNoOfferParsed(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('0 OFFER PARSED'),
+                $this->callback(static fn (array $context) => ($context['isbn'] ?? null) === self::ISBN),
+            );
+
+        $provider = $this->makeProvider(
+            new MockHttpClient([
+                new MockResponse('<html><body><p>Aucun résultat</p></body></html>', ['http_code' => 200]),
+            ]),
+            logger: $logger,
+        );
+
+        $offers = $provider->findOffers(Isbn::fromString(self::ISBN), Marketplace::Fr);
+
+        $this->assertSame([], $offers);
+    }
+
+    // ── Request shaping / guards ─────────────────────────────────────────────
 
     public function testQueriesThePricePageForTheIsbn(): void
     {

--- a/back/tests/Unit/Manga/Infrastructure/DnbEditionProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/DnbEditionProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Manga\Infrastructure;
 
+use App\Manga\Domain\EditionFormatEnum;
 use App\Manga\Domain\Service\EditionLineExtractor;
 use App\Manga\Domain\Service\EditionRelevanceFilter;
 use App\Manga\Domain\Service\PublisherNormalizer;
@@ -51,7 +52,7 @@ final class DnbEditionProviderTest extends TestCase
         }
     }
 
-    public function testFiltersOutArtbookAndKeepsRealEditions(): void
+    public function testKeepsArtbookAsDedicatedFormat(): void
     {
         $httpClient = new MockHttpClient([
             new MockResponse($this->fixtureXml(), ['http_code' => 200]),
@@ -59,11 +60,16 @@ final class DnbEditionProviderTest extends TestCase
 
         $editions = $this->makeProvider($httpClient)->findEditions('Dragon Ball', null, null);
 
-        // 3 records, the artbook is dropped → 2 real editions remain.
-        $this->assertCount(2, $editions);
-        foreach ($editions as $edition) {
-            $this->assertStringNotContainsStringIgnoringCase('artbook', $edition->editionLabel);
-        }
+        // All 3 records are kept — the artbook is a legitimate edition, surfaced with
+        // its own format instead of being dropped.
+        $this->assertCount(3, $editions);
+
+        $artbooks = array_values(array_filter(
+            $editions,
+            static fn ($edition) => $edition->format === EditionFormatEnum::Artbook,
+        ));
+        $this->assertCount(1, $artbooks);
+        $this->assertSame('Artbook', $artbooks[0]->editionLine);
     }
 
     public function testExtractsColorEditionLine(): void
@@ -121,5 +127,45 @@ final class DnbEditionProviderTest extends TestCase
         $editions = $this->makeProvider($httpClient)->findEditions('Dragon Ball', null, null);
 
         $this->assertSame([], $editions);
+    }
+
+    public function testStopsAfterSinglePageWhenAllRecordsFetched(): void
+    {
+        // numberOfRecords=3 in the fixture: everything fits in the first page.
+        $requestCount = 0;
+        $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+            $requestCount++;
+
+            return new MockResponse($this->fixtureXml(), ['http_code' => 200]);
+        });
+
+        $this->makeProvider($httpClient)->findEditions('Dragon Ball', null, null);
+
+        $this->assertSame(1, $requestCount);
+    }
+
+    public function testPaginatesUpToThreePagesWhenCatalogueIsLarger(): void
+    {
+        $hugeCatalogueXml = str_replace(
+            '<numberOfRecords>3</numberOfRecords>',
+            '<numberOfRecords>1000</numberOfRecords>',
+            $this->fixtureXml(),
+        );
+
+        $startRecords = [];
+        $httpClient   = new MockHttpClient(
+            function (string $method, string $url) use (&$startRecords, $hugeCatalogueXml): MockResponse {
+                preg_match('/startRecord=(\d+)/', $url, $matches);
+                $startRecords[] = (int) ($matches[1] ?? 0);
+
+                return new MockResponse($hugeCatalogueXml, ['http_code' => 200]);
+            },
+        );
+
+        $editions = $this->makeProvider($httpClient)->findEditions('Dragon Ball', null, null);
+
+        $this->assertSame([1, 101, 201], $startRecords);
+        // 3 pages × 3 relevant records — downstream grouping deduplicates them.
+        $this->assertCount(9, $editions);
     }
 }

--- a/back/tests/Unit/Manga/Infrastructure/EbayBrowsePriceProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/EbayBrowsePriceProviderTest.php
@@ -71,6 +71,35 @@ final class EbayBrowsePriceProviderTest extends TestCase
         $this->assertSame('ebay', $offers[0]->source);
     }
 
+    public function testFindOffersAcceptsNullCampaignId(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse($this->oauthFixture(), ['http_code' => 200]),
+            new MockResponse($this->browseFixture(), ['http_code' => 200]),
+        ]);
+
+        $cache         = new ArrayAdapter();
+        $tokenProvider = new EbayOAuthTokenProvider(
+            $httpClient,
+            self::OAUTH_URL,
+            self::CLIENT_ID,
+            self::CLIENT_SECRET,
+            $cache,
+            new NullLogger(),
+        );
+        $provider = new EbayBrowsePriceProvider($httpClient, $tokenProvider, self::BASE_URL, null, new NullLogger());
+
+        $isbn   = Isbn::fromString('9782723425483');
+        $offers = $provider->findOffers($isbn, Marketplace::Fr);
+
+        $this->assertNotEmpty($offers);
+        $this->assertSame(PriceKindEnum::MerchantLive, $offers[0]->kind);
+        $this->assertSame('eBay', $offers[0]->merchant);
+        $this->assertSame('EUR', $offers[0]->currency);
+        $this->assertIsFloat($offers[0]->amount);
+        $this->assertSame('ebay', $offers[0]->source);
+    }
+
     public function testFindOffersUsesAffiliateUrlWhenAvailable(): void
     {
         $httpClient = new MockHttpClient([

--- a/back/tests/Unit/Manga/Infrastructure/GoogleBooksEditionProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/GoogleBooksEditionProviderTest.php
@@ -69,6 +69,25 @@ final class GoogleBooksEditionProviderTest extends TestCase
         $this->assertSame(0, $requestCount);
     }
 
+    public function testFindEditionsWithPlaceholderApiKeyReturnsEmptyWithoutRequest(): void
+    {
+        // "change_me" is the committed .env default and "CHANGEME" the env-sync
+        // sentinel: sending either yields silent 403s, so no request must go out.
+        foreach (['change_me', 'CHANGEME', 'ChangeMe'] as $placeholderKey) {
+            $requestCount = 0;
+            $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+                $requestCount++;
+
+                return new MockResponse('{}', ['http_code' => 200]);
+            });
+
+            $editions = $this->makeProvider($httpClient, $placeholderKey)->findEditions('Berserk', null, null);
+
+            $this->assertSame([], $editions);
+            $this->assertSame(0, $requestCount);
+        }
+    }
+
     public function testFindEditionsReturnsEmptyOnNonOkResponse(): void
     {
         // Null language sweeps several locales; every call returns 429.
@@ -139,6 +158,57 @@ final class GoogleBooksEditionProviderTest extends TestCase
 
         // The same two volume ids come back from every locale → deduplicated to two.
         $this->assertCount(2, $editions);
+    }
+
+    public function testFetchesSecondPageWhenFirstPageIsFull(): void
+    {
+        $fullPage = (string) json_encode([
+            'items' => array_map(
+                static fn (int $itemIndex): array => [
+                    'id'         => 'vol-' . $itemIndex,
+                    'volumeInfo' => [
+                        'title'     => sprintf('Berserk, Vol. %d', $itemIndex + 1),
+                        'publisher' => 'Glénat',
+                        'language'  => 'fr',
+                    ],
+                ],
+                range(0, 39),
+            ),
+        ]);
+
+        $startIndexes = [];
+        $httpClient   = new MockHttpClient(
+            function (string $method, string $url) use (&$startIndexes, $fullPage): MockResponse {
+                preg_match('/startIndex=(\d+)/', $url, $matches);
+                $startIndexes[] = (int) ($matches[1] ?? -1);
+
+                // Full first page, short second page → pagination stops after two.
+                return count($startIndexes) === 1
+                    ? new MockResponse($fullPage, ['http_code' => 200])
+                    : new MockResponse($this->fixture(), ['http_code' => 200]);
+            },
+        );
+
+        $editions = $this->makeProvider($httpClient)->findEditions('Berserk', null, 'fr');
+
+        $this->assertSame([0, 40], $startIndexes);
+        // 40 volumes from page 1 + 2 from page 2, all with distinct Google ids.
+        $this->assertCount(42, $editions);
+    }
+
+    public function testDoesNotFetchSecondPageWhenFirstPageIsShort(): void
+    {
+        $requestCount = 0;
+        $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+            $requestCount++;
+
+            return new MockResponse($this->fixture(), ['http_code' => 200]);
+        });
+
+        $this->makeProvider($httpClient)->findEditions('Berserk', null, 'fr');
+
+        // The fixture holds 2 items (< 40): no second page must be requested.
+        $this->assertSame(1, $requestCount);
     }
 
     public function testFindEditionsSetsSourceAsGoogleBooks(): void

--- a/back/tests/Unit/Manga/Infrastructure/GoogleBooksPriceProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/GoogleBooksPriceProviderTest.php
@@ -94,4 +94,22 @@ final class GoogleBooksPriceProviderTest extends TestCase
         $this->assertSame([], $offers);
         $this->assertSame(0, $requestCount);
     }
+
+    public function testFindOffersTreatsPlaceholderApiKeyAsNotConfigured(): void
+    {
+        foreach (['change_me', 'CHANGE_ME', 'changeme'] as $placeholderKey) {
+            $requestCount = 0;
+            $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+                $requestCount++;
+
+                return new MockResponse('{}', ['http_code' => 200]);
+            });
+
+            $isbn   = Isbn::fromString('9782723425483');
+            $offers = $this->makeProvider($httpClient, $placeholderKey)->findOffers($isbn, Marketplace::Fr);
+
+            $this->assertSame([], $offers, sprintf('Placeholder "%s" must disable the provider', $placeholderKey));
+            $this->assertSame(0, $requestCount);
+        }
+    }
 }

--- a/back/tests/Unit/Manga/Infrastructure/NdlEditionProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/NdlEditionProviderTest.php
@@ -51,7 +51,7 @@ final class NdlEditionProviderTest extends TestCase
         }
     }
 
-    public function testUnknownPublisherIsFilteredOut(): void
+    public function testUnknownPublisherIsKeptWhenTitleMatchesWork(): void
     {
         $httpClient = new MockHttpClient([
             new MockResponse($this->fixtureXml(), ['http_code' => 200]),
@@ -59,8 +59,12 @@ final class NdlEditionProviderTest extends TestCase
 
         $editions = $this->makeProvider($httpClient)->findEditions('進撃の巨人', null, 'ja');
 
-        // 4 records in the fixture, the unknown-publisher one is dropped → 3 remain.
-        $this->assertCount(3, $editions);
+        // All 4 records are kept: the unknown-publisher record still titles the work,
+        // so it is a legitimate edition (relevance is title-driven, not publisher-driven).
+        $this->assertCount(4, $editions);
+
+        $publishers = array_column(array_map(fn ($edition) => $edition->toArray(), $editions), 'publisher');
+        $this->assertContains('未知の出版社', $publishers);
     }
 
     public function testExtractsKanjiEditionLines(): void
@@ -133,5 +137,43 @@ final class NdlEditionProviderTest extends TestCase
         $httpClient = new MockHttpClient([new MockResponse('<broken', ['http_code' => 200])]);
 
         $this->assertSame([], $this->makeProvider($httpClient)->findEditions('進撃の巨人', null, 'ja'));
+    }
+
+    public function testStopsAfterSinglePageWhenAllRecordsFetched(): void
+    {
+        // numberOfRecords=4 in the fixture: everything fits in the first page.
+        $requestCount = 0;
+        $httpClient   = new MockHttpClient(function () use (&$requestCount): MockResponse {
+            $requestCount++;
+
+            return new MockResponse($this->fixtureXml(), ['http_code' => 200]);
+        });
+
+        $this->makeProvider($httpClient)->findEditions('進撃の巨人', null, 'ja');
+
+        $this->assertSame(1, $requestCount);
+    }
+
+    public function testPaginatesUpToThreePagesWhenCatalogueIsLarger(): void
+    {
+        $hugeCatalogueXml = str_replace(
+            '<numberOfRecords>4</numberOfRecords>',
+            '<numberOfRecords>1000</numberOfRecords>',
+            $this->fixtureXml(),
+        );
+
+        $startRecords = [];
+        $httpClient   = new MockHttpClient(
+            function (string $method, string $url) use (&$startRecords, $hugeCatalogueXml): MockResponse {
+                preg_match('/startRecord=(\d+)/', $url, $matches);
+                $startRecords[] = (int) ($matches[1] ?? 0);
+
+                return new MockResponse($hugeCatalogueXml, ['http_code' => 200]);
+            },
+        );
+
+        $this->makeProvider($httpClient)->findEditions('進撃の巨人', null, 'ja');
+
+        $this->assertSame([1, 101, 201], $startRecords);
     }
 }

--- a/back/tests/Unit/Manga/Infrastructure/OpenLibraryCoversApiClientTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/OpenLibraryCoversApiClientTest.php
@@ -70,6 +70,51 @@ final class OpenLibraryCoversApiClientTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testFindByIsbnFallsBackToGetWhenHeadHasNoContentLength(): void
+    {
+        $requestedMethods = [];
+        $largeBody = str_repeat('x', 50000);
+        $httpClient = new MockHttpClient(function (string $method) use (&$requestedMethods, $largeBody): MockResponse {
+            $requestedMethods[] = $method;
+
+            // HEAD answers 200 without any content-length header; GET returns the image.
+            return $method === 'HEAD'
+                ? new MockResponse('', ['http_code' => 200])
+                : new MockResponse($largeBody, ['http_code' => 200]);
+        });
+
+        $result = $this->makeClient($httpClient)->findByIsbn($this->makeIsbn());
+
+        $this->assertSame(['HEAD', 'GET'], $requestedMethods);
+        $this->assertInstanceOf(MangaVolumeCoverDto::class, $result);
+    }
+
+    public function testFindByIsbnReturnsNullWhenGetFallbackBodyIsTooSmall(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method): MockResponse {
+            return $method === 'HEAD'
+                ? new MockResponse('', ['http_code' => 200])
+                : new MockResponse('tiny', ['http_code' => 200]);
+        });
+
+        $result = $this->makeClient($httpClient)->findByIsbn($this->makeIsbn());
+
+        $this->assertNull($result);
+    }
+
+    public function testFindByIsbnReturnsNullWhenGetFallbackFails(): void
+    {
+        $httpClient = new MockHttpClient(function (string $method): MockResponse {
+            return $method === 'HEAD'
+                ? new MockResponse('', ['http_code' => 200])
+                : new MockResponse('', ['http_code' => 404]);
+        });
+
+        $result = $this->makeClient($httpClient)->findByIsbn($this->makeIsbn());
+
+        $this->assertNull($result);
+    }
+
     public function testFindByIsbnReturnsNullOnHttpError(): void
     {
         $httpClient = new MockHttpClient([

--- a/back/tests/Unit/Manga/Infrastructure/OpenLibraryEditionProviderTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/OpenLibraryEditionProviderTest.php
@@ -167,4 +167,89 @@ final class OpenLibraryEditionProviderTest extends TestCase
 
         $this->assertSame([], $editions);
     }
+
+    public function testMergesEditionsFromSeveralMatchingWorksAndSkipsUnrelatedOnes(): void
+    {
+        // Open Library splits one manga across several Work records (main run, deluxe
+        // re-release…): every title-matching work contributes, unrelated docs do not.
+        $searchJson = (string) json_encode([
+            'numFound' => 3,
+            'start'    => 0,
+            'docs'     => [
+                ['key' => '/works/OL1W', 'title' => 'Berserk', 'author_name' => ['Kentaro Miura']],
+                ['key' => '/works/OL2W', 'title' => 'Berserk Deluxe', 'author_name' => ['Kentaro Miura']],
+                ['key' => '/works/OL9W', 'title' => 'Cooking with Gordon', 'author_name' => ['Gordon Ramsay']],
+            ],
+        ]);
+
+        $mainRunJson = (string) json_encode([
+            'entries' => [
+                [
+                    'key'             => '/books/OL1001M',
+                    'title'           => 'Berserk Vol. 1',
+                    'publishers'      => ['Dark Horse Comics'],
+                    'languages'       => [['key' => '/languages/eng']],
+                    'isbn_13'         => ['9781593070205'],
+                    'physical_format' => 'Paperback',
+                ],
+            ],
+        ]);
+
+        // OL2001M overlaps with a fresh key; OL1001M is repeated to prove deduplication.
+        $deluxeJson = (string) json_encode([
+            'entries' => [
+                [
+                    'key'             => '/books/OL1001M',
+                    'title'           => 'Berserk Vol. 1',
+                    'publishers'      => ['Dark Horse Comics'],
+                    'languages'       => [['key' => '/languages/eng']],
+                    'isbn_13'         => ['9781593070205'],
+                    'physical_format' => 'Paperback',
+                ],
+                [
+                    'key'             => '/books/OL2001M',
+                    'title'           => 'Berserk Deluxe Volume 1',
+                    'publishers'      => ['Dark Horse Comics'],
+                    'languages'       => [['key' => '/languages/eng']],
+                    'isbn_13'         => ['9781506711980'],
+                    'physical_format' => 'Hardcover',
+                ],
+            ],
+        ]);
+
+        $requestedEditionUrls = [];
+        $httpClient           = new MockHttpClient(
+            function (string $method, string $url) use (
+                &$requestedEditionUrls,
+                $searchJson,
+                $mainRunJson,
+                $deluxeJson,
+            ): MockResponse {
+                if (str_contains($url, 'search.json')) {
+                    return new MockResponse($searchJson, ['http_code' => 200]);
+                }
+
+                $requestedEditionUrls[] = $url;
+                if (str_contains($url, '/works/OL1W/editions.json')) {
+                    return new MockResponse($mainRunJson, ['http_code' => 200]);
+                }
+                if (str_contains($url, '/works/OL2W/editions.json')) {
+                    return new MockResponse($deluxeJson, ['http_code' => 200]);
+                }
+
+                return new MockResponse('{}', ['http_code' => 404]);
+            },
+        );
+
+        $editions = $this->makeProvider($httpClient)->findEditions('Berserk', 'Miura', null);
+
+        $this->assertCount(2, $requestedEditionUrls);
+        $this->assertStringContainsString('/works/OL1W/editions.json', $requestedEditionUrls[0]);
+        $this->assertStringContainsString('/works/OL2W/editions.json', $requestedEditionUrls[1]);
+
+        // 1 + 2 entries with one duplicate key → 2 distinct editions.
+        $this->assertCount(2, $editions);
+        $externalIds = array_column(array_map(fn ($edition) => $edition->toArray(), $editions), 'externalId');
+        $this->assertSame(['/books/OL1001M', '/books/OL2001M'], $externalIds);
+    }
 }

--- a/back/tests/Unit/Manga/Infrastructure/Validator/ValidIsbnValidatorTest.php
+++ b/back/tests/Unit/Manga/Infrastructure/Validator/ValidIsbnValidatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Manga\Infrastructure\Validator;
+
+use App\Manga\Infrastructure\Validator\ValidIsbn;
+use App\Manga\Infrastructure\Validator\ValidIsbnValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/** @extends ConstraintValidatorTestCase<ValidIsbnValidator> */
+final class ValidIsbnValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ValidIsbnValidator
+    {
+        return new ValidIsbnValidator();
+    }
+
+    public function testNullIsSkipped(): void
+    {
+        $this->validator->validate(null, new ValidIsbn());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsSkipped(): void
+    {
+        $this->validator->validate('', new ValidIsbn());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidIsbn13Passes(): void
+    {
+        $this->validator->validate('9782723425483', new ValidIsbn());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidIsbn10WithHyphensPasses(): void
+    {
+        $this->validator->validate('2-7234-2548-7', new ValidIsbn());
+
+        $this->assertNoViolation();
+    }
+
+    public function testIsbn13WithEanAddOnPasses(): void
+    {
+        $this->validator->validate('978272342548312345', new ValidIsbn());
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidIsbnRaisesOneViolation(): void
+    {
+        $constraint = new ValidIsbn();
+
+        $this->validator->validate('not-an-isbn', $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
+
+    public function testWrongChecksumRaisesOneViolation(): void
+    {
+        $constraint = new ValidIsbn();
+
+        $this->validator->validate('9782723425484', $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
+
+    public function testNonStringValueIsRejected(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->validator->validate(12345, new ValidIsbn());
+    }
+}

--- a/back/tests/Unit/Notification/Application/GetActivityLogs/GetActivityLogsQueryTest.php
+++ b/back/tests/Unit/Notification/Application/GetActivityLogs/GetActivityLogsQueryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Application\GetActivityLogs;
+
+use App\Notification\Application\GetActivityLogs\GetActivityLogsQuery;
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class GetActivityLogsQueryTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $query = new GetActivityLogsQuery();
+
+        $this->assertSame(1, $query->page);
+        $this->assertSame(50, $query->limit);
+        $this->assertNull($query->eventType);
+        $this->assertNull($query->status);
+        $this->assertNull($query->collectionEntryId);
+        $this->assertNull($query->ownerId);
+        $this->assertNull($query->from);
+        $this->assertNull($query->to);
+        $this->assertNull($query->search);
+    }
+
+    public function testParsesAtomDates(): void
+    {
+        $query = new GetActivityLogsQuery(
+            from: '2026-07-01T00:00:00+00:00',
+            to: '2026-07-10T23:59:59+02:00',
+        );
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $query->from);
+        $this->assertInstanceOf(DateTimeImmutable::class, $query->to);
+        $this->assertSame('2026-07-01T00:00:00+00:00', $query->from->format(DateTimeInterface::ATOM));
+        $this->assertSame('2026-07-10T23:59:59+02:00', $query->to->format(DateTimeInterface::ATOM));
+    }
+
+    public function testIgnoresInvalidDates(): void
+    {
+        $query = new GetActivityLogsQuery(from: 'not-a-date', to: '');
+
+        $this->assertNull($query->from);
+        $this->assertNull($query->to);
+    }
+
+    public function testCarriesFilters(): void
+    {
+        $query = new GetActivityLogsQuery(
+            eventType: 'http_error',
+            status: 'error',
+            collectionEntryId: 'ce-1',
+            ownerId: 'user-1',
+            search: 'share',
+            page: 3,
+            limit: 25,
+        );
+
+        $this->assertSame('http_error', $query->eventType);
+        $this->assertSame('error', $query->status);
+        $this->assertSame('ce-1', $query->collectionEntryId);
+        $this->assertSame('user-1', $query->ownerId);
+        $this->assertSame('share', $query->search);
+        $this->assertSame(3, $query->page);
+        $this->assertSame(25, $query->limit);
+    }
+}

--- a/back/tests/Unit/Notification/Domain/ActivityLogTest.php
+++ b/back/tests/Unit/Notification/Domain/ActivityLogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Notification\Domain;
 
+use App\Auth\Domain\User;
 use App\Notification\Domain\ActivityLog;
 use App\Notification\Domain\EventTypeEnum;
 use PHPUnit\Framework\TestCase;
@@ -88,12 +89,37 @@ final class ActivityLogTest extends TestCase
         $this->assertSame('l1', $arr['id']);
         $this->assertSame('auth_action', $arr['eventType']);
         $this->assertSame('gate', $arr['sourceName']);
+        $this->assertNull($arr['owner']);
         $this->assertNull($arr['collectionEntryId']);
         $this->assertSame('success', $arr['status']);
         $this->assertSame(2, $arr['newArticlesCount']);
         $this->assertArrayHasKey('startedAt', $arr);
         $this->assertArrayHasKey('finishedAt', $arr);
         $this->assertIsInt($arr['durationMs']);
+    }
+
+    public function testToArrayExposesOwnerBlock(): void
+    {
+        $owner = new User(
+            id: 'user-1',
+            email: 'owner@test.local',
+            passwordHash: 'hash',
+            displayName: 'Owner',
+        );
+
+        $log = new ActivityLog(
+            id: 'l1',
+            eventType: EventTypeEnum::UserAction,
+            sourceName: 'http',
+            owner: $owner,
+        );
+
+        $arr = $log->toArray();
+
+        $this->assertSame(
+            ['id' => 'user-1', 'email' => 'owner@test.local', 'displayName' => 'Owner'],
+            $arr['owner'],
+        );
     }
 
     public function testToArrayRunningHasNullDuration(): void

--- a/back/tests/Unit/Notification/Domain/Service/ActivityLogEventHandlerTest.php
+++ b/back/tests/Unit/Notification/Domain/Service/ActivityLogEventHandlerTest.php
@@ -4,25 +4,45 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Notification\Domain\Service;
 
+use App\Auth\Domain\User;
 use App\Collection\Domain\CollectionRepositoryInterface;
 use App\Notification\Domain\ActivityLog;
+use App\Notification\Domain\ActivityLogOwnerResolverInterface;
 use App\Notification\Domain\ActivityLogRepositoryInterface;
 use App\Notification\Domain\EventTypeEnum;
 use App\Notification\Domain\Service\ActivityLogEventHandler;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ActivityLogEventHandlerTest extends TestCase
 {
     private ActivityLogRepositoryInterface&MockObject $logRepo;
     private CollectionRepositoryInterface&MockObject $collectionRepo;
+    private ActivityLogOwnerResolverInterface&MockObject $ownerResolver;
     private ActivityLogEventHandler $handler;
 
     protected function setUp(): void
     {
         $this->logRepo        = $this->createMock(ActivityLogRepositoryInterface::class);
         $this->collectionRepo = $this->createMock(CollectionRepositoryInterface::class);
-        $this->handler        = new ActivityLogEventHandler($this->logRepo, $this->collectionRepo);
+        $this->ownerResolver  = $this->createMock(ActivityLogOwnerResolverInterface::class);
+        $this->handler        = new ActivityLogEventHandler(
+            $this->logRepo,
+            $this->collectionRepo,
+            $this->ownerResolver,
+        );
+    }
+
+    private function makeUser(string $id = 'user-1', string $email = 'user@test.local'): User
+    {
+        return new User(
+            id: $id,
+            email: $email,
+            passwordHash: 'hash',
+            displayName: 'Test User',
+        );
     }
 
     public function testHandleStartedEventCreatesLog(): void
@@ -34,6 +54,26 @@ final class ActivityLogEventHandlerTest extends TestCase
 
         $this->logRepo->expects($this->once())->method('save');
         $this->collectionRepo->expects($this->never())->method('findById');
+
+        $this->handler->handleStartedEvent($event, EventTypeEnum::CollectionAction);
+    }
+
+    public function testHandleStartedEventAttributesCurrentUserAsOwner(): void
+    {
+        $owner = $this->makeUser();
+        $this->ownerResolver->method('currentOwner')->willReturn($owner);
+
+        $event = new class {
+            public string $correlationId = 'corr-owner';
+            public string $sourceName    = 'AddToCollection';
+        };
+
+        $this->logRepo->expects($this->once())
+            ->method('save')
+            ->with($this->callback(function (ActivityLog $log) use ($owner): bool {
+                $this->assertSame($owner, $log->owner);
+                return true;
+            }));
 
         $this->handler->handleStartedEvent($event, EventTypeEnum::CollectionAction);
     }
@@ -89,6 +129,53 @@ final class ActivityLogEventHandlerTest extends TestCase
         $this->assertSame(5, $log->newArticlesCount);
     }
 
+    public function testHandleSucceededEventAttributesOwnerFromUserId(): void
+    {
+        $log   = new ActivityLog(id: 'corr-uid', eventType: EventTypeEnum::AuthAction, sourceName: 'login');
+        $owner = $this->makeUser('user-42');
+
+        $event = new class {
+            public string $correlationId = 'corr-uid';
+            public string $userId        = 'user-42';
+            public string $email         = 'user@test.local';
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+        $this->ownerResolver->expects($this->once())
+            ->method('findById')
+            ->with('user-42')
+            ->willReturn($owner);
+        $this->logRepo->expects($this->once())->method('save');
+
+        $this->handler->handleSucceededEvent($event);
+
+        $this->assertSame($owner, $log->owner);
+        $this->assertSame(['email' => 'user@test.local'], $log->metadata);
+    }
+
+    public function testHandleSucceededEventKeepsExistingOwner(): void
+    {
+        $existingOwner = $this->makeUser('user-1');
+        $log           = new ActivityLog(
+            id: 'corr-keep',
+            eventType: EventTypeEnum::AuthAction,
+            sourceName: 'gate',
+            owner: $existingOwner,
+        );
+
+        $event = new class {
+            public string $correlationId = 'corr-keep';
+            public string $userId        = 'user-other';
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+        $this->ownerResolver->expects($this->never())->method('findById');
+
+        $this->handler->handleSucceededEvent($event);
+
+        $this->assertSame($existingOwner, $log->owner);
+    }
+
     public function testHandleSucceededEventWithForcedCount(): void
     {
         $log   = new ActivityLog(id: 'corr-4', eventType: EventTypeEnum::RssFetch, sourceName: 'rss');
@@ -142,6 +229,27 @@ final class ActivityLogEventHandlerTest extends TestCase
 
         $this->assertSame('error', $log->status);
         $this->assertSame('Connection timeout', $log->errorMessage);
+        $this->assertSame(['exception_class' => 'RuntimeException'], $log->metadata);
+    }
+
+    public function testHandleFailedEventKeepsSafeMetadata(): void
+    {
+        $log   = new ActivityLog(id: 'corr-f2', eventType: EventTypeEnum::AuthAction, sourceName: 'login');
+        $event = new class {
+            public string $correlationId  = 'corr-f2';
+            public string $error          = 'Invalid credentials';
+            public string $exceptionClass = 'RuntimeException';
+            public string $email          = 'attempt@test.local';
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+
+        $this->handler->handleFailedEvent($event);
+
+        $this->assertSame(
+            ['email' => 'attempt@test.local', 'exception_class' => 'RuntimeException'],
+            $log->metadata,
+        );
     }
 
     public function testHandleFailedEventSkipsIfNoCorrelationId(): void
@@ -161,6 +269,104 @@ final class ActivityLogEventHandlerTest extends TestCase
         $this->logRepo->expects($this->never())->method('save');
         $this->handler->handleFailedEvent($event);
     }
+
+    // ── Metadata sanitization ────────────────────────────────────────────────
+
+    public function testMetadataExcludesSensitivePropertyNames(): void
+    {
+        $log   = new ActivityLog(id: 'corr-s1', eventType: EventTypeEnum::AuthAction, sourceName: 'gate');
+        $event = new class {
+            public string $correlationId  = 'corr-s1';
+            public string $token          = 'jwt-token-value';
+            public string $accessToken    = 'another-secret';
+            public string $password       = 'hunter2';
+            public string $clientSecret   = 'shhh';
+            public string $jwtValue       = 'eyJ...';
+            public string $authorization  = 'Bearer xyz';
+            public string $apiKey         = 'key-123';
+            public string $email          = 'safe@test.local';
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+
+        $this->handler->handleSucceededEvent($event);
+
+        $this->assertSame(['email' => 'safe@test.local'], $log->metadata);
+    }
+
+    public function testMetadataFromGateSucceededEventNeverContainsToken(): void
+    {
+        $log   = new ActivityLog(id: 'corr-gate', eventType: EventTypeEnum::AuthAction, sourceName: 'gate');
+        $event = new \App\Auth\Shared\Event\GateSucceededEvent(correlationId: 'corr-gate', userId: 'user-1');
+
+        $this->logRepo->method('findById')->willReturn($log);
+
+        $this->handler->handleSucceededEvent($event);
+
+        $metadataJson = json_encode($log->metadata);
+        $this->assertIsString($metadataJson);
+        $this->assertStringNotContainsStringIgnoringCase('token', $metadataJson);
+    }
+
+    public function testMetadataKeepsOnlyScalarsAndArraysOfScalars(): void
+    {
+        $log   = new ActivityLog(id: 'corr-s2', eventType: EventTypeEnum::UserAction, sourceName: 'test');
+        $event = new class {
+            public string $correlationId = 'corr-s2';
+            public string $name          = 'value';
+            public int $number           = 7;
+            public float $ratio          = 0.5;
+            public bool $flag            = true;
+            public object $service;
+            /** @var array<string, mixed> */
+            public array $mixedArray;
+
+            public function __construct()
+            {
+                $this->service    = new \stdClass();
+                $this->mixedArray = ['keep' => 'yes', 'drop' => new \stdClass(), 'secretKey' => 'no'];
+            }
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+
+        $this->handler->handleSucceededEvent($event);
+
+        $this->assertSame(
+            [
+                'name'       => 'value',
+                'number'     => 7,
+                'ratio'      => 0.5,
+                'flag'       => true,
+                'mixedArray' => ['keep' => 'yes'],
+            ],
+            $log->metadata,
+        );
+    }
+
+    public function testMetadataTruncatesLongStrings(): void
+    {
+        $log   = new ActivityLog(id: 'corr-s3', eventType: EventTypeEnum::UserAction, sourceName: 'test');
+        $event = new class {
+            public string $correlationId = 'corr-s3';
+            public string $longText;
+
+            public function __construct()
+            {
+                $this->longText = str_repeat('a', 800);
+            }
+        };
+
+        $this->logRepo->method('findById')->willReturn($log);
+
+        $this->handler->handleSucceededEvent($event);
+
+        $this->assertIsArray($log->metadata);
+        $this->assertIsString($log->metadata['longText']);
+        $this->assertSame(500, mb_strlen($log->metadata['longText']));
+    }
+
+    // ── Event type detection ─────────────────────────────────────────────────
 
     #[\PHPUnit\Framework\Attributes\DataProvider('provideDetectEventTypeEnum')]
     public function testDetectEventTypeEnum(string $namespace, EventTypeEnum $expected): void
@@ -186,7 +392,7 @@ final class ActivityLogEventHandlerTest extends TestCase
 
     public function testDetectEventTypeEnumForAuthEvent(): void
     {
-        $event = new \App\Auth\Shared\Event\GateSucceededEvent(correlationId: 'c', token: 'tok');
+        $event = new \App\Auth\Shared\Event\GateSucceededEvent(correlationId: 'c', userId: 'user-1');
         $this->assertSame(EventTypeEnum::AuthAction, $this->handler->detectEventTypeEnum($event));
     }
 
@@ -202,12 +408,15 @@ final class ActivityLogEventHandlerTest extends TestCase
         $this->assertSame(EventTypeEnum::MangaAction, $this->handler->detectEventTypeEnum($event));
     }
 
-    public function testDetectEventTypeEnumForWishlistEvent(): void
+    public function testDetectEventTypeEnumForWishlistEventInCollectionModule(): void
     {
-        $event = new class {
-            public string $fakeNamespace = 'App\\Wishlist\\Shared\\Event\\FakeEvent';
-        };
-        // anonymous class won't match namespace detection — remains UserAction
-        $this->assertSame(EventTypeEnum::UserAction, $this->handler->detectEventTypeEnum($event));
+        $event = new \App\Collection\Shared\Event\ClearWishlistStartedEvent(collectionEntryId: 'ce-1');
+        $this->assertSame(EventTypeEnum::WishlistAction, $this->handler->detectEventTypeEnum($event));
+    }
+
+    public function testDetectEventTypeEnumForAddRemainingToWishlistEvent(): void
+    {
+        $event = new \App\Collection\Shared\Event\AddRemainingToWishlistStartedEvent(collectionEntryId: 'ce-1');
+        $this->assertSame(EventTypeEnum::WishlistAction, $this->handler->detectEventTypeEnum($event));
     }
 }

--- a/back/tests/Unit/Notification/Domain/Service/ActivityLogPurgerTest.php
+++ b/back/tests/Unit/Notification/Domain/Service/ActivityLogPurgerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Domain\Service;
+
+use App\Notification\Domain\ActivityLogRepositoryInterface;
+use App\Notification\Domain\Service\ActivityLogPurger;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+
+#[AllowMockObjectsWithoutExpectations]
+final class ActivityLogPurgerTest extends TestCase
+{
+    public function testPurgeDeletesLogsOlderThanGivenDays(): void
+    {
+        $repository = $this->createMock(ActivityLogRepositoryInterface::class);
+
+        $repository->expects($this->once())
+            ->method('deleteOlderThan')
+            ->with($this->callback(function (DateTimeImmutable $cutoff): bool {
+                $expected = new DateTimeImmutable('-30 days');
+                $driftSeconds = abs($cutoff->getTimestamp() - $expected->getTimestamp());
+                $this->assertLessThan(5, $driftSeconds);
+                return true;
+            }))
+            ->willReturn(12);
+
+        $purger = new ActivityLogPurger($repository);
+
+        $this->assertSame(12, $purger->purgeOlderThanDays(30));
+    }
+
+    public function testPurgeDefaultsToNinetyDays(): void
+    {
+        $repository = $this->createMock(ActivityLogRepositoryInterface::class);
+
+        $repository->expects($this->once())
+            ->method('deleteOlderThan')
+            ->with($this->callback(function (DateTimeImmutable $cutoff): bool {
+                $expected = new DateTimeImmutable('-90 days');
+                $driftSeconds = abs($cutoff->getTimestamp() - $expected->getTimestamp());
+                $this->assertLessThan(5, $driftSeconds);
+                return true;
+            }))
+            ->willReturn(0);
+
+        $purger = new ActivityLogPurger($repository);
+
+        $this->assertSame(0, $purger->purgeOlderThanDays());
+    }
+
+    public function testPurgeRejectsRetentionBelowOneDay(): void
+    {
+        $repository = $this->createMock(ActivityLogRepositoryInterface::class);
+        $repository->expects($this->never())->method('deleteOlderThan');
+
+        $purger = new ActivityLogPurger($repository);
+
+        $this->expectException(InvalidArgumentException::class);
+        $purger->purgeOlderThanDays(0);
+    }
+}

--- a/back/tests/Unit/Notification/Infrastructure/Messenger/WorkerFailureSubscriberTest.php
+++ b/back/tests/Unit/Notification/Infrastructure/Messenger/WorkerFailureSubscriberTest.php
@@ -6,10 +6,12 @@ namespace App\Tests\Unit\Notification\Infrastructure\Messenger;
 
 use App\Notification\Domain\ActivityLog;
 use App\Notification\Domain\ActivityLogRepositoryInterface;
+use App\Notification\Domain\EventTypeEnum;
 use App\Notification\Domain\DiscordNotifierInterface;
 use App\Notification\Domain\Service\RssFeedParserException;
 use App\Notification\Infrastructure\Messenger\WorkerFailureSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
@@ -19,6 +21,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Throwable;
 
+#[AllowMockObjectsWithoutExpectations]
 final class WorkerFailureSubscriberTest extends TestCase
 {
     private ActivityLogRepositoryInterface&MockObject $activityLogRepository;
@@ -39,12 +42,25 @@ final class WorkerFailureSubscriberTest extends TestCase
     {
         $event = $this->makeEvent(new RuntimeException('boom in our code'));
 
-        $this->expectLogSavedWithExternalFlag(false);
+        /** @var list<ActivityLog> $savedLogs */
+        $savedLogs = [];
+        $this->activityLogRepository->method('save')
+            ->willReturnCallback(static function (ActivityLog $log) use (&$savedLogs): void {
+                $savedLogs[] = $log;
+            });
         $this->activityLogRepository->method('countRecentErrors')->willReturn(5);
 
         $this->discord->expects($this->once())->method('sendAlert');
 
         ($this->subscriber)($event);
+
+        // First log: the worker failure itself; second log: the Discord alert sent.
+        $this->assertCount(2, $savedLogs);
+        $this->assertSame('error', $savedLogs[0]->status);
+        $this->assertSame(EventTypeEnum::WorkerFailure, $savedLogs[0]->eventType);
+        $this->assertSame(EventTypeEnum::DiscordSent, $savedLogs[1]->eventType);
+        $this->assertSame('success', $savedLogs[1]->status);
+        $this->assertSame('discord', $savedLogs[1]->sourceName);
     }
 
     public function testAppBugDoesNotAlertBelowThreshold(): void

--- a/front/src/api/manga.ts
+++ b/front/src/api/manga.ts
@@ -130,7 +130,14 @@ export async function autoFillCovers(
   return res.data
 }
 
-export type EditionFormat = 'broche' | 'relie' | 'coffret' | 'deluxe' | 'omnibus' | 'unknown'
+export type EditionFormat =
+  | 'broche'
+  | 'relie'
+  | 'coffret'
+  | 'deluxe'
+  | 'omnibus'
+  | 'artbook'
+  | 'unknown'
 
 export interface ExternalEdition {
   workTitle: string
@@ -173,8 +180,19 @@ export interface PriceOffer {
   source: string
 }
 
+export type Retailer = 'amazon' | 'fnac' | 'ebay'
+export type RetailerStatus = 'found' | 'not_found'
+
+export interface RetailerOffer {
+  retailer: Retailer
+  label: string
+  status: RetailerStatus
+  bestOffer: PriceOffer | null
+}
+
 export interface VolumePricesResponse {
   offers: PriceOffer[]
+  retailers: RetailerOffer[]
   hasIsbn: boolean
   marketplace: string | null
 }

--- a/front/src/api/notification.ts
+++ b/front/src/api/notification.ts
@@ -29,6 +29,13 @@ export interface ActivityLogParams {
   eventType?: string
   status?: string
   collectionEntryId?: string
+  ownerId?: string
+  /** ISO 8601 / ATOM datetime lower bound */
+  from?: string
+  /** ISO 8601 / ATOM datetime upper bound */
+  to?: string
+  /** Free-text search on source, error message and request path */
+  search?: string
 }
 
 export async function getActivityLogs(params: ActivityLogParams = {}): Promise<ActivityLogPage> {

--- a/front/src/assets/main.css
+++ b/front/src/assets/main.css
@@ -88,6 +88,49 @@
 @layer base {
   :root {
     --transition-speed: 200ms;
+    /* iOS safe areas (PWA standalone, viewport-fit=cover) — 0px elsewhere */
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+  }
+}
+
+/* ── iOS safe-area utilities ────────────────────────────────────────────────
+   Reusable helpers so env(safe-area-inset-*) is never repeated inline.
+   - safe-top / safe-bottom : bare padding equal to the inset
+   - pb-safe-sheet          : bottom-sheet footer padding + home-indicator room
+   - pt-mobile-header /
+     top-mobile-header      : offset for content under the fixed mobile header
+                              (h-14 = 3.5rem, grown by the notch inset)
+   - mb-safe                : margin clearance above the home indicator      */
+
+@utility safe-top {
+  padding-top: var(--safe-top);
+}
+@utility safe-bottom {
+  padding-bottom: var(--safe-bottom);
+}
+@utility pb-safe-sheet {
+  padding-bottom: calc(1.5rem + var(--safe-bottom));
+}
+@utility pt-mobile-header {
+  padding-top: calc(3.5rem + var(--safe-top));
+}
+@utility top-mobile-header {
+  top: calc(3.5rem + var(--safe-top));
+}
+@utility mb-safe {
+  margin-bottom: var(--safe-bottom);
+}
+
+/* ── Tooltips on mobile ─────────────────────────────────────────────────────
+   DaisyUI tooltip bubbles are absolutely positioned and rendered at opacity 0
+   even when idle: side-positioned ones (tooltip-right…) silently widen the
+   page and create an invisible horizontal body scroll on small screens.
+   Tooltips are a hover affordance — disable the bubbles below `sm`.         */
+@media (max-width: 639px) {
+  .tooltip::before,
+  .tooltip::after {
+    display: none;
   }
 }
 

--- a/front/src/components/atoms/BaseHeartRating.vue
+++ b/front/src/components/atoms/BaseHeartRating.vue
@@ -151,7 +151,7 @@ function onClick(heartIndex: number, half: 'left' | 'right') {
           enter-from-class="translate-y-full"
           leave-to-class="translate-y-full"
         >
-          <div v-if="sheetOpen" class="relative bg-base-100 rounded-t-2xl shadow-xl pb-10">
+          <div v-if="sheetOpen" class="relative bg-base-100 rounded-t-2xl shadow-xl pb-safe-sheet">
             <!-- Handle -->
             <div class="w-10 h-1 bg-base-300 rounded-full mx-auto mt-3 mb-2" />
 

--- a/front/src/components/atoms/BaseMerchantLogo.vue
+++ b/front/src/components/atoms/BaseMerchantLogo.vue
@@ -29,6 +29,58 @@ defineProps<{
       </text>
     </svg>
 
+    <!-- Amazon — sober wordmark + orange smile arrow (not a trademark copy) -->
+    <svg
+      v-else-if="logo === 'amazon'"
+      class="h-full w-full"
+      viewBox="0 0 64 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <text
+        x="2"
+        y="15"
+        font-family="Arial, Helvetica, sans-serif"
+        font-size="13"
+        font-weight="bold"
+        letter-spacing="-0.5"
+        fill="currentColor"
+      >
+        amazon
+      </text>
+      <path
+        d="M8 18 C 20 23.5, 40 23.5, 52 18"
+        stroke="#FF9900"
+        stroke-width="2"
+        fill="none"
+        stroke-linecap="round"
+      />
+      <path d="M52 18 l-4.5 -0.6 M52 18 l-2.4 3.4" stroke="#FF9900" stroke-width="2" fill="none" stroke-linecap="round" />
+    </svg>
+
+    <!-- Fnac — sober mustard tile with italic lowercase wordmark (not a trademark copy) -->
+    <svg
+      v-else-if="logo === 'fnac'"
+      class="h-full w-full"
+      viewBox="0 0 48 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <rect x="0" y="0" width="48" height="24" rx="5" fill="#E9AA00" />
+      <text
+        x="24"
+        y="17"
+        text-anchor="middle"
+        font-family="Arial, Helvetica, sans-serif"
+        font-size="14"
+        font-weight="bold"
+        font-style="italic"
+        fill="#332F2C"
+      >
+        fnac
+      </text>
+    </svg>
+
     <!-- Google Play — multicolour G mark -->
     <svg
       v-else-if="logo === 'google_play'"

--- a/front/src/components/atoms/BaseModal.vue
+++ b/front/src/components/atoms/BaseModal.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, onUnmounted } from 'vue'
+
+/**
+ * Shared modal shell — single source of truth for every dialog in the app.
+ *
+ * Behaviour:
+ * - Teleported to <body> with a blurred backdrop and a springy transition.
+ * - `sheet` variant (default): bottom sheet on mobile (slides from the bottom,
+ *   safe-area padding for the iOS home indicator), centered dialog from `sm:`.
+ * - `center` variant: always a centered dialog (confirmations, small forms).
+ * - Closes on Escape and backdrop click (both opt-out), never taller than the
+ *   dynamic viewport, and keeps Tab focus inside while open.
+ */
+const props = withDefaults(defineProps<{
+  open: boolean
+  /** 'sheet' = bottom sheet mobile / centered desktop · 'center' = always centered */
+  variant?: 'sheet' | 'center'
+  /** Desktop max-width utility class applied to the panel */
+  maxWidthClass?: string
+  /** Extra classes on the panel (fixed heights, paddings…) */
+  panelClass?: string
+  /** Stacking utility class for the overlay */
+  zClass?: string
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+}>(), {
+  variant: 'sheet',
+  maxWidthClass: 'sm:max-w-md',
+  panelClass: '',
+  zClass: 'z-[70]',
+  closeOnBackdrop: true,
+  closeOnEscape: true,
+})
+
+const emit = defineEmits<{ close: [] }>()
+
+const panelRef = ref<HTMLElement | null>(null)
+
+function onBackdropClick(): void {
+  if (props.closeOnBackdrop) emit('close')
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape' && props.closeOnEscape) {
+    emit('close')
+    return
+  }
+  if (event.key !== 'Tab' || !panelRef.value) return
+  // Minimal focus trap: wrap Tab / Shift+Tab at the panel boundaries.
+  const focusables = panelRef.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+  if (focusables.length === 0) {
+    event.preventDefault()
+    panelRef.value.focus()
+    return
+  }
+  const first = focusables[0]
+  const last = focusables[focusables.length - 1]
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || active === panelRef.value)) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+watch(() => props.open, async (open) => {
+  if (open) {
+    window.addEventListener('keydown', onKeydown)
+    await nextTick()
+    panelRef.value?.focus()
+  } else {
+    window.removeEventListener('keydown', onKeydown)
+  }
+}, { immediate: true })
+
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="base-modal">
+      <div
+        v-if="open"
+        class="fixed inset-0 flex justify-center"
+        :class="[
+          zClass,
+          variant === 'sheet' ? 'items-end sm:items-center p-0 sm:p-4' : 'items-center p-4',
+        ]"
+        role="dialog"
+        aria-modal="true"
+      >
+        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="onBackdropClick" />
+
+        <div
+          ref="panelRef"
+          tabindex="-1"
+          class="base-modal-panel relative z-10 w-full bg-base-100 shadow-2xl overflow-hidden flex flex-col max-h-[92dvh] outline-none"
+          :class="[
+            variant === 'sheet'
+              ? 'rounded-t-3xl sm:rounded-2xl safe-bottom sm:pb-0'
+              : 'rounded-2xl',
+            maxWidthClass,
+            panelClass,
+          ]"
+        >
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.base-modal-enter-active,
+.base-modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.base-modal-enter-active .base-modal-panel,
+.base-modal-leave-active .base-modal-panel {
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.base-modal-enter-from,
+.base-modal-leave-to {
+  opacity: 0;
+}
+.base-modal-enter-from .base-modal-panel {
+  transform: translateY(40px) scale(0.97);
+}
+</style>

--- a/front/src/components/atoms/__tests__/BaseModal.spec.ts
+++ b/front/src/components/atoms/__tests__/BaseModal.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import BaseModal from '../BaseModal.vue'
+
+function mountModal(props: Partial<InstanceType<typeof BaseModal>['$props']> = {}, slotContent = '<p>Contenu du dialogue</p>') {
+  return mount(BaseModal, {
+    props: { open: true, ...props },
+    slots: { default: slotContent },
+  })
+}
+
+function pressEscape(): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+}
+
+describe('BaseModal', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders nothing while closed', () => {
+    mountModal({ open: false })
+    expect(document.body.textContent).not.toContain('Contenu du dialogue')
+  })
+
+  it('renders the slot content in a teleported dialog when open', () => {
+    mountModal()
+    expect(document.body.textContent).toContain('Contenu du dialogue')
+    const dialog = document.body.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(dialog!.getAttribute('aria-modal')).toBe('true')
+  })
+
+  it('uses the bottom-sheet layout by default and the centered layout with variant center', () => {
+    const sheet = mountModal()
+    expect(document.body.querySelector('[role="dialog"]')!.className).toContain('items-end')
+    sheet.unmount()
+    document.body.innerHTML = ''
+
+    mountModal({ variant: 'center' })
+    const dialogClass = document.body.querySelector('[role="dialog"]')!.className
+    expect(dialogClass).toContain('items-center')
+    expect(dialogClass).not.toContain('items-end')
+  })
+
+  it('applies safe-area bottom padding to the sheet panel', () => {
+    mountModal()
+    const panel = document.body.querySelector('.base-modal-panel')!
+    expect(panel.className).toContain('safe-bottom')
+  })
+
+  it('emits close when the backdrop is clicked', async () => {
+    const wrapper = mountModal()
+    const backdrop = document.body.querySelector('[role="dialog"] > div') as HTMLElement
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('does not emit close on backdrop click when closeOnBackdrop is false', async () => {
+    const wrapper = mountModal({ closeOnBackdrop: false })
+    const backdrop = document.body.querySelector('[role="dialog"] > div') as HTMLElement
+    backdrop.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeFalsy()
+  })
+
+  it('emits close on Escape', async () => {
+    const wrapper = mountModal()
+    pressEscape()
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('does not emit close on Escape when closeOnEscape is false', async () => {
+    const wrapper = mountModal({ closeOnEscape: false })
+    pressEscape()
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeFalsy()
+  })
+
+  it('stops listening for Escape once closed', async () => {
+    const wrapper = mountModal()
+    await wrapper.setProps({ open: false })
+    pressEscape()
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeFalsy()
+  })
+
+  it('keeps Tab focus inside the panel', async () => {
+    mountModal({}, '<button id="first">Premier</button><button id="last">Dernier</button>')
+    await nextTick()
+    const last = document.getElementById('last') as HTMLButtonElement
+    last.focus()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }))
+    await nextTick()
+    expect(document.activeElement?.id).toBe('first')
+  })
+})

--- a/front/src/components/molecules/ActivityLogCard.vue
+++ b/front/src/components/molecules/ActivityLogCard.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ChevronDown } from 'lucide-vue-next'
+import type { ActivityLog } from '@/types'
+import { EVENT_TYPE_BADGES, EVENT_TYPE_LABELS, STATUS_BADGES, formatDuration } from '@/utils/activityLog'
+import ActivityLogDetail from '@/components/molecules/ActivityLogDetail.vue'
+
+defineProps<{ log: ActivityLog }>()
+
+const { t, locale } = useI18n()
+const expanded = ref(false)
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(locale.value === 'fr' ? 'fr-FR' : 'en-GB')
+}
+</script>
+
+<template>
+  <div
+    class="rounded-xl border border-base-300 bg-base-100 p-3 space-y-2"
+    :class="{ 'border-error/40 bg-error/5': log.status === 'error' }"
+    @click="expanded = !expanded"
+  >
+    <div class="flex items-center gap-2 flex-wrap">
+      <span class="badge badge-xs" :class="EVENT_TYPE_BADGES[log.eventType]">
+        {{ EVENT_TYPE_LABELS[log.eventType] ?? log.eventType }}
+      </span>
+      <span class="badge badge-xs" :class="STATUS_BADGES[log.status]">
+        {{ t(`journal.${log.status}`) }}
+      </span>
+      <span class="ml-auto text-[11px] text-base-content/50 whitespace-nowrap">
+        {{ formatDate(log.startedAt) }}
+      </span>
+      <ChevronDown
+        class="w-3.5 h-3.5 text-base-content/40 transition-transform"
+        :class="{ 'rotate-180': expanded }"
+      />
+    </div>
+
+    <div class="text-xs flex items-center justify-between gap-2">
+      <span class="truncate">
+        {{ log.owner?.displayName ?? log.owner?.email ?? t('journal.system') }}
+      </span>
+      <span class="text-base-content/40 tabular-nums whitespace-nowrap">
+        {{ formatDuration(log.durationMs) }}
+      </span>
+    </div>
+
+    <div class="text-xs text-base-content/60 truncate">
+      {{ log.sourceName }}<template v-if="log.mangaTitle"> · {{ log.mangaTitle }}</template>
+    </div>
+
+    <div v-if="expanded" class="pt-2 border-t border-base-300">
+      <ActivityLogDetail :log="log" />
+    </div>
+  </div>
+</template>

--- a/front/src/components/molecules/ActivityLogDetail.vue
+++ b/front/src/components/molecules/ActivityLogDetail.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Copy } from 'lucide-vue-next'
+import { useUiStore } from '@/stores/useUiStore'
+import type { ActivityLog } from '@/types'
+
+const props = defineProps<{ log: ActivityLog }>()
+
+const { t } = useI18n()
+const ui = useUiStore()
+
+const metadataEntries = computed(() =>
+  Object.entries(props.log.metadata ?? {}).map(([key, value]) => ({
+    key,
+    value: typeof value === 'string' ? value : JSON.stringify(value),
+  })),
+)
+
+async function copyJson(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(props.log, null, 2))
+    ui.addToast(t('journal.copied'), 'success')
+  } catch {
+    ui.addToast(t('journal.copyFailed'), 'error')
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-3 text-xs">
+    <div
+      v-if="log.errorMessage"
+      class="rounded-lg border border-error/40 bg-error/10 text-error px-3 py-2 font-mono whitespace-pre-wrap break-all"
+    >
+      {{ log.errorMessage }}
+    </div>
+
+    <div v-if="log.owner" class="text-base-content/60">
+      {{ t('journal.user') }} :
+      <span class="font-medium text-base-content">{{ log.owner.displayName }}</span>
+      <span class="text-base-content/50"> — {{ log.owner.email }}</span>
+    </div>
+
+    <div v-if="metadataEntries.length" class="overflow-x-auto rounded-lg border border-base-300">
+      <table class="table table-xs w-full">
+        <tbody>
+          <tr v-for="entry in metadataEntries" :key="entry.key">
+            <td class="font-mono text-base-content/50 whitespace-nowrap align-top w-36">
+              {{ entry.key }}
+            </td>
+            <td class="font-mono break-all">{{ entry.value }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-else-if="!log.errorMessage" class="text-base-content/40">
+      {{ t('journal.noMetadata') }}
+    </div>
+
+    <button class="btn btn-xs btn-ghost gap-1" @click.stop="copyJson">
+      <Copy class="w-3 h-3" />
+      {{ t('journal.copyJson') }}
+    </button>
+  </div>
+</template>

--- a/front/src/components/molecules/ActivityLogRow.vue
+++ b/front/src/components/molecules/ActivityLogRow.vue
@@ -1,28 +1,18 @@
 <script setup lang="ts">
-import type { ActivityLog, EventType } from '@/types'
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ChevronRight } from 'lucide-vue-next'
+import type { ActivityLog } from '@/types'
+import { EVENT_TYPE_BADGES, EVENT_TYPE_LABELS, STATUS_BADGES, formatDuration } from '@/utils/activityLog'
+import ActivityLogDetail from '@/components/molecules/ActivityLogDetail.vue'
 
 defineProps<{ log: ActivityLog }>()
+
+const { t, locale } = useI18n()
 const expanded = ref(false)
 
-const eventTypeLabel: Record<EventType, string> = {
-  rss_fetch:         'RSS',
-  jikan_fetch:       'Jikan',
-  discord_sent:      'Discord',
-  scheduler_fire:    'Scheduler',
-  http_error:        'HTTP Error',
-  worker_failure:    'Worker',
-  user_action:       'API',
-  collection_action: 'Collection',
-  manga_action:      'Manga',
-  auth_action:       'Auth',
-  wishlist_action:   'Wishlist',
-}
-
-const statusClass: Record<string, string> = {
-  running: 'badge-warning',
-  success: 'badge-success',
-  error:   'badge-error',
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(locale.value === 'fr' ? 'fr-FR' : 'en-GB')
 }
 </script>
 
@@ -32,34 +22,39 @@ const statusClass: Record<string, string> = {
     :class="{ 'bg-error/5': log.status === 'error' }"
     @click="expanded = !expanded"
   >
+    <td class="w-6 pr-0">
+      <ChevronRight
+        class="w-3 h-3 text-base-content/40 transition-transform"
+        :class="{ 'rotate-90': expanded }"
+      />
+    </td>
     <td class="text-[11px] text-base-content/50 whitespace-nowrap">
-      {{ new Date(log.startedAt).toLocaleString('fr-FR') }}
+      {{ formatDate(log.startedAt) }}
     </td>
     <td>
-      <span class="badge badge-xs badge-outline font-mono">
-        {{ eventTypeLabel[log.eventType] ?? log.eventType }}
+      <span class="badge badge-xs" :class="EVENT_TYPE_BADGES[log.eventType]">
+        {{ EVENT_TYPE_LABELS[log.eventType] ?? log.eventType }}
       </span>
     </td>
-    <td class="text-xs truncate max-w-40">{{ log.mangaTitle ?? '—' }}</td>
-    <td class="text-xs text-base-content/60 truncate max-w-32">{{ log.sourceName }}</td>
+    <td class="text-xs truncate max-w-40" :title="log.owner?.email">
+      {{ log.owner?.displayName ?? log.owner?.email ?? t('journal.system') }}
+    </td>
+    <td class="text-xs text-base-content/60 truncate max-w-48">
+      {{ log.sourceName }}<template v-if="log.mangaTitle"> · {{ log.mangaTitle }}</template>
+    </td>
     <td>
-      <span class="badge badge-xs" :class="statusClass[log.status]">{{ log.status }}</span>
-    </td>
-    <td class="text-xs text-right tabular-nums">
-      <span v-if="log.newArticlesCount !== null" class="text-success font-semibold">
-        +{{ log.newArticlesCount }}
+      <span class="badge badge-xs" :class="STATUS_BADGES[log.status]">
+        {{ t(`journal.${log.status}`) }}
       </span>
-      <span v-else>—</span>
     </td>
-    <td class="text-xs text-right tabular-nums text-base-content/40">
-      {{ log.durationMs !== null ? `${log.durationMs}ms` : '—' }}
+    <td class="text-xs text-right tabular-nums text-base-content/40 whitespace-nowrap">
+      {{ formatDuration(log.durationMs) }}
     </td>
   </tr>
   <!-- Expanded detail row -->
   <tr v-if="expanded">
-    <td colspan="7" class="bg-base-200 px-4 py-3 text-xs font-mono">
-      <div v-if="log.errorMessage" class="text-error mb-2">{{ log.errorMessage }}</div>
-      <pre v-if="log.metadata" class="text-base-content/60 whitespace-pre-wrap text-[10px]">{{ JSON.stringify(log.metadata, null, 2) }}</pre>
+    <td colspan="7" class="bg-base-200/60 px-4 py-3">
+      <ActivityLogDetail :log="log" />
     </td>
   </tr>
 </template>

--- a/front/src/components/molecules/PriceOfferCard.vue
+++ b/front/src/components/molecules/PriceOfferCard.vue
@@ -3,22 +3,11 @@ import { ExternalLink } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import type { PriceOffer } from '@/api/manga'
 import BaseMerchantLogo from '@/components/atoms/BaseMerchantLogo.vue'
+import { formatPrice } from '@/utils/price'
 
 defineProps<{ offer: PriceOffer }>()
 
 const { t } = useI18n()
-
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  EUR: '€',
-  USD: '$',
-  GBP: '£',
-  JPY: '¥',
-}
-
-function formatPrice(amount: number, currency: string): string {
-  const symbol = CURRENCY_SYMBOLS[currency] ?? currency
-  return amount.toFixed(2) + ' ' + symbol
-}
 </script>
 
 <template>
@@ -47,7 +36,7 @@ function formatPrice(amount: number, currency: string): string {
         target="_blank"
         rel="noopener noreferrer"
         class="btn btn-ghost btn-xs btn-circle"
-        :aria-label="`Voir sur ${offer.merchant}`"
+        :aria-label="t('prices.viewOn', { merchant: offer.merchant })"
       >
         <ExternalLink class="h-3.5 w-3.5" />
       </a>

--- a/front/src/components/molecules/RetailerPriceCard.vue
+++ b/front/src/components/molecules/RetailerPriceCard.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ExternalLink, SearchX } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import type { RetailerOffer } from '@/api/manga'
+import BaseMerchantLogo from '@/components/atoms/BaseMerchantLogo.vue'
+import { formatPrice } from '@/utils/price'
+
+const props = defineProps<{ retailer: RetailerOffer }>()
+
+const { t } = useI18n()
+
+const found = computed(() => props.retailer.status === 'found' && props.retailer.bestOffer !== null)
+</script>
+
+<template>
+  <component
+    :is="found && retailer.bestOffer?.url ? 'a' : 'div'"
+    :href="found ? (retailer.bestOffer?.url ?? undefined) : undefined"
+    :target="found && retailer.bestOffer?.url ? '_blank' : undefined"
+    :rel="found && retailer.bestOffer?.url ? 'noopener noreferrer' : undefined"
+    class="flex flex-col items-center gap-2 p-3 rounded-xl border text-center transition-all duration-150"
+    :class="found
+      ? 'border-base-300/70 bg-base-100 hover:border-primary/50 hover:shadow-md'
+      : 'border-base-300/40 bg-base-200/40 opacity-60'"
+    :aria-label="found ? t('prices.viewOn', { merchant: retailer.label }) : `${retailer.label} — ${t('prices.notFound')}`"
+  >
+    <div class="h-6 w-16 flex items-center justify-center" :class="found ? '' : 'grayscale'">
+      <BaseMerchantLogo :logo="retailer.retailer" class="h-full w-full" />
+    </div>
+
+    <template v-if="found && retailer.bestOffer">
+      <span class="text-base font-bold tabular-nums leading-none">
+        {{ formatPrice(retailer.bestOffer.amount, retailer.bestOffer.currency) }}
+      </span>
+      <span v-if="retailer.bestOffer.url" class="inline-flex items-center gap-1 text-[11px] text-primary/80 font-medium">
+        <ExternalLink class="h-3 w-3" />
+        {{ t('prices.viewOn', { merchant: retailer.label }) }}
+      </span>
+    </template>
+
+    <template v-else>
+      <span class="inline-flex items-center gap-1 text-xs text-base-content/40 font-medium">
+        <SearchX class="h-3.5 w-3.5" />
+        {{ t('prices.notFound') }}
+      </span>
+    </template>
+  </component>
+</template>

--- a/front/src/components/organisms/CollectionGuideModal.vue
+++ b/front/src/components/organisms/CollectionGuideModal.vue
@@ -6,6 +6,7 @@ import {
   Search, QrCode, Camera, Link2, Sparkles, Lightbulb, Info, Barcode, BookOpenText,
 } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
+import BaseModal from '@/components/atoms/BaseModal.vue'
 
 const { t } = useI18n()
 
@@ -52,231 +53,205 @@ const COVER_SOURCES = ['mangadex', 'googlebooks', 'bnf', 'openlibrary', 'hardcov
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="guide">
-      <div
-        v-if="open"
-        class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-0 sm:p-4"
-        role="dialog"
-        aria-modal="true"
-      >
-        <div class="absolute inset-0 bg-black/70 backdrop-blur-sm" @click="emit('close')" />
-
-        <div class="relative z-10 w-full sm:max-w-2xl bg-base-100 rounded-t-3xl sm:rounded-2xl shadow-2xl overflow-hidden flex flex-col h-[88dvh] sm:h-[640px]">
-          <!-- Header -->
-          <div class="flex items-center justify-between px-5 py-4 border-b border-base-200 bg-gradient-to-br from-primary/8 to-transparent">
-            <div class="flex items-center gap-2.5">
-              <div class="w-9 h-9 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
-                <Info class="h-5 w-5" />
-              </div>
-              <div>
-                <h2 class="font-bold text-lg leading-tight">{{ t('guide.title') }}</h2>
-                <p class="text-xs text-base-content/50">{{ t('guide.subtitle') }}</p>
-              </div>
-            </div>
-            <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
-              <X class="h-4 w-4" />
-            </button>
-          </div>
-
-          <!-- Tabs -->
-          <div class="px-3 sm:px-5 pt-3 shrink-0">
-            <div class="inline-flex p-1 bg-base-200 rounded-xl gap-1 w-full sm:w-auto">
-              <button
-                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
-                :class="tab === 'statuses' ? 'btn-primary' : 'btn-ghost'"
-                @click="tab = 'statuses'"
-              >
-                <BookMarked class="h-4 w-4" />
-                <span>{{ t('guide.tabStatuses') }}</span>
-              </button>
-              <button
-                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
-                :class="tab === 'dashboard' ? 'btn-primary' : 'btn-ghost'"
-                @click="tab = 'dashboard'"
-              >
-                <PieChart class="h-4 w-4" />
-                <span>{{ t('guide.tabDashboard') }}</span>
-              </button>
-              <button
-                class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
-                :class="tab === 'covers' ? 'btn-primary' : 'btn-ghost'"
-                @click="tab = 'covers'"
-              >
-                <Search class="h-4 w-4" />
-                <span>{{ t('guide.tabCovers') }}</span>
-              </button>
-            </div>
-          </div>
-
-          <!-- Content -->
-          <div class="flex-1 overflow-y-auto px-5 py-4 min-h-0">
-            <!-- ── Statuses ── -->
-            <div v-if="tab === 'statuses'" class="space-y-4">
-              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.statusesIntro') }}</p>
-
-              <ul class="space-y-2.5">
-                <li
-                  v-for="s in STATUSES"
-                  :key="s.key"
-                  class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
-                >
-                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="s.chip">
-                    <component :is="s.icon" class="h-5 w-5" />
-                  </div>
-                  <div class="min-w-0">
-                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.status.${s.key}.name`) }}</p>
-                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.status.${s.key}.desc`) }}</p>
-                  </div>
-                </li>
-              </ul>
-
-              <div class="rounded-xl bg-primary/5 border border-primary/15 p-3.5">
-                <p class="flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-primary/80 mb-2">
-                  <Lightbulb class="h-3.5 w-3.5" />
-                  {{ t('guide.rulesTitle') }}
-                </p>
-                <ul class="space-y-1.5">
-                  <li
-                    v-for="rule in RULES"
-                    :key="rule"
-                    class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
-                  >
-                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-primary/60 shrink-0" />
-                    {{ t(`guide.${rule}`) }}
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <!-- ── Dashboard ── -->
-            <div v-else-if="tab === 'dashboard'" class="space-y-4">
-              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.dashboardIntro') }}</p>
-
-              <ul class="space-y-2.5">
-                <li
-                  v-for="m in METRICS"
-                  :key="m.key"
-                  class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
-                >
-                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="m.chip">
-                    <component :is="m.icon" class="h-5 w-5" />
-                  </div>
-                  <div class="min-w-0">
-                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.metric.${m.key}.name`) }}</p>
-                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.metric.${m.key}.formula`) }}</p>
-                  </div>
-                </li>
-              </ul>
-
-              <div class="rounded-xl bg-secondary/5 border border-secondary/15 p-3.5">
-                <p class="flex items-start gap-2 text-xs text-base-content/65 leading-snug">
-                  <Wallet class="h-4 w-4 text-secondary shrink-0 mt-px" />
-                  {{ t('guide.priceNote') }}
-                </p>
-              </div>
-            </div>
-
-            <!-- ── Covers ── -->
-            <div v-else class="space-y-4">
-              <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.coversIntro') }}</p>
-
-              <!-- ── What is an ISBN? — illustrated explainer (mirrors the volume "ISBN du tome" hint) ── -->
-              <div class="rounded-xl border border-secondary/20 bg-secondary/5 p-3.5">
-                <div class="flex items-start gap-3">
-                  <div class="w-9 h-9 rounded-lg bg-secondary/15 text-secondary flex items-center justify-center shrink-0">
-                    <BookOpenText class="h-5 w-5" />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <p class="font-semibold text-sm leading-tight">{{ t('guide.isbnExplainer.title') }}</p>
-                    <p class="text-xs text-base-content/60 mt-1 leading-snug">{{ t('guide.isbnExplainer.line1') }}</p>
-                    <p class="text-xs text-base-content/60 mt-1 leading-snug">{{ t('guide.isbnExplainer.line2') }}</p>
-
-                    <!-- Mock back-of-book label : barcode + ISBN, like the real thing -->
-                    <div class="mt-3 inline-flex flex-col items-center gap-1 rounded-lg bg-base-100 border border-base-300 px-4 py-2.5 shadow-sm">
-                      <Barcode class="h-9 w-16 text-base-content/80" stroke-width="1.25" />
-                      <span class="font-mono text-[11px] tracking-widest text-base-content/70">9 782811 645632</span>
-                      <span class="text-[9px] uppercase tracking-wider text-base-content/35">{{ t('guide.isbnExplainer.barcodeLabel') }}</span>
-                    </div>
-
-                    <div class="flex flex-wrap gap-1.5 mt-3">
-                      <span class="badge badge-sm bg-secondary/15 text-secondary border-0 font-medium">{{ t('guide.isbnExplainer.badge13') }}</span>
-                      <span class="badge badge-sm bg-base-content/10 text-base-content/60 border-0 font-medium">{{ t('guide.isbnExplainer.badge10') }}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div
-                v-for="method in COVER_METHODS"
-                :key="method.key"
-                class="rounded-xl border border-base-200 bg-base-100 p-3.5"
-              >
-                <div class="flex items-start gap-3">
-                  <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="method.chip">
-                    <component :is="method.icon" class="h-5 w-5" />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <p class="font-semibold text-sm leading-tight">{{ t(`guide.cover.${method.key}.name`) }}</p>
-                    <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.cover.${method.key}.desc`) }}</p>
-                    <ol v-if="method.steps > 0" class="mt-2.5 space-y-1.5">
-                      <li
-                        v-for="step in method.steps"
-                        :key="step"
-                        class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
-                      >
-                        <span class="flex items-center justify-center h-4 w-4 rounded-full bg-base-200 text-[10px] font-bold text-base-content/60 shrink-0 mt-px">
-                          {{ step }}
-                        </span>
-                        {{ t(`guide.cover.${method.key}.step${step}`) }}
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-              </div>
-
-              <div class="rounded-xl bg-base-200/50 border border-base-200 p-3.5">
-                <p class="text-xs font-bold uppercase tracking-wide text-base-content/50 mb-2">{{ t('guide.coverSourcesTitle') }}</p>
-                <div class="flex flex-wrap gap-1.5">
-                  <span
-                    v-for="src in COVER_SOURCES"
-                    :key="src"
-                    class="badge badge-sm badge-ghost font-medium"
-                  >
-                    {{ t(`guide.coverSource.${src}`) }}
-                  </span>
-                </div>
-                <p class="text-xs text-base-content/50 mt-2.5 leading-snug">{{ t('guide.coverSourcesNote') }}</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Footer -->
-          <div class="shrink-0 px-5 py-3 border-t border-base-200">
-            <button class="btn btn-primary btn-sm w-full sm:w-auto sm:float-right" @click="emit('close')">
-              {{ t('guide.gotIt') }}
-            </button>
-          </div>
+  <BaseModal
+    :open="open"
+    max-width-class="sm:max-w-2xl"
+    panel-class="h-[88dvh] sm:h-[640px]"
+    @close="emit('close')"
+  >
+    <!-- Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-base-200 bg-gradient-to-br from-primary/8 to-transparent">
+      <div class="flex items-center gap-2.5">
+        <div class="w-9 h-9 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
+          <Info class="h-5 w-5" />
+        </div>
+        <div>
+          <h2 class="font-bold text-lg leading-tight">{{ t('guide.title') }}</h2>
+          <p class="text-xs text-base-content/50">{{ t('guide.subtitle') }}</p>
         </div>
       </div>
-    </Transition>
-  </Teleport>
-</template>
+      <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
+        <X class="h-4 w-4" />
+      </button>
+    </div>
 
-<style scoped>
-.guide-enter-active,
-.guide-leave-active {
-  transition: opacity 0.2s ease;
-}
-.guide-enter-active .relative,
-.guide-leave-active .relative {
-  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-.guide-enter-from,
-.guide-leave-to {
-  opacity: 0;
-}
-.guide-enter-from .relative {
-  transform: translateY(40px) scale(0.97);
-}
-</style>
+    <!-- Tabs -->
+    <div class="px-3 sm:px-5 pt-3 shrink-0">
+      <div class="inline-flex p-1 bg-base-200 rounded-xl gap-1 w-full sm:w-auto">
+        <button
+          class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+          :class="tab === 'statuses' ? 'btn-primary' : 'btn-ghost'"
+          @click="tab = 'statuses'"
+        >
+          <BookMarked class="h-4 w-4" />
+          <span>{{ t('guide.tabStatuses') }}</span>
+        </button>
+        <button
+          class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+          :class="tab === 'dashboard' ? 'btn-primary' : 'btn-ghost'"
+          @click="tab = 'dashboard'"
+        >
+          <PieChart class="h-4 w-4" />
+          <span>{{ t('guide.tabDashboard') }}</span>
+        </button>
+        <button
+          class="btn btn-sm border-0 flex-1 sm:flex-none gap-1.5"
+          :class="tab === 'covers' ? 'btn-primary' : 'btn-ghost'"
+          @click="tab = 'covers'"
+        >
+          <Search class="h-4 w-4" />
+          <span>{{ t('guide.tabCovers') }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div class="flex-1 overflow-y-auto px-5 py-4 min-h-0">
+      <!-- ── Statuses ── -->
+      <div v-if="tab === 'statuses'" class="space-y-4">
+        <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.statusesIntro') }}</p>
+
+        <ul class="space-y-2.5">
+          <li
+            v-for="s in STATUSES"
+            :key="s.key"
+            class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
+          >
+            <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="s.chip">
+              <component :is="s.icon" class="h-5 w-5" />
+            </div>
+            <div class="min-w-0">
+              <p class="font-semibold text-sm leading-tight">{{ t(`guide.status.${s.key}.name`) }}</p>
+              <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.status.${s.key}.desc`) }}</p>
+            </div>
+          </li>
+        </ul>
+
+        <div class="rounded-xl bg-primary/5 border border-primary/15 p-3.5">
+          <p class="flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-primary/80 mb-2">
+            <Lightbulb class="h-3.5 w-3.5" />
+            {{ t('guide.rulesTitle') }}
+          </p>
+          <ul class="space-y-1.5">
+            <li
+              v-for="rule in RULES"
+              :key="rule"
+              class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
+            >
+              <span class="mt-1 h-1.5 w-1.5 rounded-full bg-primary/60 shrink-0" />
+              {{ t(`guide.${rule}`) }}
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- ── Dashboard ── -->
+      <div v-else-if="tab === 'dashboard'" class="space-y-4">
+        <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.dashboardIntro') }}</p>
+
+        <ul class="space-y-2.5">
+          <li
+            v-for="m in METRICS"
+            :key="m.key"
+            class="flex items-start gap-3 rounded-xl border border-base-200 bg-base-100 p-3"
+          >
+            <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="m.chip">
+              <component :is="m.icon" class="h-5 w-5" />
+            </div>
+            <div class="min-w-0">
+              <p class="font-semibold text-sm leading-tight">{{ t(`guide.metric.${m.key}.name`) }}</p>
+              <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.metric.${m.key}.formula`) }}</p>
+            </div>
+          </li>
+        </ul>
+
+        <div class="rounded-xl bg-secondary/5 border border-secondary/15 p-3.5">
+          <p class="flex items-start gap-2 text-xs text-base-content/65 leading-snug">
+            <Wallet class="h-4 w-4 text-secondary shrink-0 mt-px" />
+            {{ t('guide.priceNote') }}
+          </p>
+        </div>
+      </div>
+
+      <!-- ── Covers ── -->
+      <div v-else class="space-y-4">
+        <p class="text-sm text-base-content/60 leading-relaxed">{{ t('guide.coversIntro') }}</p>
+
+        <!-- ── What is an ISBN? — illustrated explainer (mirrors the volume "ISBN du tome" hint) ── -->
+        <div class="rounded-xl border border-secondary/20 bg-secondary/5 p-3.5">
+          <div class="flex items-start gap-3">
+            <div class="w-9 h-9 rounded-lg bg-secondary/15 text-secondary flex items-center justify-center shrink-0">
+              <BookOpenText class="h-5 w-5" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="font-semibold text-sm leading-tight">{{ t('guide.isbnExplainer.title') }}</p>
+              <p class="text-xs text-base-content/60 mt-1 leading-snug">{{ t('guide.isbnExplainer.line1') }}</p>
+              <p class="text-xs text-base-content/60 mt-1 leading-snug">{{ t('guide.isbnExplainer.line2') }}</p>
+
+              <!-- Mock back-of-book label : barcode + ISBN, like the real thing -->
+              <div class="mt-3 inline-flex flex-col items-center gap-1 rounded-lg bg-base-100 border border-base-300 px-4 py-2.5 shadow-sm">
+                <Barcode class="h-9 w-16 text-base-content/80" stroke-width="1.25" />
+                <span class="font-mono text-[11px] tracking-widest text-base-content/70">9 782811 645632</span>
+                <span class="text-[9px] uppercase tracking-wider text-base-content/35">{{ t('guide.isbnExplainer.barcodeLabel') }}</span>
+              </div>
+
+              <div class="flex flex-wrap gap-1.5 mt-3">
+                <span class="badge badge-sm bg-secondary/15 text-secondary border-0 font-medium">{{ t('guide.isbnExplainer.badge13') }}</span>
+                <span class="badge badge-sm bg-base-content/10 text-base-content/60 border-0 font-medium">{{ t('guide.isbnExplainer.badge10') }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-for="method in COVER_METHODS"
+          :key="method.key"
+          class="rounded-xl border border-base-200 bg-base-100 p-3.5"
+        >
+          <div class="flex items-start gap-3">
+            <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0" :class="method.chip">
+              <component :is="method.icon" class="h-5 w-5" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="font-semibold text-sm leading-tight">{{ t(`guide.cover.${method.key}.name`) }}</p>
+              <p class="text-xs text-base-content/55 mt-0.5 leading-snug">{{ t(`guide.cover.${method.key}.desc`) }}</p>
+              <ol v-if="method.steps > 0" class="mt-2.5 space-y-1.5">
+                <li
+                  v-for="step in method.steps"
+                  :key="step"
+                  class="flex items-start gap-2 text-xs text-base-content/65 leading-snug"
+                >
+                  <span class="flex items-center justify-center h-4 w-4 rounded-full bg-base-200 text-[10px] font-bold text-base-content/60 shrink-0 mt-px">
+                    {{ step }}
+                  </span>
+                  {{ t(`guide.cover.${method.key}.step${step}`) }}
+                </li>
+              </ol>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-xl bg-base-200/50 border border-base-200 p-3.5">
+          <p class="text-xs font-bold uppercase tracking-wide text-base-content/50 mb-2">{{ t('guide.coverSourcesTitle') }}</p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              v-for="src in COVER_SOURCES"
+              :key="src"
+              class="badge badge-sm badge-ghost font-medium"
+            >
+              {{ t(`guide.coverSource.${src}`) }}
+            </span>
+          </div>
+          <p class="text-xs text-base-content/50 mt-2.5 leading-snug">{{ t('guide.coverSourcesNote') }}</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="shrink-0 px-5 py-3 border-t border-base-200">
+      <button class="btn btn-primary btn-sm w-full sm:w-auto sm:float-right" @click="emit('close')">
+        {{ t('guide.gotIt') }}
+      </button>
+    </div>
+  </BaseModal>
+</template>

--- a/front/src/components/organisms/EditionCard.vue
+++ b/front/src/components/organisms/EditionCard.vue
@@ -16,6 +16,7 @@ const FORMAT_LABELS: Record<string, string> = {
   coffret: 'Coffret',
   deluxe: 'Deluxe',
   omnibus: 'Omnibus',
+  artbook: 'Artbook',
   unknown: '',
 }
 

--- a/front/src/components/organisms/EnrichVolumeModal.vue
+++ b/front/src/components/organisms/EnrichVolumeModal.vue
@@ -14,11 +14,14 @@ import { useCoverProvider } from '@/composables/useCoverProvider'
 import BaseQrCode from '@/components/atoms/BaseQrCode.vue'
 import BaseCoverProviderLogo from '@/components/atoms/BaseCoverProviderLogo.vue'
 import PriceOfferCard from '@/components/molecules/PriceOfferCard.vue'
+import RetailerPriceCard from '@/components/molecules/RetailerPriceCard.vue'
+import { normalizeIsbn13 } from '@/utils/isbn'
 import CollectionGuideModal from '@/components/organisms/CollectionGuideModal.vue'
 import { useI18n } from 'vue-i18n'
 import type { CollectionEntryDetail, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
+import BaseModal from '@/components/atoms/BaseModal.vue'
 
 const { t } = useI18n()
 
@@ -74,8 +77,12 @@ function selectCoverProvider(key: CoverProvider): void {
   if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
 }
 
-function buildContextQuery(title: string, volumeNumber: number, edition: string | null): string {
-  return `${title} tome ${volumeNumber}${edition ? ' ' + edition : ''}`.trim()
+// The field only carries the series title: the volume number and edition are
+// already sent as dedicated params by runSearch, so repeating them here made
+// providers receive a polluted title ("Berserk tome 1 Glénat — Édition
+// classique") that matched nothing.
+function buildContextQuery(title: string): string {
+  return title.trim()
 }
 
 watch(searchQuery, (val) => {
@@ -151,12 +158,25 @@ const mode = ref<'search' | 'isbn' | 'scan' | 'prix'>(props.initialMode ?? 'sear
 const volumeIdForPrices = computed(() => props.volume?.volumeId ?? '')
 const {
   offers: priceOffers,
+  retailers: priceRetailers,
   hasIsbn: priceHasIsbn,
   isLoading: pricesLoading,
   error: pricesError,
   loaded: pricesLoaded,
   load: loadPrices,
 } = useVolumePrices(() => props.mangaId, volumeIdForPrices)
+
+// Offers not already surfaced as a target shop's best offer (shown below the 3 cards).
+const otherPriceOffers = computed(() => {
+  const bestOffers = priceRetailers.value
+    .map((retailerBlock) => retailerBlock.bestOffer)
+    .filter((offer) => offer !== null)
+  return priceOffers.value.filter(
+    (offer) => !bestOffers.some(
+      (best) => best.merchant === offer.merchant && best.amount === offer.amount && best.url === offer.url,
+    ),
+  )
+})
 
 // ── ISBN mode state ──
 const isbnInput = ref('')
@@ -173,17 +193,45 @@ watch(isbnInput, () => {
   isbnSearched.value = false
 })
 
+// ── ISBN auto-save ──
+// The typed/scanned ISBN is persisted on its own (field blur + before every cover
+// search), so it is never lost when no cover is found or the modal is closed.
+const isbnSaveMutation = useMutation({
+  mutationFn: (isbn: string) =>
+    updateVolume(props.mangaId, props.volume!.volumeId, { isbn }),
+  onSuccess: () => {
+    qc.invalidateQueries({ queryKey: ['collection', props.collectionEntryId] })
+    // Keep the price tab in sync — a fresh ISBN unlocks the price search.
+    if (pricesLoaded.value) loadPrices()
+    ui.addToast(t('enrich.isbnSaved'), 'success')
+  },
+  onError: () => {
+    ui.addToast(t('enrich.isbnSaveError'), 'error')
+  },
+})
+
+function autoSaveIsbn(): void {
+  const vol = props.volume
+  if (!vol) return
+  const normalized = normalizeIsbn13(isbnInput.value)
+  if (!normalized || normalized === vol.isbn || isbnSaveMutation.isPending.value) return
+  isbnSaveMutation.mutate(normalized)
+}
+
 async function runIsbnSearch(): Promise<void> {
   if (!isbnInput.value.trim()) return
+  autoSaveIsbn()
   await isbnSearch()
   isbnSearched.value = true
 }
 
 function applyIsbnCover(cover: { coverUrl: string; spineUrl: string | null; isbn: string | null }): void {
+  // The ISBN the user typed/scanned wins over the one echoed back by the cover API.
+  const typedIsbn = normalizeIsbn13(isbnInput.value)
   enrichMutation.mutate({
     coverUrl: cover.coverUrl,
     spineUrl: cover.spineUrl ?? undefined,
-    isbn: cover.isbn ?? undefined,
+    isbn: typedIsbn ?? cover.isbn ?? undefined,
   })
 }
 
@@ -205,7 +253,7 @@ function fallbackToTitleSearch(): void {
   if (!props.volume) return
   mode.value = 'search'
   // Seeding the field triggers the debounced search below.
-  searchQuery.value = buildContextQuery(props.mangaTitle, props.volume.number, props.mangaEdition)
+  searchQuery.value = buildContextQuery(props.mangaTitle)
 }
 
 // Clears every per-tome result so switching tomes never shows the previous one's.
@@ -238,7 +286,7 @@ watch(() => props.volume?.id ?? null, (volumeEntryId, previousId) => {
   if (props.open && vol && !vol.coverUrl && mode.value !== 'prix') {
     // Seed the field with the default context query — visible and editable —
     // which triggers the (debounced) search.
-    searchQuery.value = buildContextQuery(props.mangaTitle, vol.number, props.mangaEdition)
+    searchQuery.value = buildContextQuery(props.mangaTitle)
   }
   if (props.open && mode.value === 'prix') {
     loadPrices()
@@ -456,15 +504,18 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="modal">
-      <div v-if="open && volume" class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
-        <!-- Backdrop -->
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="emit('close')" />
-
-        <!-- Modal -->
-        <div class="relative z-10 w-full sm:max-w-5xl bg-base-100 rounded-t-3xl sm:rounded-2xl shadow-2xl overflow-hidden flex flex-col h-[90dvh] sm:h-[680px]">
-          <!-- Header -->
+  <!-- Escape is handled by this component's own keydown listener (guide and
+       lightbox close first), so BaseModal's Escape handling is disabled. -->
+  <BaseModal
+    :open="open && volume !== null"
+    max-width-class="sm:max-w-5xl"
+    panel-class="h-[90dvh] sm:h-[680px]"
+    z-class="z-50"
+    :close-on-escape="false"
+    @close="emit('close')"
+  >
+    <template v-if="volume">
+      <!-- Header -->
           <div class="flex items-center justify-between px-5 py-4 border-b border-base-200">
             <div class="flex items-center gap-2.5">
               <div>
@@ -636,23 +687,24 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
             <div class="min-w-0 flex flex-col sm:flex-1 sm:overflow-hidden">
               <div class="px-4 sm:px-5 pt-4">
                 <p class="text-xs font-semibold uppercase tracking-wide text-base-content/40 mb-2">{{ t('enrich.findCover') }}</p>
-                <!-- Segmented switcher -->
-                <div class="inline-flex p-1 bg-base-200 rounded-xl gap-1">
-                  <button class="btn btn-sm border-0 gap-1.5" :class="mode === 'search' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'search'">
-                    <Search class="h-4 w-4" />
-                    {{ t('enrich.tabSearch') }}
+                <!-- Segmented switcher — full width with flex-1 tabs on mobile so
+                     the 4 tabs never overflow at 360px (icons hidden when cramped) -->
+                <div class="flex sm:inline-flex w-full sm:w-auto p-1 bg-base-200 rounded-xl gap-1">
+                  <button class="btn btn-sm border-0 gap-1.5 flex-1 sm:flex-none min-w-0 max-[440px]:px-1 max-[440px]:text-xs" :class="mode === 'search' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'search'">
+                    <Search class="h-4 w-4 shrink-0 max-[400px]:hidden" />
+                    <span class="truncate">{{ t('enrich.tabSearch') }}</span>
                   </button>
-                  <button class="btn btn-sm border-0 gap-1.5" :class="mode === 'isbn' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'isbn'">
-                    <QrCode class="h-4 w-4" />
-                    {{ t('enrich.tabIsbn') }}
+                  <button class="btn btn-sm border-0 gap-1.5 flex-1 sm:flex-none min-w-0 max-[440px]:px-1 max-[440px]:text-xs" :class="mode === 'isbn' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'isbn'">
+                    <QrCode class="h-4 w-4 shrink-0 max-[400px]:hidden" />
+                    <span class="truncate">{{ t('enrich.tabIsbn') }}</span>
                   </button>
-                  <button class="btn btn-sm border-0 gap-1.5" :class="mode === 'scan' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'scan'">
-                    <Camera class="h-4 w-4" />
-                    {{ t('enrich.tabScan') }}
+                  <button class="btn btn-sm border-0 gap-1.5 flex-1 sm:flex-none min-w-0 max-[440px]:px-1 max-[440px]:text-xs" :class="mode === 'scan' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'scan'">
+                    <Camera class="h-4 w-4 shrink-0 max-[400px]:hidden" />
+                    <span class="truncate">{{ t('enrich.tabScan') }}</span>
                   </button>
-                  <button class="btn btn-sm border-0 gap-1.5" :class="mode === 'prix' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'prix'">
-                    <Tag class="h-4 w-4" />
-                    {{ t('prices.tabLabel') }}
+                  <button class="btn btn-sm border-0 gap-1.5 flex-1 sm:flex-none min-w-0 max-[440px]:px-1 max-[440px]:text-xs" :class="mode === 'prix' ? 'btn-primary' : 'btn-ghost'" @click="mode = 'prix'">
+                    <Tag class="h-4 w-4 shrink-0 max-[400px]:hidden" />
+                    <span class="truncate">{{ t('prices.tabLabel') }}</span>
                   </button>
                 </div>
               </div>
@@ -750,13 +802,14 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
                       class="input input-bordered input-sm flex-1"
                       :placeholder="t('enrich.isbnPlaceholder')"
                       @keyup.enter="runIsbnSearch()"
+                      @blur="autoSaveIsbn()"
                     />
                     <button class="btn btn-sm btn-primary shrink-0" :disabled="!isbnInput.trim() || isbnLoading" @click="runIsbnSearch()">
                       <BaseLoader v-if="isbnLoading" size="xs" />
                       {{ t('enrich.searchIsbn') }}
                     </button>
                   </div>
-                  <p v-if="isbnError" class="text-error text-xs mt-2">{{ isbnError }}</p>
+                  <p v-if="isbnError" class="text-error text-xs mt-2">{{ t(isbnError) }}</p>
                 </template>
 
                 <!-- Résultats ISBN/Scan regroupés par source — affichés EN PRIORITÉ, au-dessus du scan -->
@@ -814,19 +867,44 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
                   </div>
                   <p v-else-if="pricesError" class="text-sm text-error">{{ pricesError }}</p>
                   <template v-else-if="pricesLoaded">
-                    <p v-if="!priceHasIsbn" class="text-sm text-base-content/50 py-4 text-center">
-                      {{ t('prices.noIsbn') }}
-                    </p>
-                    <template v-else-if="priceOffers.length">
-                      <PriceOfferCard
-                        v-for="(offer, idx) in priceOffers"
-                        :key="`${offer.source}-${idx}`"
-                        :offer="offer"
-                      />
+                    <!-- No ISBN: explain + shortcut to the ISBN tab (no dead end) -->
+                    <div v-if="!priceHasIsbn" class="flex flex-col items-center gap-3 py-4">
+                      <p class="text-sm text-base-content/50 text-center">
+                        {{ t('prices.noIsbn') }}
+                      </p>
+                      <button class="btn btn-sm btn-primary gap-2" @click="mode = 'isbn'">
+                        <QrCode class="h-4 w-4" />
+                        {{ t('prices.enterIsbn') }}
+                      </button>
+                    </div>
+                    <template v-else>
+                      <!-- The 3 target shops — always shown, found or honestly "not found" -->
+                      <p class="text-[11px] font-bold uppercase tracking-wide text-base-content/45">
+                        {{ t('prices.retailersTitle') }}
+                      </p>
+                      <div class="grid grid-cols-3 gap-2 sm:gap-3">
+                        <RetailerPriceCard
+                          v-for="retailerBlock in priceRetailers"
+                          :key="retailerBlock.retailer"
+                          :retailer="retailerBlock"
+                        />
+                      </div>
+
+                      <!-- Remaining offers (other merchants, publisher references) -->
+                      <template v-if="otherPriceOffers.length">
+                        <p class="text-[11px] font-bold uppercase tracking-wide text-base-content/45 mt-2">
+                          {{ t('prices.otherOffers') }}
+                        </p>
+                        <PriceOfferCard
+                          v-for="(offer, idx) in otherPriceOffers"
+                          :key="`${offer.source}-${idx}`"
+                          :offer="offer"
+                        />
+                      </template>
+                      <p v-else-if="!priceOffers.length" class="text-sm text-base-content/40 py-2 text-center">
+                        {{ t('prices.empty') }}
+                      </p>
                     </template>
-                    <p v-else class="text-sm text-base-content/40 py-4 text-center">
-                      {{ t('prices.empty') }}
-                    </p>
                   </template>
                   <p v-else class="text-sm text-base-content/40 py-4 text-center">
                     {{ t('prices.loading') }}
@@ -854,10 +932,8 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
               </div>
             </div>
           </div>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
+    </template>
+  </BaseModal>
 
   <!-- Lightbox -->
   <Teleport to="body">
@@ -882,21 +958,6 @@ const possessionToggles = computed<{ config: StatusToggleConfig; active: boolean
 </template>
 
 <style scoped>
-.modal-enter-active,
-.modal-leave-active {
-  transition: opacity 0.2s ease;
-}
-.modal-enter-active .relative,
-.modal-leave-active .relative {
-  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-.modal-enter-from,
-.modal-leave-to {
-  opacity: 0;
-}
-.modal-enter-from .relative {
-  transform: translateY(40px) scale(0.97);
-}
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.18s ease;

--- a/front/src/components/organisms/MainLayout.vue
+++ b/front/src/components/organisms/MainLayout.vue
@@ -61,34 +61,36 @@ const adminNavItems = computed(() =>
 </script>
 
 <template>
-  <!-- Mobile top header -->
-  <header class="lg:hidden fixed top-0 inset-x-0 z-30 h-14 bg-base-100/80 backdrop-blur-md border-b border-base-200 flex items-center px-4 gap-3">
-    <button
-      class="flex items-center justify-center w-10 h-10 rounded-lg text-base-content/60 hover:bg-base-200 hover:text-base-content transition-colors"
-      :class="{ 'text-primary bg-primary/10': mobileNavOpen }"
-      @click="mobileNavOpen = true"
-    >
-      <Menu class="w-5 h-5" stroke-width="1.5" />
-    </button>
+  <!-- Mobile top header — safe-top grows it under the iOS notch -->
+  <header class="lg:hidden fixed top-0 inset-x-0 z-30 safe-top bg-base-100/80 backdrop-blur-md border-b border-base-200">
+    <div class="flex items-center h-14 px-4 gap-3">
+      <button
+        class="flex items-center justify-center w-10 h-10 rounded-lg text-base-content/60 hover:bg-base-200 hover:text-base-content transition-colors"
+        :class="{ 'text-primary bg-primary/10': mobileNavOpen }"
+        @click="mobileNavOpen = true"
+      >
+        <Menu class="w-5 h-5" stroke-width="1.5" />
+      </button>
 
-    <div class="flex-1 flex justify-center">
-      <AppLogo />
+      <div class="flex-1 flex justify-center">
+        <AppLogo />
+      </div>
+
+      <button
+        class="flex items-center justify-center w-10 h-10 rounded-lg text-base-content/60 hover:bg-base-200 hover:text-base-content transition-colors"
+        :class="{ 'text-primary bg-primary/10': settingsOpen }"
+        @click="openSettings"
+      >
+        <Settings class="w-5 h-5" stroke-width="1.5" />
+      </button>
     </div>
-
-    <button
-      class="flex items-center justify-center w-10 h-10 rounded-lg text-base-content/60 hover:bg-base-200 hover:text-base-content transition-colors"
-      :class="{ 'text-primary bg-primary/10': settingsOpen }"
-      @click="openSettings"
-    >
-      <Settings class="w-5 h-5" stroke-width="1.5" />
-    </button>
   </header>
 
   <div class="drawer lg:drawer-open min-h-screen">
     <input id="drawer" type="checkbox" class="drawer-toggle" />
 
     <div class="drawer-content flex flex-col">
-      <main class="flex-1 bg-base-200 min-h-screen pt-14 lg:pt-0">
+      <main class="flex-1 bg-base-200 min-h-screen pt-mobile-header lg:pt-0">
         <RouterView />
       </main>
     </div>
@@ -204,7 +206,7 @@ const adminNavItems = computed(() =>
           enter-from-class="-translate-x-full"
           leave-to-class="-translate-x-full"
         >
-          <nav v-if="mobileNavOpen" class="relative flex flex-col w-20 min-h-screen bg-base-100 shadow-2xl">
+          <nav v-if="mobileNavOpen" class="relative flex flex-col w-20 min-h-screen bg-base-100 shadow-2xl safe-top">
             <!-- Logo mark -->
             <div class="flex items-center justify-center h-14 border-b border-base-200">
               <AppLogo :full="false" />
@@ -246,8 +248,8 @@ const adminNavItems = computed(() =>
               </template>
             </div>
 
-            <!-- Bottom actions -->
-            <div class="flex flex-col items-center pb-8 gap-1 border-t border-base-200 pt-2">
+            <!-- Bottom actions — kept above the iOS home indicator -->
+            <div class="flex flex-col items-center pb-safe-sheet gap-1 border-t border-base-200 pt-2">
               <button
                 class="flex items-center justify-center w-14 h-14 rounded-xl text-base-content/50 hover:bg-base-200 hover:text-base-content transition-colors"
                 @click="openSettings"
@@ -282,7 +284,7 @@ const adminNavItems = computed(() =>
           enter-from-class="translate-y-full"
           leave-to-class="translate-y-full"
         >
-          <div v-if="settingsOpen" class="relative bg-base-100 rounded-t-2xl pb-10 shadow-xl">
+          <div v-if="settingsOpen" class="relative bg-base-100 rounded-t-2xl pb-safe-sheet shadow-xl">
             <div class="w-10 h-1 bg-base-300 rounded-full mx-auto mt-3 mb-2" />
 
             <div class="px-4 py-3">
@@ -321,8 +323,8 @@ const adminNavItems = computed(() =>
       </div>
     </Transition>
 
-    <!-- Toast container -->
-    <div class="toast toast-end toast-bottom z-[9999] fixed">
+    <!-- Toast container — margin keeps toasts above the iOS home indicator -->
+    <div class="toast toast-end toast-bottom z-[9999] fixed mb-safe">
       <BaseToast
         v-for="toast in ui.toasts"
         :key="toast.id"

--- a/front/src/components/organisms/ShareModal.vue
+++ b/front/src/components/organisms/ShareModal.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { X, Copy, Check, Mail, MessageSquare, Share2, Link2 } from 'lucide-vue-next'
 import { useUiStore } from '@/stores/useUiStore'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
+import BaseModal from '@/components/atoms/BaseModal.vue'
 import type { Stats } from '@/types'
 
 const props = defineProps<{ open: boolean; url: string | null; loading: boolean; stats: Stats | undefined }>()
@@ -63,124 +64,98 @@ async function nativeShare(): Promise<void> {
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition name="share">
-      <div
-        v-if="open"
-        class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-0 sm:p-4"
-        role="dialog"
-        aria-modal="true"
-      >
-        <div class="absolute inset-0 bg-black/70 backdrop-blur-sm" @click="emit('close')" />
+  <BaseModal
+    :open="open"
+    max-width-class="sm:max-w-md"
+    panel-class="sm:rounded-3xl"
+    @close="emit('close')"
+  >
+    <!-- Header -->
+    <div class="flex items-center justify-between px-5 py-4 border-b border-base-200">
+      <div class="flex items-center gap-2.5">
+        <div class="w-9 h-9 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
+          <Share2 class="h-5 w-5" />
+        </div>
+        <div>
+          <h2 class="font-bold text-lg leading-tight">{{ t('share.title') }}</h2>
+          <p class="text-xs text-base-content/50">{{ t('share.subtitle') }}</p>
+        </div>
+      </div>
+      <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
+        <X class="h-4 w-4" />
+      </button>
+    </div>
 
-        <div class="relative z-10 w-full sm:max-w-md bg-base-100 rounded-t-3xl sm:rounded-3xl shadow-2xl overflow-hidden">
-          <!-- Header -->
-          <div class="flex items-center justify-between px-5 py-4 border-b border-base-200">
-            <div class="flex items-center gap-2.5">
-              <div class="w-9 h-9 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
-                <Share2 class="h-5 w-5" />
-              </div>
-              <div>
-                <h2 class="font-bold text-lg leading-tight">{{ t('share.title') }}</h2>
-                <p class="text-xs text-base-content/50">{{ t('share.subtitle') }}</p>
-              </div>
-            </div>
-            <button class="btn btn-ghost btn-sm btn-circle" :aria-label="t('common.close')" @click="emit('close')">
-              <X class="h-4 w-4" />
-            </button>
+    <div class="p-5 space-y-5">
+      <!-- Preview card -->
+      <div class="rounded-2xl bg-gradient-to-br from-primary/10 via-base-200/40 to-secondary/10 border border-base-200 p-4">
+        <p class="text-[10px] font-semibold uppercase tracking-widest text-base-content/40 mb-3">
+          {{ t('share.previewLabel') }}
+        </p>
+        <div v-if="stats" class="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p class="text-2xl font-bold leading-none">{{ stats.totalMangas }}</p>
+            <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.totalMangas') }}</p>
           </div>
-
-          <div class="p-5 space-y-5">
-            <!-- Preview card -->
-            <div class="rounded-2xl bg-gradient-to-br from-primary/10 via-base-200/40 to-secondary/10 border border-base-200 p-4">
-              <p class="text-[10px] font-semibold uppercase tracking-widest text-base-content/40 mb-3">
-                {{ t('share.previewLabel') }}
-              </p>
-              <div v-if="stats" class="grid grid-cols-3 gap-3 text-center">
-                <div>
-                  <p class="text-2xl font-bold leading-none">{{ stats.totalMangas }}</p>
-                  <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.totalMangas') }}</p>
-                </div>
-                <div>
-                  <p class="text-2xl font-bold leading-none text-success">{{ stats.totalOwned }}</p>
-                  <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.ownedVolumes') }}</p>
-                </div>
-                <div>
-                  <p class="text-2xl font-bold leading-none text-primary">{{ readingProgress }}%</p>
-                  <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.readingProgress') }}</p>
-                </div>
-              </div>
-            </div>
-
-            <!-- Link -->
-            <div v-if="loading" class="flex items-center justify-center gap-2 py-4 text-base-content/50">
-              <BaseLoader size="xs" />
-              <span class="text-sm">{{ t('share.generating') }}</span>
-            </div>
-
-            <template v-else-if="url">
-              <div class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-200/50 p-1.5 pl-3">
-                <Link2 class="h-4 w-4 text-base-content/40 shrink-0" />
-                <input
-                  :value="url"
-                  readonly
-                  class="flex-1 bg-transparent text-sm text-base-content/70 outline-none truncate"
-                  @focus="($event.target as HTMLInputElement).select()"
-                />
-                <button class="btn btn-sm btn-primary gap-1.5" @click="copyLink">
-                  <Check v-if="copied" class="h-4 w-4" />
-                  <Copy v-else class="h-4 w-4" />
-                  {{ copied ? t('share.copied') : t('share.copy') }}
-                </button>
-              </div>
-
-              <!-- Share targets -->
-              <div class="grid grid-cols-3 gap-2.5">
-                <a :href="mailtoHref" class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200">
-                  <Mail class="h-5 w-5 text-primary" />
-                  <span class="text-xs">{{ t('share.email') }}</span>
-                </a>
-                <a :href="smsHref" class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200">
-                  <MessageSquare class="h-5 w-5 text-success" />
-                  <span class="text-xs">{{ t('share.sms') }}</span>
-                </a>
-                <button
-                  v-if="canNativeShare"
-                  class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200"
-                  @click="nativeShare"
-                >
-                  <Share2 class="h-5 w-5 text-secondary" />
-                  <span class="text-xs">{{ t('share.more') }}</span>
-                </button>
-                <button v-else class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200" @click="copyLink">
-                  <Copy class="h-5 w-5 text-secondary" />
-                  <span class="text-xs">{{ t('share.copy') }}</span>
-                </button>
-              </div>
-
-              <p class="text-xs text-base-content/40 text-center leading-relaxed">{{ t('share.privacyNote') }}</p>
-            </template>
+          <div>
+            <p class="text-2xl font-bold leading-none text-success">{{ stats.totalOwned }}</p>
+            <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.ownedVolumes') }}</p>
+          </div>
+          <div>
+            <p class="text-2xl font-bold leading-none text-primary">{{ readingProgress }}%</p>
+            <p class="text-[10px] uppercase tracking-wide text-base-content/45 mt-1">{{ t('dashboard.readingProgress') }}</p>
           </div>
         </div>
       </div>
-    </Transition>
-  </Teleport>
-</template>
 
-<style scoped>
-.share-enter-active,
-.share-leave-active {
-  transition: opacity 0.2s ease;
-}
-.share-enter-active .relative,
-.share-leave-active .relative {
-  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-.share-enter-from,
-.share-leave-to {
-  opacity: 0;
-}
-.share-enter-from .relative {
-  transform: translateY(40px) scale(0.97);
-}
-</style>
+      <!-- Link -->
+      <div v-if="loading" class="flex items-center justify-center gap-2 py-4 text-base-content/50">
+        <BaseLoader size="xs" />
+        <span class="text-sm">{{ t('share.generating') }}</span>
+      </div>
+
+      <template v-else-if="url">
+        <div class="flex items-center gap-2 rounded-xl border border-base-300 bg-base-200/50 p-1.5 pl-3">
+          <Link2 class="h-4 w-4 text-base-content/40 shrink-0" />
+          <input
+            :value="url"
+            readonly
+            class="flex-1 bg-transparent text-sm text-base-content/70 outline-none truncate"
+            @focus="($event.target as HTMLInputElement).select()"
+          />
+          <button class="btn btn-sm btn-primary gap-1.5" @click="copyLink">
+            <Check v-if="copied" class="h-4 w-4" />
+            <Copy v-else class="h-4 w-4" />
+            {{ copied ? t('share.copied') : t('share.copy') }}
+          </button>
+        </div>
+
+        <!-- Share targets -->
+        <div class="grid grid-cols-3 gap-2.5">
+          <a :href="mailtoHref" class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200">
+            <Mail class="h-5 w-5 text-primary" />
+            <span class="text-xs">{{ t('share.email') }}</span>
+          </a>
+          <a :href="smsHref" class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200">
+            <MessageSquare class="h-5 w-5 text-success" />
+            <span class="text-xs">{{ t('share.sms') }}</span>
+          </a>
+          <button
+            v-if="canNativeShare"
+            class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200"
+            @click="nativeShare"
+          >
+            <Share2 class="h-5 w-5 text-secondary" />
+            <span class="text-xs">{{ t('share.more') }}</span>
+          </button>
+          <button v-else class="btn btn-ghost flex-col h-auto py-3 gap-1.5 border border-base-200" @click="copyLink">
+            <Copy class="h-5 w-5 text-secondary" />
+            <span class="text-xs">{{ t('share.copy') }}</span>
+          </button>
+        </div>
+
+        <p class="text-xs text-base-content/40 text-center leading-relaxed">{{ t('share.privacyNote') }}</p>
+      </template>
+    </div>
+  </BaseModal>
+</template>

--- a/front/src/composables/__tests__/useActivityLogFilters.spec.ts
+++ b/front/src/composables/__tests__/useActivityLogFilters.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { useActivityLogFilters } from '../useActivityLogFilters'
+
+describe('useActivityLogFilters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with empty filters and page 1', () => {
+    const filters = useActivityLogFilters()
+
+    expect(filters.page.value).toBe(1)
+    expect(filters.hasActiveFilters.value).toBe(false)
+    expect(filters.params.value).toEqual({
+      page: 1,
+      limit: 50,
+      eventType: undefined,
+      status: undefined,
+      collectionEntryId: undefined,
+      ownerId: undefined,
+      from: undefined,
+      to: undefined,
+      search: undefined,
+    })
+  })
+
+  it('exposes selected filters in params', async () => {
+    const filters = useActivityLogFilters()
+
+    filters.eventType.value = 'http_error'
+    filters.status.value = 'error'
+    filters.ownerId.value = 'user-1'
+    filters.collectionEntryId.value = 'ce-1'
+    await nextTick()
+
+    expect(filters.params.value.eventType).toBe('http_error')
+    expect(filters.params.value.status).toBe('error')
+    expect(filters.params.value.ownerId).toBe('user-1')
+    expect(filters.params.value.collectionEntryId).toBe('ce-1')
+    expect(filters.hasActiveFilters.value).toBe(true)
+  })
+
+  it('debounces the search input', async () => {
+    const filters = useActivityLogFilters({ debounceMs: 300 })
+
+    filters.searchInput.value = '  share  '
+    await nextTick()
+    expect(filters.params.value.search).toBeUndefined()
+
+    vi.advanceTimersByTime(299)
+    expect(filters.search.value).toBe('')
+
+    vi.advanceTimersByTime(1)
+    await nextTick()
+    expect(filters.search.value).toBe('share')
+    expect(filters.params.value.search).toBe('share')
+  })
+
+  it('only applies the last search value when typing fast', async () => {
+    const filters = useActivityLogFilters({ debounceMs: 300 })
+
+    filters.searchInput.value = 'sha'
+    await nextTick()
+    vi.advanceTimersByTime(150)
+
+    filters.searchInput.value = 'share'
+    await nextTick()
+    vi.advanceTimersByTime(300)
+
+    expect(filters.search.value).toBe('share')
+  })
+
+  it('resets the page to 1 when a filter changes', async () => {
+    const filters = useActivityLogFilters()
+
+    filters.page.value = 4
+    filters.eventType.value = 'auth_action'
+    await nextTick()
+
+    expect(filters.page.value).toBe(1)
+  })
+
+  it('converts datetime-local values to ISO strings', async () => {
+    const filters = useActivityLogFilters()
+
+    filters.from.value = '2026-07-01T10:00'
+    filters.to.value = 'not-a-date'
+    await nextTick()
+
+    expect(filters.params.value.from).toBe(new Date('2026-07-01T10:00').toISOString())
+    expect(filters.params.value.to).toBeUndefined()
+  })
+
+  it('reset() clears every filter and the search input', async () => {
+    const filters = useActivityLogFilters()
+
+    filters.eventType.value = 'rss_fetch'
+    filters.searchInput.value = 'abc'
+    filters.from.value = '2026-07-01T10:00'
+    filters.page.value = 3
+    await nextTick()
+    vi.runAllTimers()
+    await nextTick()
+
+    filters.reset()
+    await nextTick()
+
+    expect(filters.eventType.value).toBe('')
+    expect(filters.searchInput.value).toBe('')
+    expect(filters.from.value).toBe('')
+    expect(filters.page.value).toBe(1)
+    expect(filters.hasActiveFilters.value).toBe(false)
+  })
+})

--- a/front/src/composables/__tests__/useIsbnCoverSearch.spec.ts
+++ b/front/src/composables/__tests__/useIsbnCoverSearch.spec.ts
@@ -38,6 +38,36 @@ describe('useIsbnCoverSearch', () => {
     expect(isLoading.value).toBe(false)
   })
 
+  it('normalizes the ISBN before calling the API (hyphens, ISBN-10, EAN add-on)', async () => {
+    mockCoverByIsbn.mockResolvedValue(mockCovers)
+
+    const isbn = ref('978-2-8116-4563-2')
+    const { search } = useIsbnCoverSearch(isbn)
+    await search()
+    expect(mockCoverByIsbn).toHaveBeenLastCalledWith('9782811645632')
+
+    // ISBN-10 converted to ISBN-13
+    isbn.value = '2-8116-4563-2'
+    await search()
+    expect(mockCoverByIsbn).toHaveBeenLastCalledWith('9782811645632')
+
+    // EAN-5 barcode add-on stripped
+    isbn.value = '978281164563212345'
+    await search()
+    expect(mockCoverByIsbn).toHaveBeenLastCalledWith('9782811645632')
+  })
+
+  it('flags an invalid ISBN without calling the API', async () => {
+    const isbn = ref('not-an-isbn')
+    const { covers, error, search } = useIsbnCoverSearch(isbn)
+
+    await search()
+
+    expect(mockCoverByIsbn).not.toHaveBeenCalled()
+    expect(covers.value).toEqual([])
+    expect(error.value).toBe('enrich.isbnInvalid')
+  })
+
   it('does not call coverByIsbn when isbn is empty', async () => {
     const isbn = ref('')
     const { search } = useIsbnCoverSearch(isbn)
@@ -47,7 +77,7 @@ describe('useIsbnCoverSearch', () => {
     expect(mockCoverByIsbn).not.toHaveBeenCalled()
   })
 
-  it('fills error and resets isLoading on API rejection', async () => {
+  it('fills a backend-error key and resets isLoading on API rejection', async () => {
     mockCoverByIsbn.mockRejectedValueOnce(new Error('Network error'))
 
     const isbn = ref('9782811645632')
@@ -57,17 +87,31 @@ describe('useIsbnCoverSearch', () => {
 
     expect(covers.value).toEqual([])
     expect(isLoading.value).toBe(false)
-    expect(error.value).toBeTruthy()
+    expect(error.value).toBe('enrich.isbnSearchError')
   })
 
-  it('returns empty covers when no source has a cover', async () => {
+  it('distinguishes "0 result" (empty covers, no error) from a backend error', async () => {
     mockCoverByIsbn.mockResolvedValueOnce([])
 
     const isbn = ref('9782723492607')
-    const { covers, search } = useIsbnCoverSearch(isbn)
+    const { covers, error, search } = useIsbnCoverSearch(isbn)
 
     await search()
 
     expect(covers.value).toEqual([])
+    expect(error.value).toBeNull()
+  })
+
+  it('clears a previous error on the next search', async () => {
+    const isbn = ref('invalid')
+    const { error, search } = useIsbnCoverSearch(isbn)
+
+    await search()
+    expect(error.value).toBe('enrich.isbnInvalid')
+
+    mockCoverByIsbn.mockResolvedValueOnce(mockCovers)
+    isbn.value = '9782811645632'
+    await search()
+    expect(error.value).toBeNull()
   })
 })

--- a/front/src/composables/__tests__/useMediaQuery.spec.ts
+++ b/front/src/composables/__tests__/useMediaQuery.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { effectScope } from 'vue'
+import { useMediaQuery, useIsMobile } from '../useMediaQuery'
+
+type ChangeListener = (event: { matches: boolean }) => void
+
+function stubMatchMedia(initialMatches: boolean) {
+  const listeners: ChangeListener[] = []
+  const mediaQueryList = {
+    matches: initialMatches,
+    addEventListener: vi.fn((_type: string, listener: ChangeListener) => listeners.push(listener)),
+    removeEventListener: vi.fn((_type: string, listener: ChangeListener) => {
+      const index = listeners.indexOf(listener)
+      if (index !== -1) listeners.splice(index, 1)
+    }),
+  }
+  const matchMedia = vi.fn(() => mediaQueryList)
+  vi.stubGlobal('matchMedia', matchMedia)
+  return {
+    matchMedia,
+    fireChange(matches: boolean) {
+      listeners.forEach((listener) => listener({ matches }))
+    },
+    mediaQueryList,
+  }
+}
+
+describe('useMediaQuery', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reflects the initial match state', () => {
+    stubMatchMedia(true)
+    const matches = useMediaQuery('(max-width: 639px)')
+    expect(matches.value).toBe(true)
+  })
+
+  it('updates when the media query changes', () => {
+    const stub = stubMatchMedia(false)
+    const matches = useMediaQuery('(max-width: 639px)')
+    expect(matches.value).toBe(false)
+    stub.fireChange(true)
+    expect(matches.value).toBe(true)
+  })
+
+  it('removes its listener when the effect scope is disposed', () => {
+    const stub = stubMatchMedia(false)
+    const scope = effectScope()
+    scope.run(() => useMediaQuery('(max-width: 639px)'))
+    scope.stop()
+    expect(stub.mediaQueryList.removeEventListener).toHaveBeenCalled()
+  })
+
+  it('falls back to false when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined)
+    const matches = useMediaQuery('(max-width: 639px)')
+    expect(matches.value).toBe(false)
+  })
+
+  it('useIsMobile queries the sm breakpoint', () => {
+    const stub = stubMatchMedia(true)
+    const isMobile = useIsMobile()
+    expect(stub.matchMedia).toHaveBeenCalledWith('(max-width: 639px)')
+    expect(isMobile.value).toBe(true)
+  })
+})

--- a/front/src/composables/__tests__/useVolumePrices.spec.ts
+++ b/front/src/composables/__tests__/useVolumePrices.spec.ts
@@ -6,7 +6,7 @@ vi.mock('@/api/manga', () => ({
 }))
 
 import { getVolumePrices } from '@/api/manga'
-import type { PriceOffer } from '@/api/manga'
+import type { PriceOffer, RetailerOffer } from '@/api/manga'
 import { useVolumePrices } from '../useVolumePrices'
 
 const mockGetVolumePrices = vi.mocked(getVolumePrices)
@@ -21,31 +21,42 @@ const OFFER: PriceOffer = {
   source: 'ebay',
 }
 
+const RETAILERS: RetailerOffer[] = [
+  { retailer: 'amazon', label: 'Amazon', status: 'not_found', bestOffer: null },
+  { retailer: 'fnac', label: 'Fnac', status: 'not_found', bestOffer: null },
+  { retailer: 'ebay', label: 'eBay', status: 'found', bestOffer: OFFER },
+]
+
 describe('useVolumePrices', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('starts with empty offers and not loaded', () => {
-    const { offers, hasIsbn, loaded, isLoading } = useVolumePrices('m1', 'v1')
+    const { offers, retailers, hasIsbn, loaded, isLoading } = useVolumePrices('m1', 'v1')
     expect(offers.value).toEqual([])
+    expect(retailers.value).toEqual([])
     expect(hasIsbn.value).toBe(false)
     expect(loaded.value).toBe(false)
     expect(isLoading.value).toBe(false)
   })
 
-  it('load() fetches prices and sets offers', async () => {
+  it('load() fetches prices and sets offers and retailers', async () => {
     mockGetVolumePrices.mockResolvedValueOnce({
       offers: [OFFER],
+      retailers: RETAILERS,
       hasIsbn: true,
       marketplace: 'EBAY_FR',
     })
 
-    const { offers, hasIsbn, loaded, load } = useVolumePrices('m1', 'v1')
+    const { offers, retailers, hasIsbn, loaded, load } = useVolumePrices('m1', 'v1')
     await load()
 
     expect(mockGetVolumePrices).toHaveBeenCalledWith('m1', 'v1', undefined)
     expect(offers.value).toHaveLength(1)
+    expect(retailers.value).toHaveLength(3)
+    expect(retailers.value[2].status).toBe('found')
+    expect(retailers.value[2].bestOffer).toEqual(OFFER)
     expect(hasIsbn.value).toBe(true)
     expect(loaded.value).toBe(true)
   })
@@ -53,6 +64,7 @@ describe('useVolumePrices', () => {
   it('load() accepts a marketplace param', async () => {
     mockGetVolumePrices.mockResolvedValueOnce({
       offers: [],
+      retailers: RETAILERS,
       hasIsbn: true,
       marketplace: 'EBAY_US',
     })
@@ -66,6 +78,7 @@ describe('useVolumePrices', () => {
   it('load() accepts reactive refs as inputs', async () => {
     mockGetVolumePrices.mockResolvedValueOnce({
       offers: [OFFER],
+      retailers: RETAILERS,
       hasIsbn: true,
       marketplace: 'EBAY_FR',
     })
@@ -79,13 +92,14 @@ describe('useVolumePrices', () => {
     expect(offers.value).toHaveLength(1)
   })
 
-  it('load() sets error and clears offers on failure', async () => {
+  it('load() sets error and clears offers and retailers on failure', async () => {
     mockGetVolumePrices.mockRejectedValueOnce(new Error('Network error'))
 
-    const { offers, error, loaded, load } = useVolumePrices('m1', 'v1')
+    const { offers, retailers, error, loaded, load } = useVolumePrices('m1', 'v1')
     await load()
 
     expect(offers.value).toEqual([])
+    expect(retailers.value).toEqual([])
     expect(error.value).toBeTruthy()
     expect(loaded.value).toBe(false)
   })

--- a/front/src/composables/useActivityLogFilters.ts
+++ b/front/src/composables/useActivityLogFilters.ts
@@ -1,0 +1,109 @@
+import { computed, getCurrentScope, onScopeDispose, ref, watch } from 'vue'
+import type { ActivityLogParams } from '@/api/notification'
+import type { EventType, LogStatus } from '@/types'
+
+export interface UseActivityLogFiltersOptions {
+  /** Delay applied to the free-text search before it hits the API. */
+  debounceMs?: number
+  /** Page size sent to the API. */
+  limit?: number
+}
+
+/**
+ * Reactive filter state for the activity journal.
+ *
+ * Exposes raw refs bound to the filter controls, a debounced `search` value,
+ * and a computed `params` object ready to be passed to getActivityLogs().
+ * Any filter change resets the page to 1.
+ */
+export function useActivityLogFilters(options: UseActivityLogFiltersOptions = {}) {
+  const debounceMs = options.debounceMs ?? 350
+  const limit = options.limit ?? 50
+
+  const eventType = ref<EventType | ''>('')
+  const status = ref<LogStatus | ''>('')
+  const collectionEntryId = ref('')
+  const ownerId = ref('')
+  /** datetime-local input values (local timezone) */
+  const from = ref('')
+  const to = ref('')
+  const searchInput = ref('')
+  const search = ref('')
+  const page = ref(1)
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  watch(searchInput, (value) => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      search.value = value.trim()
+    }, debounceMs)
+  })
+
+  watch([eventType, status, collectionEntryId, ownerId, from, to, search], () => {
+    page.value = 1
+  })
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (debounceTimer) clearTimeout(debounceTimer)
+    })
+  }
+
+  function toIso(localValue: string): string | undefined {
+    if (!localValue) return undefined
+    const date = new Date(localValue)
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString()
+  }
+
+  const params = computed<ActivityLogParams>(() => ({
+    page: page.value,
+    limit,
+    eventType: eventType.value || undefined,
+    status: status.value || undefined,
+    collectionEntryId: collectionEntryId.value || undefined,
+    ownerId: ownerId.value || undefined,
+    from: toIso(from.value),
+    to: toIso(to.value),
+    search: search.value || undefined,
+  }))
+
+  function reset(): void {
+    eventType.value = ''
+    status.value = ''
+    collectionEntryId.value = ''
+    ownerId.value = ''
+    from.value = ''
+    to.value = ''
+    searchInput.value = ''
+    search.value = ''
+    page.value = 1
+    if (debounceTimer) clearTimeout(debounceTimer)
+  }
+
+  const hasActiveFilters = computed(
+    () =>
+      eventType.value !== '' ||
+      status.value !== '' ||
+      collectionEntryId.value !== '' ||
+      ownerId.value !== '' ||
+      from.value !== '' ||
+      to.value !== '' ||
+      search.value !== '',
+  )
+
+  return {
+    eventType,
+    status,
+    collectionEntryId,
+    ownerId,
+    from,
+    to,
+    searchInput,
+    search,
+    page,
+    limit,
+    params,
+    hasActiveFilters,
+    reset,
+  }
+}

--- a/front/src/composables/useIsbnCoverSearch.ts
+++ b/front/src/composables/useIsbnCoverSearch.ts
@@ -1,6 +1,7 @@
 import { ref, watch, toRef } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 import { coverByIsbn } from '@/api/manga'
+import { normalizeIsbn13 } from '@/utils/isbn'
 
 export interface IsbnCoverResult {
   coverUrl: string
@@ -9,6 +10,12 @@ export interface IsbnCoverResult {
   source: string
 }
 
+/**
+ * Cover search by ISBN. The input is normalized (separators / EAN add-on stripped,
+ * ISBN-10 converted) before hitting the API, and `error` distinguishes an invalid
+ * ISBN or a backend failure (i18n keys, translated by the caller) from the plain
+ * "0 result" empty state (`covers` empty, `error` null).
+ */
 export function useIsbnCoverSearch(
   isbn: MaybeRefOrGetter<string>,
   options?: { immediate?: boolean },
@@ -17,20 +24,28 @@ export function useIsbnCoverSearch(
   // Grouped: every source's cover for this ISBN (BnF, OpenLibrary, Google…).
   const covers = ref<IsbnCoverResult[]>([])
   const isLoading = ref(false)
+  /** i18n key of the current error, or null. */
   const error = ref<string | null>(null)
 
   async function search(): Promise<void> {
-    const value = isbnRef.value
-    if (!value.trim()) return
+    const rawValue = isbnRef.value
+    if (!rawValue.trim()) return
+
+    covers.value = []
+    error.value = null
+
+    const normalized = normalizeIsbn13(rawValue)
+    if (!normalized) {
+      error.value = 'enrich.isbnInvalid'
+      return
+    }
 
     isLoading.value = true
-    error.value = null
-    covers.value = []
 
     try {
-      covers.value = await coverByIsbn(value)
+      covers.value = await coverByIsbn(normalized)
     } catch {
-      error.value = 'Erreur lors de la recherche de couverture.'
+      error.value = 'enrich.isbnSearchError'
     } finally {
       isLoading.value = false
     }

--- a/front/src/composables/useMediaQuery.ts
+++ b/front/src/composables/useMediaQuery.ts
@@ -1,0 +1,34 @@
+import { onScopeDispose, ref, type Ref } from 'vue'
+
+/**
+ * Reactive CSS media-query matcher.
+ *
+ * Returns a ref that stays in sync with `window.matchMedia(query)`, so
+ * components can branch between mobile and desktop presentations
+ * (e.g. bottom sheet vs. anchored popover).
+ */
+export function useMediaQuery(query: string): Ref<boolean> {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return ref(false)
+  }
+
+  const mediaQueryList = window.matchMedia(query)
+  const matches = ref(mediaQueryList.matches)
+
+  function onChange(event: MediaQueryListEvent): void {
+    matches.value = event.matches
+  }
+
+  mediaQueryList.addEventListener('change', onChange)
+  onScopeDispose(() => mediaQueryList.removeEventListener('change', onChange))
+
+  return matches
+}
+
+/**
+ * True below Tailwind's `sm` breakpoint (640px) — the threshold every
+ * modal/popover in the app uses to switch to its bottom-sheet layout.
+ */
+export function useIsMobile(): Ref<boolean> {
+  return useMediaQuery('(max-width: 639px)')
+}

--- a/front/src/composables/useVolumePrices.ts
+++ b/front/src/composables/useVolumePrices.ts
@@ -2,15 +2,16 @@ import { ref } from 'vue'
 import type { MaybeRefOrGetter } from 'vue'
 import { toValue } from 'vue'
 import { getVolumePrices } from '@/api/manga'
-import type { PriceOffer } from '@/api/manga'
+import type { PriceOffer, RetailerOffer } from '@/api/manga'
 
-export type { PriceOffer }
+export type { PriceOffer, RetailerOffer }
 
 export function useVolumePrices(
   mangaId: MaybeRefOrGetter<string>,
   volumeId: MaybeRefOrGetter<string>,
 ) {
   const offers = ref<PriceOffer[]>([])
+  const retailers = ref<RetailerOffer[]>([])
   const hasIsbn = ref(false)
   const marketplace = ref<string | null>(null)
   const isLoading = ref(false)
@@ -26,16 +27,18 @@ export function useVolumePrices(
     try {
       const result = await getVolumePrices(mid, vid, marketplaceParam)
       offers.value = result.offers
+      retailers.value = result.retailers ?? []
       hasIsbn.value = result.hasIsbn
       marketplace.value = result.marketplace
       loaded.value = true
     } catch {
       error.value = 'Prix indisponibles'
       offers.value = []
+      retailers.value = []
     } finally {
       isLoading.value = false
     }
   }
 
-  return { offers, hasIsbn, marketplace, isLoading, error, loaded, load }
+  return { offers, retailers, hasIsbn, marketplace, isLoading, error, loaded, load }
 }

--- a/front/src/i18n/en.json
+++ b/front/src/i18n/en.json
@@ -91,7 +91,13 @@
       "volumes": "Volumes",
       "editions": "Editions",
       "prices": "Prices"
-    }
+    },
+    "volumeSheetTitle": "Volume {number}",
+    "volumeMenuLabel": "Volume {number} actions",
+    "coverUrlTitle": "Cover URL",
+    "readingStatusTitle": "Reading status",
+    "moreOptionsTitle": "More options",
+    "detailsAction": "Volume details"
   },
   "volume": {
     "price": "Price (€)",
@@ -149,21 +155,32 @@
     "allTypes": "All types",
     "allStatuses": "All statuses",
     "allMangas": "All mangas",
+    "allUsers": "All users",
     "running": "Running",
     "success": "Success",
     "error": "Error",
     "date": "Date",
     "type": "Type",
-    "manga": "Manga",
+    "user": "User",
     "source": "Source",
     "status": "Status",
-    "articles": "Articles",
     "duration": "Duration",
-    "entries": "entries",
     "empty": "No events recorded",
-    "userAction": "User action",
-    "search": "Search",
-    "hint": "Select filters and click Search"
+    "searchPlaceholder": "Search (source, error, API path)…",
+    "from": "From",
+    "to": "To",
+    "reset": "Reset",
+    "live": "Live",
+    "liveHint": "Auto-refreshes every 30 seconds",
+    "totalEntries": "Entries",
+    "pageErrors": "Errors (page)",
+    "pageErrorRate": "Error rate (page)",
+    "avgDuration": "Avg duration (page)",
+    "system": "System",
+    "copyJson": "Copy JSON",
+    "copied": "JSON copied to clipboard",
+    "copyFailed": "Copy failed",
+    "noMetadata": "No metadata"
   },
   "genre": {
     "shonen": "Shōnen",
@@ -260,6 +277,10 @@
     "scanPhone": "Scan with my phone",
     "coverFound": "Cover found",
     "noCoverForIsbn": "No cover found for this ISBN.",
+    "isbnSaved": "ISBN saved for this volume.",
+    "isbnSaveError": "Could not save the ISBN — try again.",
+    "isbnInvalid": "Invalid ISBN — check the 10 or 13 digits.",
+    "isbnSearchError": "Cover search failed — try again.",
     "isbnFromPhone": "ISBN received from phone: {isbn}",
     "searchByTitle": "Search by title",
     "cameraError": "Camera unavailable. Check permissions and ensure the page uses HTTPS.",
@@ -433,8 +454,18 @@
     "loading": "Fetching prices…",
     "empty": "No prices available for this volume.",
     "noIsbn": "This volume has no ISBN — cannot search for prices.",
+    "enterIsbn": "Enter the ISBN",
+    "retailersTitle": "Shops",
+    "otherOffers": "Other offers",
+    "notFound": "Not found",
+    "viewOn": "View on {merchant}",
     "merchantLive": "Live offer",
     "publisherReference": "Publisher price",
     "selectVolume": "Select a volume to see prices."
+  },
+  "admin": {
+    "approve": "Approve",
+    "resetLink": "Reset link",
+    "notConfigured": "not configured"
   }
 }

--- a/front/src/i18n/fr.json
+++ b/front/src/i18n/fr.json
@@ -91,7 +91,13 @@
       "volumes": "Tomes",
       "editions": "Éditions",
       "prices": "Prix"
-    }
+    },
+    "volumeSheetTitle": "Tome {number}",
+    "volumeMenuLabel": "Actions du tome {number}",
+    "coverUrlTitle": "URL de la couverture",
+    "readingStatusTitle": "Statut de lecture",
+    "moreOptionsTitle": "Plus d'options",
+    "detailsAction": "Détails du tome"
   },
   "volume": {
     "price": "Prix (€)",
@@ -149,21 +155,32 @@
     "allTypes": "Tous les types",
     "allStatuses": "Tous les statuts",
     "allMangas": "Tous les mangas",
+    "allUsers": "Tous les utilisateurs",
     "running": "En cours",
     "success": "Succès",
     "error": "Erreur",
     "date": "Date",
     "type": "Type",
-    "manga": "Manga",
+    "user": "Utilisateur",
     "source": "Source",
     "status": "Statut",
-    "articles": "Articles",
     "duration": "Durée",
-    "entries": "entrées",
     "empty": "Aucun événement enregistré",
-    "userAction": "Action utilisateur",
-    "search": "Rechercher",
-    "hint": "Sélectionnez des filtres et cliquez sur Rechercher"
+    "searchPlaceholder": "Rechercher (source, erreur, chemin d'API)…",
+    "from": "Du",
+    "to": "Au",
+    "reset": "Réinitialiser",
+    "live": "Live",
+    "liveHint": "Actualisation automatique toutes les 30 secondes",
+    "totalEntries": "Entrées",
+    "pageErrors": "Erreurs (page)",
+    "pageErrorRate": "Taux d'erreur (page)",
+    "avgDuration": "Durée moyenne (page)",
+    "system": "Système",
+    "copyJson": "Copier le JSON",
+    "copied": "JSON copié dans le presse-papiers",
+    "copyFailed": "La copie a échoué",
+    "noMetadata": "Aucune métadonnée"
   },
   "genre": {
     "shonen": "Shōnen",
@@ -260,6 +277,10 @@
     "scanPhone": "Scanner avec mon téléphone",
     "coverFound": "Couverture trouvée",
     "noCoverForIsbn": "Aucune couverture pour cet ISBN.",
+    "isbnSaved": "ISBN enregistré pour ce tome.",
+    "isbnSaveError": "Impossible d'enregistrer l'ISBN — réessayez.",
+    "isbnInvalid": "ISBN invalide — vérifiez les 10 ou 13 chiffres.",
+    "isbnSearchError": "Erreur lors de la recherche de couverture — réessayez.",
     "isbnFromPhone": "ISBN reçu du téléphone : {isbn}",
     "searchByTitle": "Chercher par titre",
     "cameraError": "Caméra indisponible. Vérifiez les autorisations et que la page est en HTTPS.",
@@ -433,8 +454,18 @@
     "loading": "Recherche des prix…",
     "empty": "Aucun prix disponible pour ce tome.",
     "noIsbn": "Ce tome n'a pas d'ISBN — impossible de chercher les prix.",
+    "enterIsbn": "Saisir l'ISBN",
+    "retailersTitle": "Boutiques",
+    "otherOffers": "Autres offres",
+    "notFound": "Introuvable",
+    "viewOn": "Voir sur {merchant}",
     "merchantLive": "Offre en direct",
     "publisherReference": "Prix éditeur",
     "selectVolume": "Sélectionnez un tome pour voir les prix."
+  },
+  "admin": {
+    "approve": "Approuver",
+    "resetLink": "Lien de réinitialisation",
+    "notConfigured": "non configuré"
   }
 }

--- a/front/src/pages/AdminUsersPage.vue
+++ b/front/src/pages/AdminUsersPage.vue
@@ -12,8 +12,11 @@ import {
 import type { User } from '@/api/auth'
 import { useUiStore } from '@/stores/useUiStore'
 import { X } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
+import BaseModal from '@/components/atoms/BaseModal.vue'
 
+const { t } = useI18n()
 const ui = useUiStore()
 const queryClient = useQueryClient()
 
@@ -168,7 +171,63 @@ async function copyResetLink(user: User): Promise<void> {
       Aucun utilisateur trouvé.
     </div>
 
-    <div v-else class="overflow-x-auto rounded-lg border border-base-200">
+    <!-- Mobile: stacked cards (the 6-column table is unusable on a phone) -->
+    <div v-else class="space-y-3 sm:hidden">
+      <div
+        v-for="user in data?.items"
+        :key="user.id"
+        class="rounded-xl border border-base-200 bg-base-100 p-4 space-y-3"
+      >
+        <div class="flex items-start gap-3">
+          <div class="avatar avatar-placeholder shrink-0">
+            <div class="w-10 rounded-full bg-primary/15 text-primary">
+              <span class="text-xs font-semibold">{{ initials(user.displayName) }}</span>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="font-semibold leading-tight truncate">{{ user.displayName }}</p>
+            <p class="text-xs text-base-content/50 truncate">{{ user.email }}</p>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-1.5">
+          <span
+            class="badge badge-sm"
+            :class="user.role === 'ROLE_ADMIN' ? 'badge-primary' : 'badge-ghost'"
+          >
+            {{ user.role === 'ROLE_ADMIN' ? 'Admin' : 'Utilisateur' }}
+          </span>
+          <span class="badge badge-sm" :class="STATUS_BADGES[user.status]">
+            {{ STATUS_LABELS[user.status] }}
+          </span>
+          <span class="badge badge-sm badge-ghost capitalize">
+            {{ user.notificationChannel }}<template v-if="user.notificationConfigured === false"> · {{ t('admin.notConfigured') }}</template>
+          </span>
+        </div>
+
+        <div class="grid grid-cols-2 gap-2">
+          <button
+            v-if="user.status === 'pending_admin_approval'"
+            class="btn btn-success btn-sm col-span-2"
+            @click="approve(user)"
+          >
+            {{ t('admin.approve') }}
+          </button>
+          <button class="btn btn-outline btn-sm" @click="openEdit(user)">
+            {{ t('common.edit') }}
+          </button>
+          <button class="btn btn-outline btn-sm" @click="copyResetLink(user)">
+            {{ t('admin.resetLink') }}
+          </button>
+          <button class="btn btn-error btn-outline btn-sm col-span-2" @click="remove(user)">
+            {{ t('common.delete') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Desktop: full table -->
+    <div v-if="!isPending && (data?.items.length ?? 0) > 0" class="hidden sm:block overflow-x-auto rounded-lg border border-base-200">
       <table class="table table-zebra">
         <thead>
           <tr>
@@ -251,8 +310,12 @@ async function copyResetLink(user: User): Promise<void> {
     </div>
 
     <!-- Edit modal -->
-    <dialog v-if="editing !== null" class="modal modal-open" @close="closeEdit">
-      <div class="modal-box max-w-md p-0 overflow-hidden">
+    <BaseModal
+      :open="editing !== null"
+      max-width-class="sm:max-w-md"
+      @close="closeEdit"
+    >
+      <template v-if="editing">
         <!-- Header -->
         <div class="flex items-center gap-3 px-5 py-4 border-b border-base-200">
           <div class="avatar avatar-placeholder">
@@ -270,7 +333,7 @@ async function copyResetLink(user: User): Promise<void> {
         </div>
 
         <!-- Body -->
-        <div class="px-5 py-4 space-y-4">
+        <div class="px-5 py-4 space-y-4 overflow-y-auto">
           <div>
             <label class="text-sm font-medium">Nom d'affichage</label>
             <input
@@ -311,8 +374,7 @@ async function copyResetLink(user: User): Promise<void> {
             Enregistrer
           </button>
         </div>
-      </div>
-      <form method="dialog" class="modal-backdrop"><button @click="closeEdit">close</button></form>
-    </dialog>
+      </template>
+    </BaseModal>
   </div>
 </template>

--- a/front/src/pages/CollectionPage.vue
+++ b/front/src/pages/CollectionPage.vue
@@ -266,8 +266,8 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <!-- Sticky filter bar -->
-    <div class="sticky top-0 z-10 bg-base-100/90 backdrop-blur-md border-b border-base-200/70 shadow-[0_1px_0_0_rgba(0,0,0,0.02)]">
+    <!-- Sticky filter bar — sticks below the fixed mobile header (h-14 + notch) -->
+    <div class="sticky top-mobile-header lg:top-0 z-20 bg-base-100/90 backdrop-blur-md border-b border-base-200/70 shadow-[0_1px_0_0_rgba(0,0,0,0.02)]">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 py-3 space-y-3">
 
         <!-- Row 1: Search + refine toggle + reset -->

--- a/front/src/pages/GatePage.vue
+++ b/front/src/pages/GatePage.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
+import BaseModal from '@/components/atoms/BaseModal.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -42,8 +43,14 @@ function cancel() {
 </script>
 
 <template>
-  <div class="modal modal-open">
-    <div class="modal-box max-w-sm">
+  <div class="min-h-screen bg-base-200" />
+
+  <BaseModal
+    :open="true"
+    max-width-class="sm:max-w-sm"
+    @close="cancel"
+  >
+    <div class="p-6 pb-4 sm:pb-6">
       <h3 class="font-bold text-lg">Accès administrateur</h3>
       <p class="py-2 text-sm text-base-content/70">
         Entrez le mot de passe d'accès pour débloquer cette section.
@@ -57,6 +64,7 @@ function cancel() {
             placeholder="Mot de passe d'accès"
             class="input input-bordered w-full"
             :class="{ 'input-error': error }"
+            autocomplete="current-password"
             autofocus
           />
           <label v-if="error" class="label">
@@ -64,7 +72,7 @@ function cancel() {
           </label>
         </div>
 
-        <div class="modal-action mt-0">
+        <div class="flex justify-end gap-2">
           <button
             type="button"
             class="btn btn-ghost"
@@ -84,6 +92,5 @@ function cancel() {
         </div>
       </form>
     </div>
-    <div class="modal-backdrop bg-base-200/80" />
-  </div>
+  </BaseModal>
 </template>

--- a/front/src/pages/JournalPage.vue
+++ b/front/src/pages/JournalPage.vue
@@ -1,137 +1,250 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
-import { useQuery } from '@tanstack/vue-query'
+import { computed } from 'vue'
+import { keepPreviousData, useQuery } from '@tanstack/vue-query'
 import { useI18n } from 'vue-i18n'
+import { RotateCcw, Search } from 'lucide-vue-next'
 import { getActivityLogs } from '@/api/notification'
 import { getCollection } from '@/api/collection'
+import { getUsers } from '@/api/admin'
+import { useActivityLogFilters } from '@/composables/useActivityLogFilters'
+import { EVENT_TYPE_LABELS } from '@/utils/activityLog'
 import ActivityLogRow from '@/components/molecules/ActivityLogRow.vue'
+import ActivityLogCard from '@/components/molecules/ActivityLogCard.vue'
 import BaseLoader from '@/components/atoms/BaseLoader.vue'
 import type { EventType, LogStatus } from '@/types'
 
 const { t } = useI18n()
 
-const page      = ref(1)
-const limit     = 50
-const eventType = ref<EventType | ''>('')
-const status    = ref<LogStatus | ''>('')
-const ceId      = ref<string>('')
-const searched  = ref(false)
+const filters = useActivityLogFilters()
+const { eventType, status, collectionEntryId, ownerId, from, to, searchInput, page } = filters
 
-const { data: collection } = useQuery({ queryKey: ['collection'], queryFn: () => getCollection() })
+const { data: collection } = useQuery({
+  queryKey: ['collection'],
+  queryFn: () => getCollection(),
+  staleTime: 60_000,
+})
 
-const { data, isLoading, isFetching, refetch } = useQuery({
-  queryKey: computed(() => ['journal', page.value, eventType.value, status.value, ceId.value]),
-  queryFn: () => getActivityLogs({
-    page: page.value,
-    limit,
-    eventType: eventType.value || undefined,
-    status:    status.value    || undefined,
-    collectionEntryId: ceId.value || undefined,
-  }),
-  enabled: searched,
-  // Plain number — not a computed. TanStack Query + enabled:searched already gates execution.
+const { data: users } = useQuery({
+  queryKey: ['admin', 'users', 'journal-filter'],
+  queryFn: () => getUsers({ limit: 100 }),
+  staleTime: 60_000,
+})
+
+const { data, isLoading, isFetching } = useQuery({
+  queryKey: computed(() => ['journal', filters.params.value]),
+  queryFn: () => getActivityLogs(filters.params.value),
+  placeholderData: keepPreviousData,
   refetchInterval: 30_000,
 })
 
-function search() {
-  page.value = 1
-  searched.value = true
-  refetch()
-}
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil((data.value?.total ?? 0) / filters.limit)),
+)
+
+// ── Summary band (current page) ───────────────────────────────────────────
+
+const pageErrorCount = computed(
+  () => (data.value?.items ?? []).filter((log) => log.status === 'error').length,
+)
+
+const pageErrorRate = computed(() => {
+  const count = data.value?.items.length ?? 0
+  if (count === 0) return 0
+  return Math.round((pageErrorCount.value / count) * 100)
+})
+
+const pageAverageDuration = computed(() => {
+  const durations = (data.value?.items ?? [])
+    .map((log) => log.durationMs)
+    .filter((duration): duration is number => duration !== null)
+  if (durations.length === 0) return null
+  return Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length)
+})
 
 const EVENT_TYPES: { value: EventType | ''; label: string }[] = [
-  { value: '',                  label: t('journal.allTypes') },
-  { value: 'rss_fetch',         label: 'RSS' },
-  { value: 'jikan_fetch',       label: 'Jikan' },
-  { value: 'discord_sent',      label: 'Discord' },
-  { value: 'scheduler_fire',    label: 'Scheduler' },
-  { value: 'worker_failure',    label: 'Worker' },
-  { value: 'user_action',       label: t('journal.userAction') },
-  { value: 'collection_action', label: 'Collection' },
-  { value: 'manga_action',      label: 'Manga' },
-  { value: 'auth_action',       label: 'Auth' },
-  { value: 'wishlist_action',   label: 'Wishlist' },
+  { value: '', label: t('journal.allTypes') },
+  ...(Object.entries(EVENT_TYPE_LABELS) as [EventType, string][]).map(([value, label]) => ({
+    value,
+    label,
+  })),
 ]
 
 const STATUSES: { value: LogStatus | ''; label: string }[] = [
-  { value: '',        label: t('journal.allStatuses') },
+  { value: '', label: t('journal.allStatuses') },
   { value: 'running', label: t('journal.running') },
   { value: 'success', label: t('journal.success') },
-  { value: 'error',   label: t('journal.error') },
+  { value: 'error', label: t('journal.error') },
 ]
 </script>
 
 <template>
   <div class="p-4 sm:p-6 space-y-4">
-    <h1 class="text-2xl font-bold">{{ t('journal.title') }}</h1>
-
-    <!-- Filters -->
-    <div class="flex gap-3 flex-wrap items-center">
-      <select v-model="eventType" class="select select-sm select-bordered">
-        <option v-for="o in EVENT_TYPES" :key="o.value" :value="o.value">{{ o.label }}</option>
-      </select>
-      <select v-model="status" class="select select-sm select-bordered">
-        <option v-for="o in STATUSES" :key="o.value" :value="o.value">{{ o.label }}</option>
-      </select>
-      <select v-model="ceId" class="select select-sm select-bordered">
-        <option value="">{{ t('journal.allMangas') }}</option>
-        <option v-for="e in collection?.items" :key="e.id" :value="e.id">{{ e.manga.title }}</option>
-      </select>
-      <button class="btn btn-sm btn-primary" :disabled="isFetching" @click="search">
-        <BaseLoader v-if="isFetching" size="xs" />
-        {{ t('journal.search') }}
-      </button>
-      <span v-if="searched" class="text-xs text-base-content/40 ml-auto">
-        {{ data?.total ?? 0 }} {{ t('journal.entries') }}
+    <div class="flex items-center gap-3 flex-wrap">
+      <h1 class="text-2xl font-bold">{{ t('journal.title') }}</h1>
+      <!-- Live auto-refresh indicator -->
+      <span
+        class="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-base-content/40"
+        :title="t('journal.liveHint')"
+      >
+        <span class="relative flex h-2 w-2">
+          <span
+            class="absolute inline-flex h-full w-full rounded-full bg-success opacity-60"
+            :class="{ 'animate-ping': isFetching }"
+          />
+          <span class="relative inline-flex h-2 w-2 rounded-full bg-success" />
+        </span>
+        {{ t('journal.live') }}
       </span>
     </div>
 
-    <!-- Initial state -->
-    <div v-if="!searched" class="py-16 text-center text-base-content/40 text-sm">
-      {{ t('journal.hint') }}
-    </div>
+    <!-- Filters -->
+    <div class="rounded-xl border border-base-300 bg-base-100 p-3 space-y-3">
+      <label class="input input-sm input-bordered flex items-center gap-2 w-full">
+        <Search class="w-4 h-4 text-base-content/40 shrink-0" />
+        <input
+          v-model="searchInput"
+          type="text"
+          class="grow"
+          :placeholder="t('journal.searchPlaceholder')"
+        />
+      </label>
 
-    <!-- Loading skeleton -->
-    <div v-else-if="isLoading" class="space-y-1">
-      <div v-for="i in 10" :key="i" class="h-10 rounded bg-base-200 animate-pulse" />
-    </div>
+      <div class="flex gap-2 flex-wrap items-center">
+        <select v-model="eventType" class="select select-sm select-bordered">
+          <option v-for="option in EVENT_TYPES" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
 
-    <!-- Table -->
-    <div v-else class="overflow-x-auto rounded-xl border border-base-300">
-      <table class="table table-xs w-full">
-        <thead>
-          <tr class="text-base-content/50">
-            <th>{{ t('journal.date') }}</th>
-            <th>{{ t('journal.type') }}</th>
-            <th>{{ t('journal.manga') }}</th>
-            <th>{{ t('journal.source') }}</th>
-            <th>{{ t('journal.status') }}</th>
-            <th class="text-right">{{ t('journal.articles') }}</th>
-            <th class="text-right">{{ t('journal.duration') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <template v-for="log in data?.items ?? []" :key="log.id">
-            <ActivityLogRow :log="log" />
-          </template>
-        </tbody>
-      </table>
-      <div v-if="!data?.items?.length" class="py-12 text-center text-base-content/40 text-sm">
-        {{ t('journal.empty') }}
+        <select v-model="status" class="select select-sm select-bordered">
+          <option v-for="option in STATUSES" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+
+        <select v-model="ownerId" class="select select-sm select-bordered">
+          <option value="">{{ t('journal.allUsers') }}</option>
+          <option v-for="user in users?.items ?? []" :key="user.id" :value="user.id">
+            {{ user.displayName }} — {{ user.email }}
+          </option>
+        </select>
+
+        <select v-model="collectionEntryId" class="select select-sm select-bordered">
+          <option value="">{{ t('journal.allMangas') }}</option>
+          <option v-for="entry in collection?.items ?? []" :key="entry.id" :value="entry.id">
+            {{ entry.manga.title }}
+          </option>
+        </select>
+
+        <label class="flex items-center gap-1 text-xs text-base-content/60">
+          {{ t('journal.from') }}
+          <input v-model="from" type="datetime-local" class="input input-sm input-bordered" />
+        </label>
+
+        <label class="flex items-center gap-1 text-xs text-base-content/60">
+          {{ t('journal.to') }}
+          <input v-model="to" type="datetime-local" class="input input-sm input-bordered" />
+        </label>
+
+        <button
+          v-if="filters.hasActiveFilters.value"
+          class="btn btn-sm btn-ghost gap-1"
+          @click="filters.reset()"
+        >
+          <RotateCcw class="w-3.5 h-3.5" />
+          {{ t('journal.reset') }}
+        </button>
       </div>
     </div>
 
+    <!-- Summary band -->
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+        <div class="text-[11px] uppercase tracking-wide text-base-content/40">
+          {{ t('journal.totalEntries') }}
+        </div>
+        <div class="text-xl font-bold tabular-nums">{{ data?.total ?? 0 }}</div>
+      </div>
+      <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+        <div class="text-[11px] uppercase tracking-wide text-base-content/40">
+          {{ t('journal.pageErrors') }}
+        </div>
+        <div class="text-xl font-bold tabular-nums" :class="{ 'text-error': pageErrorCount > 0 }">
+          {{ pageErrorCount }}
+        </div>
+      </div>
+      <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+        <div class="text-[11px] uppercase tracking-wide text-base-content/40">
+          {{ t('journal.pageErrorRate') }}
+        </div>
+        <div class="text-xl font-bold tabular-nums" :class="{ 'text-error': pageErrorRate > 0 }">
+          {{ pageErrorRate }}%
+        </div>
+      </div>
+      <div class="rounded-xl border border-base-300 bg-base-100 p-3">
+        <div class="text-[11px] uppercase tracking-wide text-base-content/40">
+          {{ t('journal.avgDuration') }}
+        </div>
+        <div class="text-xl font-bold tabular-nums">
+          {{ pageAverageDuration !== null ? `${pageAverageDuration} ms` : '—' }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading skeleton -->
+    <div v-if="isLoading" class="space-y-1">
+      <div v-for="index in 10" :key="index" class="h-10 rounded bg-base-200 animate-pulse" />
+    </div>
+
+    <template v-else>
+      <!-- Desktop table -->
+      <div class="hidden sm:block overflow-x-auto rounded-xl border border-base-300">
+        <table class="table table-xs w-full">
+          <thead>
+            <tr class="text-base-content/50">
+              <th class="w-6"></th>
+              <th>{{ t('journal.date') }}</th>
+              <th>{{ t('journal.type') }}</th>
+              <th>{{ t('journal.user') }}</th>
+              <th>{{ t('journal.source') }}</th>
+              <th>{{ t('journal.status') }}</th>
+              <th class="text-right">{{ t('journal.duration') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="log in data?.items ?? []" :key="log.id">
+              <ActivityLogRow :log="log" />
+            </template>
+          </tbody>
+        </table>
+        <div v-if="!data?.items?.length" class="py-12 text-center text-base-content/40 text-sm">
+          {{ t('journal.empty') }}
+        </div>
+      </div>
+
+      <!-- Mobile cards -->
+      <div class="sm:hidden space-y-2">
+        <ActivityLogCard v-for="log in data?.items ?? []" :key="log.id" :log="log" />
+        <div v-if="!data?.items?.length" class="py-12 text-center text-base-content/40 text-sm">
+          {{ t('journal.empty') }}
+        </div>
+      </div>
+    </template>
+
     <!-- Pagination -->
-    <div v-if="(data?.totalPages ?? 0) > 1" class="flex justify-center gap-2">
-      <button class="btn btn-sm btn-ghost" :disabled="page === 1" @click="page--">‹</button>
+    <div v-if="totalPages > 1" class="flex justify-center items-center gap-2">
+      <button class="btn btn-sm btn-ghost" :disabled="page === 1 || isFetching" @click="page--">
+        ‹
+      </button>
+      <span class="text-xs text-base-content/60 tabular-nums"> {{ page }} / {{ totalPages }} </span>
       <button
-        v-for="p in data!.totalPages"
-        :key="p"
-        class="btn btn-sm"
-        :class="p === page ? 'btn-primary' : 'btn-ghost'"
-        @click="page = p"
-      >{{ p }}</button>
-      <button class="btn btn-sm btn-ghost" :disabled="page === data!.totalPages" @click="page++">›</button>
+        class="btn btn-sm btn-ghost"
+        :disabled="page >= totalPages || isFetching"
+        @click="page++"
+      >
+        ›
+      </button>
+      <BaseLoader v-if="isFetching" size="xs" />
     </div>
   </div>
 </template>

--- a/front/src/pages/MangaDetailPage.vue
+++ b/front/src/pages/MangaDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
@@ -30,6 +30,8 @@ import BaseHeartRating from '@/components/atoms/BaseHeartRating.vue'
 import { FRENCH_EDITIONS } from '@/data/editions'
 import BaseEditionSelector from '@/components/atoms/BaseEditionSelector.vue'
 import BaseLazyImage from '@/components/atoms/BaseLazyImage.vue'
+import BaseModal from '@/components/atoms/BaseModal.vue'
+import { useIsMobile } from '@/composables/useMediaQuery'
 import type { CollectionEntryDetail, ReadingStatus, VolumeEntry, VolumeToggleField } from '@/types'
 import { coverUrl } from '@/utils/coverUrl'
 
@@ -40,6 +42,9 @@ const ui = useUiStore()
 const { t } = useI18n()
 
 const id = route.params.id as string
+
+// Below `sm`, every anchored popover of this page turns into a bottom sheet.
+const isMobile = useIsMobile()
 
 // ── Tab navigation ──
 const tabParam = computed<'volumes' | 'editions' | 'prix'>(() => {
@@ -304,23 +309,61 @@ function selectAnnounced() {
   selectedIds.value = new Set(sortedVolumes.value.filter((v) => v.isAnnounced && !v.isOwned).map((v) => v.id))
 }
 
-// ── Context menu ──
+// ── Volume quick actions ──
+// Desktop: right-click context menu (teleported, clamped to the viewport by
+// measuring the rendered menu). Mobile: bottom sheet, opened either by the
+// visible "⋯" button on each tile or by a long-press (contextmenu event).
 const contextMenu = ref<{ ve: VolumeEntry; x: number; y: number } | null>(null)
+const contextMenuRef = ref<HTMLElement | null>(null)
+const actionSheetVeId = ref<string | null>(null)
 
-function openContextMenu(event: MouseEvent, ve: VolumeEntry) {
-  const x = Math.min(event.clientX, window.innerWidth - 216)
-  const y = Math.min(event.clientY, window.innerHeight - 200)
-  contextMenu.value = { ve, x, y }
+// Derived from the query cache so optimistic toggles refresh the open sheet.
+const actionSheetVolume = computed(() =>
+  sortedVolumes.value.find((volumeEntry) => volumeEntry.id === actionSheetVeId.value) ?? null,
+)
+
+function openVolumeActions(ve: VolumeEntry) {
+  actionSheetVeId.value = ve.id
+}
+
+async function openContextMenu(event: MouseEvent, ve: VolumeEntry) {
+  if (isMobile.value) {
+    openVolumeActions(ve)
+    return
+  }
+  contextMenu.value = { ve, x: event.clientX, y: event.clientY }
+  // Clamp against the real rendered size instead of magic constants.
+  await nextTick()
+  const menuElement = contextMenuRef.value
+  if (!menuElement || !contextMenu.value) return
+  const menuRect = menuElement.getBoundingClientRect()
+  contextMenu.value = {
+    ve,
+    x: Math.max(8, Math.min(event.clientX, window.innerWidth - menuRect.width - 8)),
+    y: Math.max(8, Math.min(event.clientY, window.innerHeight - menuRect.height - 8)),
+  }
 }
 
 function closeContextMenu() {
   contextMenu.value = null
 }
 
+function closeActionSheet() {
+  actionSheetVeId.value = null
+}
+
 function openModalFromContext() {
   if (contextMenu.value) {
     openVolumeModal(contextMenu.value.ve)
     closeContextMenu()
+  }
+}
+
+function openModalFromActionSheet() {
+  if (actionSheetVolume.value) {
+    const ve = actionSheetVolume.value
+    closeActionSheet()
+    openVolumeModal(ve)
   }
 }
 
@@ -594,16 +637,17 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   <Pencil class="h-7 w-7 text-white" />
                 </div>
               </div>
-              <!-- Cover URL edit popover -->
+              <!-- Cover URL edit — anchored popover on desktop only -->
               <div
-                v-if="editingCover"
+                v-if="editingCover && !isMobile"
                 class="absolute top-full left-0 mt-2 z-30 bg-base-100 border border-base-300 rounded-xl shadow-2xl p-3 w-[min(16rem,calc(100vw-2rem))]"
                 @click.stop
               >
-                <p class="text-xs text-base-content/50 mb-1.5 font-medium">URL de la couverture</p>
+                <p class="text-xs text-base-content/50 mb-1.5 font-medium">{{ t('manga.coverUrlTitle') }}</p>
                 <input
                   v-model="editCoverValue"
                   type="url"
+                  inputmode="url"
                   class="input input-bordered input-xs w-full font-mono text-[11px]"
                   placeholder="https://..."
                   autofocus
@@ -611,10 +655,35 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   @keydown.escape="cancelEditCover"
                 />
                 <div class="flex gap-1.5 mt-2">
-                  <button class="btn btn-primary btn-xs flex-1" @click="saveCover">Enregistrer</button>
-                  <button class="btn btn-ghost btn-xs" @click="cancelEditCover">Annuler</button>
+                  <button class="btn btn-primary btn-xs flex-1" @click="saveCover">{{ t('common.save') }}</button>
+                  <button class="btn btn-ghost btn-xs" @click="cancelEditCover">{{ t('common.cancel') }}</button>
                 </div>
               </div>
+
+              <!-- Cover URL edit — bottom sheet on mobile (the cover is centered,
+                   an anchored popover would overflow the viewport) -->
+              <BaseModal
+                :open="editingCover && isMobile"
+                max-width-class="sm:max-w-sm"
+                z-class="z-[80]"
+                @close="cancelEditCover"
+              >
+                <div class="p-5" @click.stop>
+                  <p class="text-sm font-semibold mb-2">{{ t('manga.coverUrlTitle') }}</p>
+                  <input
+                    v-model="editCoverValue"
+                    type="url"
+                    inputmode="url"
+                    class="input input-bordered w-full font-mono text-xs"
+                    placeholder="https://..."
+                    @keydown.enter="saveCover"
+                  />
+                  <div class="flex gap-2 mt-3">
+                    <button class="btn btn-primary flex-1" @click="saveCover">{{ t('common.save') }}</button>
+                    <button class="btn btn-ghost" @click="cancelEditCover">{{ t('common.cancel') }}</button>
+                  </div>
+                </div>
+              </BaseModal>
             </div>
 
             <div class="flex-1 min-w-0 space-y-3">
@@ -766,12 +835,12 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   </button>
                   <Transition name="menu-pop">
                     <div
-                      v-if="statusMenuOpen"
+                      v-if="statusMenuOpen && !isMobile"
                       class="absolute left-0 top-[calc(100%+6px)] z-30 min-w-[230px] rounded-2xl border border-base-300 bg-base-100 shadow-2xl p-1.5"
                       role="menu"
                     >
                       <div class="px-2.5 py-2 text-[10px] font-bold uppercase tracking-widest text-base-content/40 flex items-center justify-between">
-                        Statut de lecture
+                        {{ t('manga.readingStatusTitle') }}
                         <button class="text-base-content/35 hover:text-primary" :aria-label="t('guide.openTooltip')" @click="statusMenuOpen = false; showGuide = true">
                           <HelpCircle class="h-3.5 w-3.5" />
                         </button>
@@ -790,6 +859,35 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                       </button>
                     </div>
                   </Transition>
+
+                  <!-- Mobile: reading status as a bottom sheet -->
+                  <BaseModal
+                    :open="statusMenuOpen && isMobile"
+                    max-width-class="sm:max-w-sm"
+                    z-class="z-[80]"
+                    @close="statusMenuOpen = false"
+                  >
+                    <div class="p-3 pt-4">
+                      <div class="px-2 pb-2 text-[10px] font-bold uppercase tracking-widest text-base-content/40 flex items-center justify-between">
+                        {{ t('manga.readingStatusTitle') }}
+                        <button class="text-base-content/35 hover:text-primary" :aria-label="t('guide.openTooltip')" @click="statusMenuOpen = false; showGuide = true">
+                          <HelpCircle class="h-4 w-4" />
+                        </button>
+                      </div>
+                      <button
+                        v-for="s in STATUS_OPTIONS"
+                        :key="s.value"
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200"
+                        :class="entry.readingStatus === s.value ? 'text-base-content' : 'text-base-content/70'"
+                        role="menuitem"
+                        @click="pickStatus(s.value)"
+                      >
+                        <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="s.dot" />
+                        {{ s.label }}
+                        <Check v-if="entry.readingStatus === s.value" class="h-4 w-4 ml-auto text-primary" />
+                      </button>
+                    </div>
+                  </BaseModal>
                 </div>
 
                 <div class="flex-1 min-w-2" />
@@ -833,7 +931,7 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   </div>
                   <Transition name="menu-pop">
                     <div
-                      v-if="moreMenuOpen"
+                      v-if="moreMenuOpen && !isMobile"
                       class="absolute right-0 top-[calc(100%+6px)] z-30 min-w-[250px] rounded-2xl border border-base-300 bg-base-100 shadow-2xl p-1.5"
                       role="menu"
                     >
@@ -882,6 +980,63 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                       </button>
                     </div>
                   </Transition>
+
+                  <!-- Mobile: secondary actions as a bottom sheet -->
+                  <BaseModal
+                    :open="moreMenuOpen && isMobile"
+                    max-width-class="sm:max-w-sm"
+                    z-class="z-[80]"
+                    @close="moreMenuOpen = false"
+                  >
+                    <div class="p-3 pt-4">
+                      <div class="px-2 pb-2 text-[10px] font-bold uppercase tracking-widest text-base-content/40">
+                        {{ t('manga.moreOptionsTitle') }}
+                      </div>
+                      <button
+                        v-if="missingVolumes.length > 0"
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200"
+                        role="menuitem"
+                        @click="moreMenuOpen = false; addToWishlistMutation.mutate()"
+                      >
+                        <Star class="h-[18px] w-[18px] text-base-content/50" />
+                        Souhaiter les {{ missingVolumes.length }} manquant{{ missingVolumes.length > 1 ? 's' : '' }}
+                      </button>
+                      <button
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200 disabled:opacity-50"
+                        role="menuitem"
+                        :disabled="autoFillMutation.isPending.value || (batchProgress.progress.value !== null && !batchProgress.progress.value.done)"
+                        @click="moreMenuOpen = false; autoFillMutation.mutate()"
+                      >
+                        <Sparkles class="h-[18px] w-[18px] text-base-content/50" />
+                        Compléter les couvertures
+                      </button>
+                      <button
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200"
+                        role="menuitem"
+                        @click="moreMenuOpen = false; showPrice = true"
+                      >
+                        <Tag class="h-[18px] w-[18px] text-base-content/50" />
+                        Définir le prix (en lot)
+                      </button>
+                      <div class="h-px bg-base-200 my-1 mx-2" />
+                      <button
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200"
+                        role="menuitem"
+                        @click="moreMenuOpen = false; showGuide = true"
+                      >
+                        <HelpCircle class="h-[18px] w-[18px] text-base-content/50" />
+                        {{ t('guide.openLabel') }}
+                      </button>
+                      <button
+                        class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors text-error hover:bg-error/10"
+                        role="menuitem"
+                        @click="moreMenuOpen = false; showDeleteConfirm = true"
+                      >
+                        <Trash2 class="h-[17px] w-[17px]" />
+                        Retirer la série
+                      </button>
+                    </div>
+                  </BaseModal>
                 </div>
               </div>
 
@@ -1148,6 +1303,17 @@ function volumeOpacityClass(ve: VolumeEntry): string {
                   <Eye class="h-4 w-4 text-primary" />
                 </div>
               </div>
+
+              <!-- Mobile quick actions — visible "⋯" trigger (long-press via
+                   @contextmenu is unreliable on iOS Safari) -->
+              <button
+                v-if="!batchMode"
+                class="sm:hidden absolute bottom-1 right-1 z-10 w-8 h-8 flex items-center justify-center rounded-full bg-base-100/90 text-base-content/70 shadow ring-1 ring-base-300"
+                :aria-label="t('manga.volumeMenuLabel', { number: ve.number })"
+                @click.stop="openVolumeActions(ve)"
+              >
+                <MoreHorizontal class="h-4 w-4" />
+              </button>
             </div>
 
             <!-- Announced badge (top-left) -->
@@ -1219,7 +1385,8 @@ function volumeOpacityClass(ve: VolumeEntry): string {
       <!-- Prix tab -->
       <div v-if="tabParam === 'prix'" class="max-w-5xl mx-auto px-4 sm:px-6 py-6">
         <p class="text-xs text-base-content/50 mb-4">{{ t('prices.selectVolume') }}</p>
-        <div class="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2">
+        <!-- 3 columns max on mobile so each tile stays a comfortable tap target -->
+        <div class="grid grid-cols-3 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-3 sm:gap-2">
           <div
             v-for="ve in sortedVolumes"
             :key="ve.id"
@@ -1265,10 +1432,11 @@ function volumeOpacityClass(ve: VolumeEntry): string {
     </template>
   </div>
 
-  <!-- ── Context Menu ── -->
+  <!-- ── Context Menu (desktop right-click) ── -->
   <Teleport to="body">
     <div v-if="contextMenu" class="fixed inset-0 z-[90]" @click="closeContextMenu">
       <div
+        ref="contextMenuRef"
         class="absolute bg-base-100 rounded-xl shadow-2xl border border-base-300 overflow-hidden w-48 py-1"
         :style="{ top: `${contextMenu.y}px`, left: `${contextMenu.x}px` }"
         @click.stop
@@ -1353,12 +1521,87 @@ function volumeOpacityClass(ve: VolumeEntry): string {
     </div>
   </Teleport>
 
+  <!-- ── Volume quick actions (mobile bottom sheet) ── -->
+  <BaseModal
+    :open="actionSheetVolume !== null"
+    max-width-class="sm:max-w-sm"
+    z-class="z-[90]"
+    @close="closeActionSheet"
+  >
+    <template v-if="actionSheetVolume">
+      <div class="px-5 pt-4 pb-2 text-[10px] font-bold uppercase tracking-widest text-base-content/40 border-b border-base-200">
+        {{ t('manga.volumeSheetTitle', { number: actionSheetVolume.number }) }}
+      </div>
+      <div class="p-2">
+        <!-- Annoncé (only when not owned) -->
+        <button
+          v-if="!actionSheetVolume.isOwned"
+          class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200 disabled:opacity-50"
+          :disabled="toggleMutation.isPending.value"
+          :class="actionSheetVolume.isAnnounced ? 'text-secondary' : 'text-base-content/80'"
+          @click="toggleMutation.mutate({ veId: actionSheetVolume.id, field: 'isAnnounced' })"
+        >
+          <Megaphone class="h-[18px] w-[18px]" :class="actionSheetVolume.isAnnounced ? 'text-secondary' : 'text-base-content/50'" />
+          {{ t('enrich.statusAnnouncedLabel') }}
+          <Check v-if="actionSheetVolume.isAnnounced" class="h-4 w-4 ml-auto text-secondary" />
+        </button>
+        <!-- Possédé -->
+        <button
+          class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200 disabled:opacity-50"
+          :disabled="toggleMutation.isPending.value"
+          :class="actionSheetVolume.isOwned ? 'text-success' : 'text-base-content/80'"
+          @click="toggleMutation.mutate({ veId: actionSheetVolume.id, field: 'isOwned' })"
+        >
+          <Package class="h-[18px] w-[18px]" :class="actionSheetVolume.isOwned ? 'text-success' : 'text-base-content/50'" />
+          {{ t('enrich.statusOwnedLabel') }}
+          <Check v-if="actionSheetVolume.isOwned" class="h-4 w-4 ml-auto text-success" />
+        </button>
+        <!-- Lu (only when owned) -->
+        <button
+          v-if="actionSheetVolume.isOwned"
+          class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200 disabled:opacity-50"
+          :disabled="toggleMutation.isPending.value"
+          :class="actionSheetVolume.isRead ? 'text-info' : 'text-base-content/80'"
+          @click="toggleMutation.mutate({ veId: actionSheetVolume.id, field: 'isRead' })"
+        >
+          <BookOpen class="h-[18px] w-[18px]" :class="actionSheetVolume.isRead ? 'text-info' : 'text-base-content/50'" />
+          {{ t('enrich.statusReadLabel') }}
+          <Check v-if="actionSheetVolume.isRead" class="h-4 w-4 ml-auto text-info" />
+        </button>
+        <!-- Souhaité (only when not owned) -->
+        <button
+          v-if="!actionSheetVolume.isOwned"
+          class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200 disabled:opacity-50"
+          :disabled="toggleMutation.isPending.value"
+          :class="actionSheetVolume.isWished ? 'text-warning' : 'text-base-content/80'"
+          @click="toggleMutation.mutate({ veId: actionSheetVolume.id, field: 'isWished' })"
+        >
+          <Star
+            class="h-[18px] w-[18px]"
+            :class="actionSheetVolume.isWished ? 'text-warning' : 'text-base-content/50'"
+            :fill="actionSheetVolume.isWished ? 'currentColor' : 'none'"
+          />
+          {{ t('enrich.statusWishedLabel') }}
+          <Check v-if="actionSheetVolume.isWished" class="h-4 w-4 ml-auto text-warning" />
+        </button>
+        <div class="h-px bg-base-200 my-1 mx-2" />
+        <button
+          class="flex items-center gap-3 w-full px-3 py-3 rounded-xl text-sm font-semibold text-left transition-colors hover:bg-base-200"
+          @click="openModalFromActionSheet"
+        >
+          <Info class="h-[18px] w-[18px] text-base-content/50" />
+          {{ t('manga.detailsAction') }}
+        </button>
+      </div>
+    </template>
+  </BaseModal>
+
   <!-- ── Batch Action Bar ── -->
   <Teleport to="body">
     <Transition name="slide-up">
       <div
         v-if="batchMode && selectedIds.size > 0"
-        class="fixed bottom-16 lg:bottom-0 left-0 right-0 z-50 bg-base-100/95 backdrop-blur-sm border-t-2 border-primary/40 shadow-2xl"
+        class="fixed bottom-0 left-0 right-0 z-50 bg-base-100/95 backdrop-blur-sm border-t-2 border-primary/40 shadow-2xl safe-bottom"
       >
         <div class="max-w-5xl mx-auto px-4 py-3 flex items-center gap-3 flex-wrap">
           <span class="badge badge-primary badge-lg shrink-0">
@@ -1429,12 +1672,15 @@ function volumeOpacityClass(ve: VolumeEntry): string {
   </Teleport>
 
   <!-- ── Delete Confirm Dialog ── -->
-  <Teleport to="body">
-    <Transition name="modal-fade">
-      <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="showDeleteConfirm = false">
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-        <div class="relative z-10 bg-base-100 rounded-2xl shadow-2xl p-6 max-w-sm w-full">
-          <div class="flex items-start gap-3 mb-4">
+  <BaseModal
+    :open="showDeleteConfirm"
+    variant="center"
+    max-width-class="sm:max-w-sm"
+    z-class="z-[80]"
+    @close="showDeleteConfirm = false"
+  >
+    <div class="p-6">
+      <div class="flex items-start gap-3 mb-4">
             <div class="w-10 h-10 rounded-full bg-error/15 flex items-center justify-center shrink-0 text-error">
               <Trash2 class="h-5 w-5" />
             </div>
@@ -1445,21 +1691,19 @@ function volumeOpacityClass(ve: VolumeEntry): string {
               </p>
             </div>
           </div>
-          <div class="flex gap-3 justify-end">
-            <button class="btn btn-ghost" @click="showDeleteConfirm = false">Annuler</button>
-            <button
-              class="btn btn-error gap-2"
-              :disabled="removeMutation.isPending.value"
-              @click="removeMutation.mutate()"
-            >
-              <BaseLoader v-if="removeMutation.isPending.value" size="xs" />
-              Supprimer
-            </button>
-          </div>
-        </div>
+      <div class="flex gap-3 justify-end">
+        <button class="btn btn-ghost" @click="showDeleteConfirm = false">Annuler</button>
+        <button
+          class="btn btn-error gap-2"
+          :disabled="removeMutation.isPending.value"
+          @click="removeMutation.mutate()"
+        >
+          <BaseLoader v-if="removeMutation.isPending.value" size="xs" />
+          Supprimer
+        </button>
       </div>
-    </Transition>
-  </Teleport>
+    </div>
+  </BaseModal>
 </template>
 
 <style scoped>
@@ -1471,22 +1715,6 @@ function volumeOpacityClass(ve: VolumeEntry): string {
 .slide-up-leave-to {
   transform: translateY(100%);
   opacity: 0;
-}
-
-.modal-fade-enter-active,
-.modal-fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-.modal-fade-enter-from,
-.modal-fade-leave-to {
-  opacity: 0;
-}
-.modal-fade-enter-active .relative,
-.modal-fade-leave-active .relative {
-  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-.modal-fade-enter-from .relative {
-  transform: translateY(20px) scale(0.97);
 }
 
 .panel-fade-enter-active,

--- a/front/src/pages/SharePage.vue
+++ b/front/src/pages/SharePage.vue
@@ -53,7 +53,7 @@ const tiles = computed(() => {
 <template>
   <div class="min-h-dvh bg-base-200/40">
     <!-- Top bar -->
-    <header class="sticky top-0 z-10 border-b border-base-200 bg-base-100/80 backdrop-blur">
+    <header class="sticky top-0 z-10 border-b border-base-200 bg-base-100/80 backdrop-blur safe-top">
       <div class="mx-auto max-w-3xl px-5 py-3 flex items-center justify-between">
         <AppLogo class="h-8" />
         <router-link to="/login" class="btn btn-ghost btn-sm">{{ t('share.public.signIn') }}</router-link>

--- a/front/src/pages/WishlistPage.vue
+++ b/front/src/pages/WishlistPage.vue
@@ -406,7 +406,7 @@ onUnmounted(() => {
     <Transition name="slide-up">
       <div
         v-if="batchMode && selectedVeIds.size > 0"
-        class="fixed bottom-16 lg:bottom-0 left-0 right-0 z-50 bg-base-100/95 backdrop-blur-sm border-t-2 border-warning/40 shadow-2xl"
+        class="fixed bottom-0 left-0 right-0 z-50 bg-base-100/95 backdrop-blur-sm border-t-2 border-warning/40 shadow-2xl safe-bottom"
       >
         <div class="max-w-5xl mx-auto px-4 py-3 flex items-center gap-3 flex-wrap">
           <span class="badge badge-warning badge-lg shrink-0">

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -105,10 +105,17 @@ export type EventType =
 
 export type LogStatus = 'running' | 'success' | 'error'
 
+export interface ActivityLogOwner {
+  id: string
+  email: string
+  displayName: string
+}
+
 export interface ActivityLog {
   id: string
   eventType: EventType
   sourceName: string
+  owner: ActivityLogOwner | null
   collectionEntryId: string | null
   mangaTitle: string | null
   status: LogStatus
@@ -125,7 +132,6 @@ export interface ActivityLogPage {
   total: number
   page: number
   limit: number
-  totalPages: number
 }
 
 export interface CollectionEntryDetail extends CollectionEntry {

--- a/front/src/utils/__tests__/isbn.spec.ts
+++ b/front/src/utils/__tests__/isbn.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeIsbn13 } from '../isbn'
+
+describe('normalizeIsbn13', () => {
+  // 9782723425483 and 2723425487 are checksum-valid (Berserk tome 1 FR)
+  const ISBN13 = '9782723425483'
+  const ISBN10 = '2723425487'
+
+  it('accepts a bare valid ISBN-13', () => {
+    expect(normalizeIsbn13(ISBN13)).toBe(ISBN13)
+  })
+
+  it('strips hyphens and spaces', () => {
+    expect(normalizeIsbn13('978-2-7234-2548-3')).toBe(ISBN13)
+    expect(normalizeIsbn13(' 978 2 7234 2548 3 ')).toBe(ISBN13)
+  })
+
+  it('accepts a 979-prefixed ISBN-13', () => {
+    expect(normalizeIsbn13('9791034701360')).toBe('9791034701360')
+  })
+
+  it('converts a valid ISBN-10 to ISBN-13', () => {
+    expect(normalizeIsbn13(ISBN10)).toBe(ISBN13)
+  })
+
+  it('converts an ISBN-10 with X check digit', () => {
+    // 048665088X — checksum-valid
+    expect(normalizeIsbn13('048665088X')).toBe('9780486650883')
+    expect(normalizeIsbn13('048665088x')).toBe('9780486650883')
+  })
+
+  it('converts a hyphenated ISBN-10', () => {
+    expect(normalizeIsbn13('2-7234-2548-7')).toBe(ISBN13)
+  })
+
+  it('drops an EAN-5 barcode add-on', () => {
+    expect(normalizeIsbn13(ISBN13 + '12345')).toBe(ISBN13)
+  })
+
+  it('drops an EAN-2 barcode add-on', () => {
+    expect(normalizeIsbn13(ISBN13 + '99')).toBe(ISBN13)
+  })
+
+  it('still validates the checksum when an add-on is dropped', () => {
+    expect(normalizeIsbn13('9782723425484' + '12345')).toBeNull()
+  })
+
+  it('rejects an ISBN-13 with a wrong check digit', () => {
+    expect(normalizeIsbn13('9782723425484')).toBeNull()
+  })
+
+  it('rejects an ISBN-10 with a wrong check digit', () => {
+    expect(normalizeIsbn13('2723425480')).toBeNull()
+  })
+
+  it('rejects a 13-digit code without a 978/979 prefix', () => {
+    expect(normalizeIsbn13('1234567890128')).toBeNull()
+  })
+
+  it('rejects invalid characters', () => {
+    expect(normalizeIsbn13('97827A3425483')).toBeNull()
+    expect(normalizeIsbn13('not-an-isbn')).toBeNull()
+  })
+
+  it('rejects wrong lengths', () => {
+    expect(normalizeIsbn13('')).toBeNull()
+    expect(normalizeIsbn13('978272342548')).toBeNull()
+    expect(normalizeIsbn13('97827234254831')).toBeNull()
+  })
+})

--- a/front/src/utils/__tests__/price.spec.ts
+++ b/front/src/utils/__tests__/price.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { formatPrice } from '../price'
+
+describe('formatPrice', () => {
+  it('formats a known currency with its symbol', () => {
+    expect(formatPrice(7.2, 'EUR')).toBe('7.20 €')
+    expect(formatPrice(12, 'USD')).toBe('12.00 $')
+  })
+
+  it('falls back to the currency code when unknown', () => {
+    expect(formatPrice(1500, 'SEK')).toBe('1500.00 SEK')
+  })
+})

--- a/front/src/utils/activityLog.ts
+++ b/front/src/utils/activityLog.ts
@@ -1,0 +1,41 @@
+import type { EventType, LogStatus } from '@/types'
+
+export const EVENT_TYPE_LABELS: Record<EventType, string> = {
+  rss_fetch: 'RSS',
+  jikan_fetch: 'Jikan',
+  discord_sent: 'Discord',
+  scheduler_fire: 'Scheduler',
+  http_error: 'HTTP',
+  worker_failure: 'Worker',
+  user_action: 'API',
+  collection_action: 'Collection',
+  manga_action: 'Manga',
+  auth_action: 'Auth',
+  wishlist_action: 'Wishlist',
+}
+
+export const EVENT_TYPE_BADGES: Record<EventType, string> = {
+  rss_fetch: 'badge-info',
+  jikan_fetch: 'badge-info',
+  discord_sent: 'badge-secondary',
+  scheduler_fire: 'badge-accent',
+  http_error: 'badge-error',
+  worker_failure: 'badge-error',
+  user_action: 'badge-neutral',
+  collection_action: 'badge-primary',
+  manga_action: 'badge-primary',
+  auth_action: 'badge-warning',
+  wishlist_action: 'badge-secondary',
+}
+
+export const STATUS_BADGES: Record<LogStatus, string> = {
+  running: 'badge-warning',
+  success: 'badge-success',
+  error: 'badge-error',
+}
+
+export function formatDuration(durationMs: number | null): string {
+  if (durationMs === null) return '—'
+  if (durationMs < 1000) return `${durationMs} ms`
+  return `${(durationMs / 1000).toFixed(1)} s`
+}

--- a/front/src/utils/isbn.ts
+++ b/front/src/utils/isbn.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared ISBN normalization — mirrors the backend `Isbn` value object so what the
+ * front auto-saves is exactly what the API will store.
+ *
+ * Accepts ISBN-13 and ISBN-10 (converted to ISBN-13), tolerates hyphens, spaces and
+ * a trailing EAN-2/EAN-5 barcode add-on. Returns the canonical 13-digit string, or
+ * `null` when the input is not a valid ISBN.
+ */
+export function normalizeIsbn13(raw: string): string | null {
+  let stripped = raw.trim().toUpperCase().replace(/[-\s]/g, '')
+
+  if (!/^[0-9]+X?$/.test(stripped)) return null
+
+  // Barcode scanners may append an EAN-2 or EAN-5 add-on after the 13 digits.
+  const addOnMatch = stripped.match(/^(97[89][0-9]{10})[0-9]{2}(?:[0-9]{3})?$/)
+  if (addOnMatch) stripped = addOnMatch[1]
+
+  if (stripped.length === 13) {
+    if (!stripped.startsWith('978') && !stripped.startsWith('979')) return null
+    return isValidIsbn13Checksum(stripped) ? stripped : null
+  }
+
+  if (stripped.length === 10) {
+    if (!isValidIsbn10Checksum(stripped)) return null
+    const first12 = '978' + stripped.slice(0, 9)
+    return first12 + isbn13CheckDigit(first12)
+  }
+
+  return null
+}
+
+function isValidIsbn13Checksum(isbn13: string): boolean {
+  return isbn13CheckDigit(isbn13.slice(0, 12)) === isbn13[12]
+}
+
+function isbn13CheckDigit(first12: string): string {
+  let sum = 0
+  for (let position = 0; position < 12; position++) {
+    const digit = Number(first12[position])
+    sum += position % 2 === 0 ? digit : digit * 3
+  }
+  return String((10 - (sum % 10)) % 10)
+}
+
+function isValidIsbn10Checksum(isbn10: string): boolean {
+  let sum = 0
+  for (let position = 0; position < 9; position++) {
+    sum += Number(isbn10[position]) * (10 - position)
+  }
+  const lastChar = isbn10[9]
+  sum += lastChar === 'X' ? 10 : Number(lastChar)
+  return sum % 11 === 0
+}

--- a/front/src/utils/price.ts
+++ b/front/src/utils/price.ts
@@ -1,0 +1,12 @@
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  EUR: '€',
+  USD: '$',
+  GBP: '£',
+  JPY: '¥',
+}
+
+/** Formats a price amount with its currency symbol (e.g. "7.20 €"). */
+export function formatPrice(amount: number, currency: string): string {
+  const symbol = CURRENCY_SYMBOLS[currency] ?? currency
+  return amount.toFixed(2) + ' ' + symbol
+}


### PR DESCRIPTION
# Résumé

Cette PR traite six chantiers d'amélioration identifiés après analyse complète du projet.

## 1. Activity logs — journal d'audit type Datadog
- **Sécurité** : `GET /api/articles/activity-logs` réservé `ROLE_ADMIN_UNLOCKED` côté serveur (la restriction n'existait que dans le front — n'importe quel utilisateur connecté lisait les logs de tout le monde).
- **Fuite corrigée** : le JWT admin transitait en clair dans `metadata` via `GateSucceededEvent.token` (propriété supprimée) ; le sanitizer des metadata applique désormais une denylist (`token|password|secret|jwt|authorization|apikey`), ne copie que des scalaires et tronque à 500 caractères. Les paths sensibles (`/api/share/{token}`, `/api/scan/...`) sont masqués.
- **Attribution** : chaque log porte l'utilisateur (`owner` : id, email, displayName) — la colonne existait mais n'était jamais renseignée.
- **Couverture** : logins/inscriptions tracés (réussite et échec, sans credential), erreurs HTTP réelles (`http_error` + `markError` sur ≥ 400, IP + user-agent), événements wishlist reclassés, alertes Discord tracées.
- **Rétention** : commande `app:activity-log:purge` + cron quotidien (90 jours).
- **Filtres** : utilisateur, plage de dates, recherche texte (source, erreur, path JSON via nouvelle fonction DQL `JSON_GET_TEXT`), pagination migrée sur les classes Shared (R11).
- **Front** : page Journal réécrite — chargement auto, filtres réactifs, bandeau de synthèse (total, taux d'erreur, durée moyenne), badges par type/statut, lignes dépliables avec metadata en clé/valeur, vue cartes sur mobile, indicateur live.

## 2. Découverte d'éditions exhaustive par pays
- Le filtre de pertinence n'exige plus un éditeur de l'allowlist : **les artbooks, guidebooks et fanbooks sont acceptés** (nouveau format `artbook`), les éditeurs inconnus passent si le titre matche l'œuvre ; seul le vrai bruit est rejeté (coloriages, agendas, calendriers, romans, guides non officiels…).
- Le groupeur ne fusionne plus des éditions distinctes : imprints préservés (Tonkam ≠ Delcourt), partition par groupe d'enregistrement ISBN (978-2 vs 978-4).
- Extraction de lignes éditoriales enrichie (prestige, collector, coffret, kanzenban, aizoban, anniversaire, black edition…).
- **Pagination des catalogues** : BnF/DNB/NDL jusqu'à 300 notices (3 pages SRU), BnF interroge aussi sans l'auteur (artbooks catalogués sous un autre créateur), Google Books paginé par `startIndex`, OpenLibrary fusionne jusqu'à 3 works.
- Les clés d'API factices (`change_me`) sont traitées comme absentes au lieu de générer des 403 silencieux.

## 3. Prix par boutique (Amazon, Fnac, eBay)
- Nouveau modèle : la réponse expose `retailers` — une entrée par boutique cible avec `status: found | not_found` et la meilleure offre. **« Introuvable » est un état honnête et visible.**
- Parseur Chasse aux Livres (source Amazon/Fnac) réécrit en 3 stratégies (JSON-LD → DOM multi-sélecteurs → regex tolérante) avec warning loggé quand une page 200 ne produit aucune offre (diagnostic prod).
- **Fix d'un 500 réel** : `EbayBrowsePriceProvider` plantait quand `EBAY_CAMPAIGN_ID` résolvait à `null` — reproduit sur stack locale, corrigé et testé.
- Front : cartes Amazon/Fnac/eBay avec logos dans l'onglet Prix, autres offres en dessous, raccourci « Saisir l'ISBN » quand le tome n'en a pas.

## 4. ISBN — sauvegarde automatique et cover par ISBN
- **L'ISBN saisi ou scanné est maintenant sauvegardé automatiquement** (au blur du champ et à chaque recherche/scan), indépendamment de l'application d'une cover — avant, il n'était persisté que via `applyIsbnCover` et seulement si l'API renvoyait un ISBN.
- Normalisation partagée front/back : ISBN-10 → ISBN-13, tirets/espaces, add-on EAN des codes-barres.
- Validation dédiée sur le payload (`ValidIsbn`) : un ISBN invalide produit un 422 propre scoped au champ au lieu d'un rollback silencieux de tout le PATCH.
- Cover par ISBN : OpenLibrary ne rejette plus les covers valides quand le HEAD ne renvoie pas de `content-length` (fallback GET) ; le front distingue « erreur backend » de « aucun résultat ».

## 5. Passe UX/UI mobile (PWA iOS)
- **Safe-areas** : utilitaires `safe-top`/`safe-bottom`/`pb-safe-sheet` appliqués au header, aux drawers, aux toasts, aux bottom-sheets et aux barres d'action batch (qui flottaient à 64 px du bas au-dessus d'une bottom-nav inexistante).
- **`BaseModal` factorisé** (Teleport, bottom-sheet mobile / dialog desktop, Escape, focus-trap, transitions uniques) — migration de GatePage, AdminUsers, ShareModal, CollectionGuideModal, EnrichVolumeModal, confirmation de suppression.
- **Popovers hors écran corrigés** : menus statut/options/edit-cover en bottom-sheets sur mobile, context-menu clampé dynamiquement sur desktop et remplacé par une action-sheet déclenchable au bouton ⋯ visible sur chaque vignette.
- Corrections par page : barre de filtres Collection qui passait sous le header, onglet Prix en 3 colonnes mobile, AdminUsers en cartes empilées, switcher 4 onglets de la modale volume sans débordement à 360 px, fix d'un scroll horizontal global causé par les tooltips DaisyUI.
- Vérifié avec Playwright en 390×844 et 360×780 : aucun scroll horizontal, aucune erreur JS sur toutes les routes.

# Qualité
- **Backend** : PHPUnit **779 tests / 2002 assertions, 0 échec** · PHPStan niveau 8 « No errors » · PHPCS OK · Deptrac 0 violation · `doctrine:schema:validate` OK
- **Frontend** : Vitest **116 tests / 22 fichiers, 0 échec** · `vue-tsc` OK · ESLint OK
- Screenshots mobile pris sur la stack réelle (login, données seedées) pour chaque page.

# À faire en prod (Railway)
- Renseigner `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET` pour activer la source eBay Browse (sinon état « introuvable » honnête).
- Remplacer `GOOGLE_BOOKS_API_KEY=CHANGEME` par une vraie clé pour les prix Google Play et le catalogue Google Books.
- Surveiller le log `CHASSE_AUX_LIVRES PRICES : … 0 OFFER PARSED` : il signale que le layout du site diffère des stratégies de parsing (écrites sur fixtures, le site n'étant pas joignable depuis l'environnement de dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K45EPYCN4BL1ZLJuyufdcs